### PR TITLE
Add tester shell commands and SHT serial number reading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Zephyr RTOS-based firmware project for the HARDWARIO Sticker device - an IoT sensor device with LoRaWAN connectivity, STM32WLE5CC MCU, NFC configuration, and multiple sensor support.
+
+## Build Commands
+
+All commands should be run from `sticker/sticker/app/`:
+
+```bash
+# Build release
+make
+
+# Build debug (with debug.conf)
+make debug
+
+# Flash to device
+make flash
+
+# Start RTT terminal (for debug output)
+make rttt
+
+# Start GDB debugger
+make gdb
+
+# Clean build artifacts
+make clean
+
+# Menuconfig
+make config
+make config_debug
+
+# Build both release and debug hexes to deploy/
+make deploy
+
+# Format source code (run from sticker/sticker/)
+make format
+```
+
+## Project Structure
+
+```
+sticker/sticker/           # Main application repository
+├── app/                   # Application code
+│   ├── src/               # Source files (main.c, app_*.c modules)
+│   ├── prj.conf           # Base Kconfig configuration
+│   └── debug.conf         # Debug overlay configuration
+├── boards/sticker/        # Custom board definition
+├── drivers/               # Custom Zephyr drivers (mpl3115a2, w1_ds28e17)
+├── dts/bindings/          # Device tree bindings
+├── include/               # Header files
+└── west.yml               # West manifest (uses hardwario/sticker-zephyr)
+```
+
+## Architecture
+
+- **Zephyr-based**: Uses West build system and Zephyr RTOS
+- **Modular app_* design**: Each subsystem (sensors, NFC, LoRaWAN, etc.) is in its own `app_*.c` file
+- **Nanopb protobuf**: NFC configuration uses protobuf (`src/nfc_config.proto`)
+- **Conditional compilation**: Sensor drivers enabled via Kconfig (CONFIG_SHT4X, CONFIG_LIS2DH, CONFIG_OPT3001, etc.)
+- **Custom board**: Target board is `sticker` defined in `boards/sticker/`
+
+## Key Technologies
+
+- **MCU**: STM32WLE5CC (Cortex-M4 with LoRa radio)
+- **Connectivity**: LoRaWAN
+- **Sensors**: SHT40 (temp/humidity), LIS2DH (accelerometer), OPT3001 (light), MPL3115A2 (pressure), DS18B20 (1-Wire temp), PYQ1648 (PIR)
+- **NFC**: Configuration via NDEF records
+- **RTT**: Segger RTT for debug output (address: 0x20000800)
+
+## Development Setup
+
+Requires Python virtual environment with West, RTTT, and Protocol Buffers tools installed. See README.md for full setup instructions.
+
+## Tester Shell Commands
+
+The `app_tester.c` module provides shell commands for testing hardware:
+
+```bash
+tester sensors sample    # Print all sensor values
+tester sensors serial    # Print sensor serial numbers (SHT40, DS18B20, Machine Probe)
+tester sensors reset     # Reset sensor counters
+tester sensors check <sensor> [timeout]  # Monitor sensor for changes
+
+tester led_cycle [count]           # Cycle LEDs (R/Y/G)
+tester led_switch <color> <on|off> # Control individual LED
+tester hw_deveui                   # Print hardware DevEUI
+```
+
+## Serial Number Reading
+
+- **SHT43 (motherboard)**: Uses I2C command `0x89` (1-byte) at address from devicetree
+- **SHT33 (machine probe)**: Uses I2C command `0x3780` (2-byte) at address `0x45`
+- **DS18B20**: Serial from 1-Wire ROM
+- **Machine Probe**: Serial from DS28E17 1-Wire bridge
+
+Future SHT43 support on machine probe: Set `CONFIG_APP_MACHINE_PROBE_SHT43=y` in prj.conf
+
+## Recent Changes (app_tester branch)
+
+- Added `app_sht40_read_serial()` for SHT43 serial number reading
+- Added `app_machine_probe_read_hygrometer_serial()` for SHT33 serial
+- Added `CONFIG_APP_MACHINE_PROBE_SHT43` Kconfig option
+- Removed "tester" prefix from sample/serial output for cleaner display

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -14,6 +14,14 @@ config APP_VERBOSE_LOGGING
 	  This adds detailed logging for NFC parameters and other
 	  configuration changes. Disable to save flash space.
 
+config APP_MACHINE_PROBE_SHT43
+	bool "Use SHT43 sensor on Machine Probe"
+	default n
+	help
+	  Select SHT43 sensor type for Machine Probe hygrometer.
+	  When disabled (default), SHT30/SHT33 is used.
+	  Enable this when Machine Probe hardware uses SHT43.
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/app/src/app_machine_probe.h
+++ b/app/src/app_machine_probe.h
@@ -20,6 +20,8 @@ int app_machine_probe_get_count(void);
 int app_machine_probe_read_thermometer(int index, uint64_t *serial_number, float *temperature);
 int app_machine_probe_read_hygrometer(int index, uint64_t *serial_number, float *temperature,
 				      float *humidity);
+int app_machine_probe_read_hygrometer_serial(int index, uint64_t *serial_number,
+					     uint32_t *sht_serial);
 int app_machine_probe_read_lux_meter(int index, uint64_t *serial_number, float *illuminance);
 int app_machine_probe_read_magnetometer(int index, uint64_t *serial_number, float *magnetic_field);
 int app_machine_probe_read_accelerometer(int index, uint64_t *serial_number, float *accel_x,

--- a/app/src/app_sht40.c
+++ b/app/src/app_sht40.c
@@ -10,6 +10,7 @@
 /* Zephyr includes */
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -64,6 +65,57 @@ int app_sht40_read(float *temperature, float *humidity)
 	if (humidity) {
 		*humidity = humidity_;
 	}
+
+	return 0;
+}
+
+int app_sht40_read_serial(uint32_t *serial_number)
+{
+	int ret;
+
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(sht40));
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Device not ready");
+		return -ENODEV;
+	}
+
+	/* Get I2C bus and address from devicetree */
+	const struct device *i2c_dev = DEVICE_DT_GET(DT_BUS(DT_NODELABEL(sht40)));
+	if (!device_is_ready(i2c_dev)) {
+		LOG_ERR("I2C device not ready");
+		return -ENODEV;
+	}
+
+	uint16_t addr = DT_REG_ADDR(DT_NODELABEL(sht40));
+
+	/* SHT4x (SHT40/SHT43) Read Serial Number command: 0x89
+	 * Note: For SHT30/SHT33 use 2-byte command 0x3780 instead
+	 */
+	uint8_t cmd = 0x89;
+	uint8_t data[6];
+
+	ret = i2c_write(i2c_dev, &cmd, 1, addr);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("i2c_write", ret);
+		return ret;
+	}
+
+	/* Wait for measurement (1ms should be enough for serial read) */
+	k_sleep(K_MSEC(1));
+
+	ret = i2c_read(i2c_dev, data, sizeof(data), addr);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("i2c_read", ret);
+		return ret;
+	}
+
+	/* Serial number is in data[0:1] and data[3:4], with CRC in data[2] and data[5] */
+	if (serial_number) {
+		*serial_number = ((uint32_t)data[0] << 24) | ((uint32_t)data[1] << 16) |
+				 ((uint32_t)data[3] << 8) | (uint32_t)data[4];
+	}
+
+	LOG_DBG("SHT40 Serial: 0x%08X", *serial_number);
 
 	return 0;
 }

--- a/app/src/app_sht40.h
+++ b/app/src/app_sht40.h
@@ -7,11 +7,14 @@
 #ifndef APP_SHT40_H_
 #define APP_SHT40_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int app_sht40_read(float *temperature, float *humidity);
+int app_sht40_read_serial(uint32_t *serial_number);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_tester.c
+++ b/app/src/app_tester.c
@@ -4,35 +4,117 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "app_ds18b20.h"
 #include "app_led.h"
+#include "app_machine_probe.h"
 #include "app_sensor.h"
+#include "app_sht40.h"
 
 /* Zephyr includes */
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/sys/util.h>
 
 /* Standard includes */
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 LOG_MODULE_REGISTER(app_tester, LOG_LEVEL_DBG);
 
 #define SHELL_PFX "tester"
+#define SENSOR_CHECK_POLL_INTERVAL_MS 300 /* Poll interval for sensor check in milliseconds */
 
-void cmd_cycle_led(void)
+static struct k_work_delayable g_led_cycle_work;
+static volatile bool g_led_cycle_stop = false;
+static volatile int g_led_cycle_remaining = 0;
+static volatile int g_led_cycle_state = 0; /* 0=red, 1=yellow, 2=green, 3=off */
+
+static void led_cycle_work_handler(struct k_work *work)
 {
-	app_led_set(APP_LED_CHANNEL_R, 1);
-	k_sleep(K_MSEC(1000));
-	app_led_set(APP_LED_CHANNEL_R, 0);
-	k_sleep(K_MSEC(200));
-	app_led_set(APP_LED_CHANNEL_Y, 1);
-	k_sleep(K_MSEC(1000));
-	app_led_set(APP_LED_CHANNEL_Y, 0);
-	k_sleep(K_MSEC(200));
-	app_led_set(APP_LED_CHANNEL_G, 1);
-	k_sleep(K_MSEC(1000));
-	app_led_set(APP_LED_CHANNEL_G, 0);
+	if (g_led_cycle_stop || g_led_cycle_remaining <= 0) {
+		/* Turn off all LEDs and stop */
+		app_led_set(APP_LED_CHANNEL_R, 0);
+		app_led_set(APP_LED_CHANNEL_Y, 0);
+		app_led_set(APP_LED_CHANNEL_G, 0);
+		g_led_cycle_remaining = 0;
+		return;
+	}
+
+	switch (g_led_cycle_state) {
+	case 0: /* Red on */
+		app_led_set(APP_LED_CHANNEL_R, 1);
+		app_led_set(APP_LED_CHANNEL_Y, 0);
+		app_led_set(APP_LED_CHANNEL_G, 0);
+		g_led_cycle_state = 1;
+		k_work_schedule(&g_led_cycle_work, K_MSEC(1000));
+		break;
+
+	case 1: /* Yellow on */
+		app_led_set(APP_LED_CHANNEL_R, 0);
+		app_led_set(APP_LED_CHANNEL_Y, 1);
+		app_led_set(APP_LED_CHANNEL_G, 0);
+		g_led_cycle_state = 2;
+		k_work_schedule(&g_led_cycle_work, K_MSEC(1000));
+		break;
+
+	case 2: /* Green on */
+		app_led_set(APP_LED_CHANNEL_R, 0);
+		app_led_set(APP_LED_CHANNEL_Y, 0);
+		app_led_set(APP_LED_CHANNEL_G, 1);
+		g_led_cycle_state = 3;
+		k_work_schedule(&g_led_cycle_work, K_MSEC(1000));
+		break;
+
+	case 3: /* All off */
+		app_led_set(APP_LED_CHANNEL_R, 0);
+		app_led_set(APP_LED_CHANNEL_Y, 0);
+		app_led_set(APP_LED_CHANNEL_G, 0);
+		g_led_cycle_remaining--;
+		g_led_cycle_state = 0;
+
+		if (g_led_cycle_remaining > 0 && !g_led_cycle_stop) {
+			k_work_schedule(&g_led_cycle_work, K_MSEC(1000));
+		}
+		break;
+	}
+}
+
+static void cmd_cycle_led(const struct shell *shell, size_t argc, char **argv)
+{
+	int cycles = 1; /* Default to 1 cycle if no parameter */
+
+	if (argc >= 2) {
+		cycles = atoi(argv[1]);
+	}
+
+	if (cycles == 0) {
+		/* Stop immediately */
+		g_led_cycle_stop = true;
+		g_led_cycle_remaining = 0;
+		k_work_cancel_delayable(&g_led_cycle_work);
+		app_led_set(APP_LED_CHANNEL_R, 0);
+		app_led_set(APP_LED_CHANNEL_Y, 0);
+		app_led_set(APP_LED_CHANNEL_G, 0);
+		shell_print(shell, SHELL_PFX " LED cycle stopped");
+		return;
+	}
+
+	if (cycles < 1 || cycles > 99) {
+		shell_error(shell, "Invalid cycle count. Use 1-99 or 0 to stop.");
+		return;
+	}
+
+	/* Start new cycle */
+	g_led_cycle_stop = false;
+	g_led_cycle_remaining = cycles;
+	g_led_cycle_state = 0;
+	shell_print(shell, SHELL_PFX " Starting %d LED cycle(s)", cycles);
+
+	k_work_schedule(&g_led_cycle_work, K_NO_WAIT);
 }
 
 static void cmd_switch_led(const struct shell *shell, size_t argc, char **argv)
@@ -66,71 +148,446 @@ static void cmd_switch_led(const struct shell *shell, size_t argc, char **argv)
 	}
 }
 
-static void cmd_print_voltage(const struct shell *shell)
+static void cmd_print_hw_deveui(const struct shell *shell)
 {
-	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " voltage %.2f", (double)g_app_sensor_data.voltage);
+	uint8_t dev_id[16];
+	ssize_t length;
+
+	/* Get hardware device ID (UID) */
+	length = hwinfo_get_device_id(dev_id, sizeof(dev_id));
+
+	if (length < 0) {
+		shell_error(shell, "Failed to read hardware device ID: %d", length);
+		return;
+	}
+
+	shell_print(shell, SHELL_PFX " Hardware Device ID length: %d bytes", length);
+
+	/* Display full device ID in hex */
+	shell_print(shell, SHELL_PFX " Hardware Device ID (hex): ");
+	for (int i = 0; i < length; i++) {
+		shell_fprintf(shell, SHELL_NORMAL, "%02x", dev_id[i]);
+	}
+	shell_fprintf(shell, SHELL_NORMAL, "\n");
+
+	/* Derive 8-byte DevEUI from device ID
+	 * For STM32, UID is 96 bits (12 bytes), we take first 8 bytes
+	 */
+	uint8_t hw_deveui[8];
+	int deveui_len = MIN(8, length);
+	memcpy(hw_deveui, dev_id, deveui_len);
+
+	/* If device ID is shorter than 8 bytes, pad with zeros */
+	if (deveui_len < 8) {
+		memset(hw_deveui + deveui_len, 0, 8 - deveui_len);
+	}
+
+	/* Print as decimal (8 bytes as uint64) */
+	uint64_t deveui = 0;
+	for (int i = 0; i < 8; i++) {
+		deveui = (deveui << 8) | hw_deveui[i];
+	}
+
+	shell_print(shell, SHELL_PFX " Hardware DevEUI (decimal): %llu", deveui);
+
+	/* Also print as hex */
+	shell_print(shell, SHELL_PFX " Hardware DevEUI (hex): "
+		    "%02x%02x%02x%02x%02x%02x%02x%02x",
+		    hw_deveui[0], hw_deveui[1], hw_deveui[2], hw_deveui[3],
+		    hw_deveui[4], hw_deveui[5], hw_deveui[6], hw_deveui[7]);
 }
 
-static void cmd_print_orientation(const struct shell *shell)
+static void cmd_print_serial_numbers(const struct shell *shell)
 {
-	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " orientation %d", (int)g_app_sensor_data.orientation);
+	int ret;
+	int count;
+
+#if defined(CONFIG_SHT4X)
+	/* SHT40 (onboard temperature/humidity sensor) */
+	uint32_t sht40_serial;
+	ret = app_sht40_read_serial(&sht40_serial);
+	if (ret) {
+		shell_error(shell, "Failed to read SHT40 serial: %d", ret);
+	} else {
+		shell_print(shell, "SHT40 serial: %u (0x%08X)", sht40_serial, sht40_serial);
+	}
+#endif /* defined(CONFIG_SHT4X) */
+
+	/* DS18B20 sensors (T1, T2) */
+	count = app_ds18b20_get_count();
+	shell_print(shell, "DS18B20 count: %d", count);
+
+	for (int i = 0; i < count; i++) {
+		uint64_t serial_number;
+		float temperature;
+
+		ret = app_ds18b20_read(i, &serial_number, &temperature);
+		if (ret) {
+			shell_error(shell, "Failed to read DS18B20 sensor %d: %d", i, ret);
+			continue;
+		}
+
+		shell_print(shell, "DS18B20[%d] serial: %llu", i, serial_number);
+	}
+
+	/* Machine Probe sensors (MP1, MP2) */
+	count = app_machine_probe_get_count();
+	shell_print(shell, "Machine Probe count: %d", count);
+
+	for (int i = 0; i < count; i++) {
+		uint64_t serial_number;
+		float temperature;
+		float humidity;
+
+		ret = app_machine_probe_read_hygrometer(i, &serial_number, &temperature, &humidity);
+		if (ret) {
+			shell_error(shell, "Failed to read Machine Probe sensor %d: %d", i, ret);
+			continue;
+		}
+
+		shell_print(shell, "Machine Probe[%d] serial: %llu", i, serial_number);
+
+		/* Read SHT serial from machine probe */
+		uint32_t sht_serial;
+		ret = app_machine_probe_read_hygrometer_serial(i, &serial_number, &sht_serial);
+		if (ret) {
+			shell_error(shell, "Failed to read Machine Probe SHT serial %d: %d", i, ret);
+		} else {
+			shell_print(shell, "Machine Probe[%d] SHT serial: %u (0x%08X)", i,
+				    sht_serial, sht_serial);
+		}
+	}
 }
 
-static void cmd_print_temperature(const struct shell *shell)
+static void cmd_reset_sample(const struct shell *shell)
 {
-	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " temperature %.2f", (double)g_app_sensor_data.temperature);
+	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
+
+	/* Reset all counters */
+	g_app_sensor_data.motion_count = 0;
+	g_app_sensor_data.hall_left_count = 0;
+	g_app_sensor_data.hall_right_count = 0;
+	g_app_sensor_data.input_a_count = 0;
+	g_app_sensor_data.input_b_count = 0;
+
+	k_mutex_unlock(&g_app_sensor_data_lock);
+
+	shell_print(shell, SHELL_PFX " Sensor counters reset");
 }
 
-static void cmd_print_humidity(const struct shell *shell)
+static void print_available_sensors(const struct shell *shell)
 {
-	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " humidity %.2f", (double)g_app_sensor_data.humidity);
+	shell_print(shell, "Available sensors:");
+	shell_print(shell, "  ---Float sensors---:");
+	shell_print(shell, "    voltage, temperature, humidity, illuminance");
+	shell_print(shell, "    t1_temperature, t2_temperature");
+	shell_print(shell, "    mp1_temperature, mp2_temperature");
+	shell_print(shell, "    mp1_humidity, mp2_humidity");
+	shell_print(shell, "    altitude, pressure");
+	shell_print(shell, "  ---Integer sensors---:");
+	shell_print(shell, "    orientation");
+	shell_print(shell, "  ---Counter sensors---:");
+	shell_print(shell, "    motion_count, hall_left_count, hall_right_count");
+	shell_print(shell, "    input_a_count, input_b_count");
+	shell_print(shell, "  ---Boolean sensors---:");
+	shell_print(shell, "    mp1_is_tilt_alert, mp2_is_tilt_alert");
+	shell_print(shell, "    hall_left_is_active, hall_right_is_active");
+	shell_print(shell, "    input_a_is_active, input_b_is_active");
 }
 
-static void cmd_print_illuminance(const struct shell *shell)
+static void cmd_check_sensor(const struct shell *shell, size_t argc, char **argv)
 {
-	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " illuminance %.2f", (double)g_app_sensor_data.illuminance);
+	if (argc < 2) {
+		shell_error(shell, "Usage: tester sensors check <sensor_name> [timeout_sec]");
+		print_available_sensors(shell);
+		return;
+	}
+
+	const char *sensor_name = argv[1];
+	int timeout_sec = 10; /* Default timeout */
+
+	if (argc >= 3) {
+		timeout_sec = atoi(argv[2]);
+		if (timeout_sec <= 0) {
+			shell_error(shell, "Invalid timeout value");
+			return;
+		}
+	}
+
+	shell_print(shell, SHELL_PFX " Monitoring '%s' for %d seconds...", sensor_name,
+		    timeout_sec);
+
+	/* Store initial value */
+	float prev_float = 0.0f;
+	uint32_t prev_uint32 = 0;
+	int prev_int = 0;
+	bool prev_bool = false;
+	bool is_float = false;
+	bool is_uint32 = false;
+	bool is_int = false;
+	bool is_bool = false;
+
+	/* Determine sensor type and get initial value */
+	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
+
+	if (strcmp(sensor_name, "voltage") == 0) {
+		prev_float = g_app_sensor_data.voltage;
+		is_float = true;
+	} else if (strcmp(sensor_name, "temperature") == 0) {
+		prev_float = g_app_sensor_data.temperature;
+		is_float = true;
+	} else if (strcmp(sensor_name, "humidity") == 0) {
+		prev_float = g_app_sensor_data.humidity;
+		is_float = true;
+	} else if (strcmp(sensor_name, "illuminance") == 0) {
+		prev_float = g_app_sensor_data.illuminance;
+		is_float = true;
+	} else if (strcmp(sensor_name, "t1_temperature") == 0) {
+		prev_float = g_app_sensor_data.t1_temperature;
+		is_float = true;
+	} else if (strcmp(sensor_name, "t2_temperature") == 0) {
+		prev_float = g_app_sensor_data.t2_temperature;
+		is_float = true;
+	} else if (strcmp(sensor_name, "mp1_temperature") == 0) {
+		prev_float = g_app_sensor_data.mp1_temperature;
+		is_float = true;
+	} else if (strcmp(sensor_name, "mp2_temperature") == 0) {
+		prev_float = g_app_sensor_data.mp2_temperature;
+		is_float = true;
+	} else if (strcmp(sensor_name, "mp1_humidity") == 0) {
+		prev_float = g_app_sensor_data.mp1_humidity;
+		is_float = true;
+	} else if (strcmp(sensor_name, "mp2_humidity") == 0) {
+		prev_float = g_app_sensor_data.mp2_humidity;
+		is_float = true;
+	} else if (strcmp(sensor_name, "altitude") == 0) {
+		prev_float = g_app_sensor_data.altitude;
+		is_float = true;
+	} else if (strcmp(sensor_name, "pressure") == 0) {
+		prev_float = g_app_sensor_data.pressure;
+		is_float = true;
+	} else if (strcmp(sensor_name, "orientation") == 0) {
+		prev_int = g_app_sensor_data.orientation;
+		is_int = true;
+	} else if (strcmp(sensor_name, "motion_count") == 0) {
+		prev_uint32 = g_app_sensor_data.motion_count;
+		is_uint32 = true;
+	} else if (strcmp(sensor_name, "hall_left_count") == 0) {
+		prev_uint32 = g_app_sensor_data.hall_left_count;
+		is_uint32 = true;
+	} else if (strcmp(sensor_name, "hall_right_count") == 0) {
+		prev_uint32 = g_app_sensor_data.hall_right_count;
+		is_uint32 = true;
+	} else if (strcmp(sensor_name, "input_a_count") == 0) {
+		prev_uint32 = g_app_sensor_data.input_a_count;
+		is_uint32 = true;
+	} else if (strcmp(sensor_name, "input_b_count") == 0) {
+		prev_uint32 = g_app_sensor_data.input_b_count;
+		is_uint32 = true;
+	} else if (strcmp(sensor_name, "mp1_is_tilt_alert") == 0) {
+		prev_bool = g_app_sensor_data.mp1_is_tilt_alert;
+		is_bool = true;
+	} else if (strcmp(sensor_name, "mp2_is_tilt_alert") == 0) {
+		prev_bool = g_app_sensor_data.mp2_is_tilt_alert;
+		is_bool = true;
+	} else if (strcmp(sensor_name, "hall_left_is_active") == 0) {
+		prev_bool = g_app_sensor_data.hall_left_is_active;
+		is_bool = true;
+	} else if (strcmp(sensor_name, "hall_right_is_active") == 0) {
+		prev_bool = g_app_sensor_data.hall_right_is_active;
+		is_bool = true;
+	} else if (strcmp(sensor_name, "input_a_is_active") == 0) {
+		prev_bool = g_app_sensor_data.input_a_is_active;
+		is_bool = true;
+	} else if (strcmp(sensor_name, "input_b_is_active") == 0) {
+		prev_bool = g_app_sensor_data.input_b_is_active;
+		is_bool = true;
+	} else {
+		k_mutex_unlock(&g_app_sensor_data_lock);
+		shell_error(shell, "Unknown sensor: %s", sensor_name);
+		print_available_sensors(shell);
+		return;
+	}
+
+	k_mutex_unlock(&g_app_sensor_data_lock);
+
+	/* Monitor for changes */
+	int64_t start_time = k_uptime_get();
+	int64_t timeout_ms = timeout_sec * 1000;
+
+	while ((k_uptime_get() - start_time) < timeout_ms) {
+		app_sensor_sample();
+
+		k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
+
+		bool changed = false;
+		float curr_float = 0.0f;
+		uint32_t curr_uint32 = 0;
+		int curr_int = 0;
+		bool curr_bool = false;
+
+		/* Check for change based on sensor type */
+		if (is_float) {
+			if (strcmp(sensor_name, "voltage") == 0) {
+				curr_float = g_app_sensor_data.voltage;
+			} else if (strcmp(sensor_name, "temperature") == 0) {
+				curr_float = g_app_sensor_data.temperature;
+			} else if (strcmp(sensor_name, "humidity") == 0) {
+				curr_float = g_app_sensor_data.humidity;
+			} else if (strcmp(sensor_name, "illuminance") == 0) {
+				curr_float = g_app_sensor_data.illuminance;
+			} else if (strcmp(sensor_name, "t1_temperature") == 0) {
+				curr_float = g_app_sensor_data.t1_temperature;
+			} else if (strcmp(sensor_name, "t2_temperature") == 0) {
+				curr_float = g_app_sensor_data.t2_temperature;
+			} else if (strcmp(sensor_name, "mp1_temperature") == 0) {
+				curr_float = g_app_sensor_data.mp1_temperature;
+			} else if (strcmp(sensor_name, "mp2_temperature") == 0) {
+				curr_float = g_app_sensor_data.mp2_temperature;
+			} else if (strcmp(sensor_name, "mp1_humidity") == 0) {
+				curr_float = g_app_sensor_data.mp1_humidity;
+			} else if (strcmp(sensor_name, "mp2_humidity") == 0) {
+				curr_float = g_app_sensor_data.mp2_humidity;
+			} else if (strcmp(sensor_name, "altitude") == 0) {
+				curr_float = g_app_sensor_data.altitude;
+			} else if (strcmp(sensor_name, "pressure") == 0) {
+				curr_float = g_app_sensor_data.pressure;
+			}
+
+			if (curr_float != prev_float) {
+				shell_print(shell, SHELL_PFX " %s: %.2f", sensor_name,
+					    (double)curr_float);
+				prev_float = curr_float;
+				changed = true;
+			}
+		} else if (is_uint32) {
+			if (strcmp(sensor_name, "motion_count") == 0) {
+				curr_uint32 = g_app_sensor_data.motion_count;
+			} else if (strcmp(sensor_name, "hall_left_count") == 0) {
+				curr_uint32 = g_app_sensor_data.hall_left_count;
+			} else if (strcmp(sensor_name, "hall_right_count") == 0) {
+				curr_uint32 = g_app_sensor_data.hall_right_count;
+			} else if (strcmp(sensor_name, "input_a_count") == 0) {
+				curr_uint32 = g_app_sensor_data.input_a_count;
+			} else if (strcmp(sensor_name, "input_b_count") == 0) {
+				curr_uint32 = g_app_sensor_data.input_b_count;
+			}
+
+			if (curr_uint32 != prev_uint32) {
+				shell_print(shell, SHELL_PFX " %s: %u", sensor_name, curr_uint32);
+				prev_uint32 = curr_uint32;
+				changed = true;
+			}
+		} else if (is_int) {
+			curr_int = g_app_sensor_data.orientation;
+
+			if (curr_int != prev_int) {
+				shell_print(shell, SHELL_PFX " %s: %d", sensor_name, curr_int);
+				prev_int = curr_int;
+				changed = true;
+			}
+		} else if (is_bool) {
+			if (strcmp(sensor_name, "mp1_is_tilt_alert") == 0) {
+				curr_bool = g_app_sensor_data.mp1_is_tilt_alert;
+			} else if (strcmp(sensor_name, "mp2_is_tilt_alert") == 0) {
+				curr_bool = g_app_sensor_data.mp2_is_tilt_alert;
+			} else if (strcmp(sensor_name, "hall_left_is_active") == 0) {
+				curr_bool = g_app_sensor_data.hall_left_is_active;
+			} else if (strcmp(sensor_name, "hall_right_is_active") == 0) {
+				curr_bool = g_app_sensor_data.hall_right_is_active;
+			} else if (strcmp(sensor_name, "input_a_is_active") == 0) {
+				curr_bool = g_app_sensor_data.input_a_is_active;
+			} else if (strcmp(sensor_name, "input_b_is_active") == 0) {
+				curr_bool = g_app_sensor_data.input_b_is_active;
+			}
+
+			if (curr_bool != prev_bool) {
+				shell_print(shell, SHELL_PFX " %s: %s", sensor_name,
+					    curr_bool ? "true" : "false");
+				prev_bool = curr_bool;
+				changed = true;
+			}
+		}
+
+		k_mutex_unlock(&g_app_sensor_data_lock);
+
+		k_sleep(K_MSEC(SENSOR_CHECK_POLL_INTERVAL_MS));
+	}
+
+	shell_print(shell, SHELL_PFX " Monitoring timeout");
 }
 
-static void cmd_print_t1_temperature(const struct shell *shell)
+static void cmd_print_sample(const struct shell *shell)
 {
 	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " t1 temperature %.2f",
+
+	shell_print(shell, "orientation:              %d", g_app_sensor_data.orientation);
+	shell_print(shell, "voltage:                  %.2f V", (double)g_app_sensor_data.voltage);
+	shell_print(shell, "temperature:              %.2f C",
+		    (double)g_app_sensor_data.temperature);
+	shell_print(shell, "humidity:                 %.2f %%", (double)g_app_sensor_data.humidity);
+	shell_print(shell, "illuminance:              %.2f lux",
+		    (double)g_app_sensor_data.illuminance);
+	shell_print(shell, "t1_temperature:           %.2f C",
 		    (double)g_app_sensor_data.t1_temperature);
-}
-
-static void cmd_print_t2_temperature(const struct shell *shell)
-{
-	app_sensor_sample();
-	shell_print(shell, SHELL_PFX " t2 temperature %.2f",
+	shell_print(shell, "t2_temperature:           %.2f C",
 		    (double)g_app_sensor_data.t2_temperature);
+	shell_print(shell, "motion_count:             %u", g_app_sensor_data.motion_count);
+	shell_print(shell, "altitude:                 %.2f m", (double)g_app_sensor_data.altitude);
+	shell_print(shell, "pressure:                 %.2f Pa", (double)g_app_sensor_data.pressure);
+	shell_print(shell, "machine_probe_temp_1:     %.2f C",
+		    (double)g_app_sensor_data.mp1_temperature);
+	shell_print(shell, "machine_probe_temp_2:     %.2f C",
+		    (double)g_app_sensor_data.mp2_temperature);
+	shell_print(shell, "machine_probe_humidity_1: %.2f %%",
+		    (double)g_app_sensor_data.mp1_humidity);
+	shell_print(shell, "machine_probe_humidity_2: %.2f %%",
+		    (double)g_app_sensor_data.mp2_humidity);
+	shell_print(shell, "machine_probe_tilt_1:     %s",
+		    g_app_sensor_data.mp1_is_tilt_alert ? "true" : "false");
+	shell_print(shell, "machine_probe_tilt_2:     %s",
+		    g_app_sensor_data.mp2_is_tilt_alert ? "true" : "false");
+	shell_print(shell, "hall_left_count:          %u", g_app_sensor_data.hall_left_count);
+	shell_print(shell, "hall_right_count:         %u", g_app_sensor_data.hall_right_count);
+	shell_print(shell, "hall_left_active:         %s",
+		    g_app_sensor_data.hall_left_is_active ? "true" : "false");
+	shell_print(shell, "hall_right_active:        %s",
+		    g_app_sensor_data.hall_right_is_active ? "true" : "false");
+	shell_print(shell, "input_a_count:            %u", g_app_sensor_data.input_a_count);
+	shell_print(shell, "input_b_count:            %u", g_app_sensor_data.input_b_count);
+	shell_print(shell, "input_a_active:           %s",
+		    g_app_sensor_data.input_a_is_active ? "true" : "false");
+	shell_print(shell, "input_b_active:           %s",
+		    g_app_sensor_data.input_b_is_active ? "true" : "false");
 }
 
-static void cmd_print_motion_count(const struct shell *shell)
-{
-	shell_print(shell, SHELL_PFX " motion count %d", (int)g_app_sensor_data.motion_count);
-}
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensors,
+	SHELL_CMD_ARG(sample, NULL, "Print all sensor values.", cmd_print_sample, 1, 0),
+	SHELL_CMD_ARG(reset, NULL, "Reset sensor counters.", cmd_reset_sample, 1, 0),
+	SHELL_CMD_ARG(serial, NULL, "Print sensor serial numbers.", cmd_print_serial_numbers, 1,
+		      0),
+	SHELL_CMD_ARG(check, NULL, "Monitor sensor for changes. Usage: check <sensor> [timeout]",
+		      cmd_check_sensor, 2, 1),
+	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_test, SHELL_CMD_ARG(led_cycle, NULL, "Cycle LED (R/G/Y).", cmd_cycle_led, 1, 0),
+	sub_test,
+	SHELL_CMD_ARG(led_cycle, NULL,
+		      "Cycle LED (R/Y/G/off). Usage: led_cycle [count] (default=1, 0=stop, 1-99=cycles)",
+		      cmd_cycle_led, 1, 1),
 	SHELL_CMD_ARG(led_switch, NULL, "Switch LED channel (format red|yellow|green on|off).",
 		      cmd_switch_led, 3, 0),
-	SHELL_CMD_ARG(voltage, NULL, "Print voltage.", cmd_print_voltage, 1, 0),
-	SHELL_CMD_ARG(orientation, NULL, "Print orientation.", cmd_print_orientation, 1, 0),
-	SHELL_CMD_ARG(temperature, NULL, "Print temperature.", cmd_print_temperature, 1, 0),
-	SHELL_CMD_ARG(humidity, NULL, "Print humidity.", cmd_print_humidity, 1, 0),
-	SHELL_CMD_ARG(illuminance, NULL, "Print illuminance.", cmd_print_illuminance, 1, 0),
-	SHELL_CMD_ARG(t1_temperature, NULL, "Print T1 temperature.", cmd_print_t1_temperature, 1,
-		      0),
-	SHELL_CMD_ARG(t2_temperature, NULL, "Print T2 temperature.", cmd_print_t2_temperature, 1,
-		      0),
-	SHELL_CMD_ARG(motion, NULL, "Print number of PIR activations", cmd_print_motion_count, 1,
-		      0),
-
+	SHELL_CMD(sensors, &sub_sensors, "Sensor commands.", NULL),
+	SHELL_CMD_ARG(hw_deveui, NULL, "Print hardware DevEUI from chip UID.",
+		      cmd_print_hw_deveui, 1, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(tester, &sub_test, "Tester commands.", NULL);
+
+static int app_tester_init(void)
+{
+	k_work_init_delayable(&g_led_cycle_work, led_cycle_work_handler);
+	return 0;
+}
+
+SYS_INIT(app_tester_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
- Add tester shell commands for hardware testing (sensors, LEDs, DevEUI)
- Add app_sht40_read_serial() for SHT43 serial on motherboard
- Add app_machine_probe_read_hygrometer_serial() for SHT33 on machine probe
- Add CONFIG_APP_MACHINE_PROBE_SHT43 Kconfig option for future SHT43 support
- Add CLAUDE.md with project documentation