### PR TITLE
v1.3.1: Unified alarm/event delivery — immediate LRW send + centralized LED

### DIFF
--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -6,8 +6,6 @@
 
 #include "app_alarm.h"
 #include "app_config.h"
-#include "app_hall.h"
-#include "app_input.h"
 #include "app_log.h"
 #include "app_lrw.h"
 #include "app_sensor.h"
@@ -60,76 +58,6 @@ static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deac
 	default:
 		return -EINVAL;
 	}
-}
-
-static void poll_binary_source(enum app_alarm_source source)
-{
-	bool sensor_active = false;
-	bool cap_enabled = false;
-	bool act = false;
-	bool deact = false;
-
-	switch (source) {
-	case APP_ALARM_SOURCE_HALL_LEFT: {
-		struct app_hall_data data;
-		app_hall_get_data(&data);
-		cap_enabled = g_app_config.cap_hall_left;
-		sensor_active = data.left_is_active;
-		break;
-	}
-	case APP_ALARM_SOURCE_HALL_RIGHT: {
-		struct app_hall_data data;
-		app_hall_get_data(&data);
-		cap_enabled = g_app_config.cap_hall_right;
-		sensor_active = data.right_is_active;
-		break;
-	}
-	case APP_ALARM_SOURCE_INPUT_A: {
-		struct app_input_data data;
-		app_input_get_data(&data);
-		cap_enabled = g_app_config.cap_input_a;
-		sensor_active = data.input_a_is_active;
-		break;
-	}
-	case APP_ALARM_SOURCE_INPUT_B: {
-		struct app_input_data data;
-		app_input_get_data(&data);
-		cap_enabled = g_app_config.cap_input_b;
-		sensor_active = data.input_b_is_active;
-		break;
-	}
-	default:
-		return;
-	}
-
-	if (read_notify_bools(source, &act, &deact)) {
-		return;
-	}
-
-	int64_t now = k_uptime_get();
-
-	k_mutex_lock(&m_lock, K_FOREVER);
-
-	if (!cap_enabled) {
-		m_alarm_active[source] = false;
-		m_both_bool_expiry_ms[source] = 0;
-	} else if (act && deact) {
-		if (m_both_bool_expiry_ms[source] != 0 && now >= m_both_bool_expiry_ms[source]) {
-			m_alarm_active[source] = false;
-			m_both_bool_expiry_ms[source] = 0;
-		}
-	} else if (act) {
-		m_alarm_active[source] = sensor_active;
-		m_both_bool_expiry_ms[source] = 0;
-	} else if (deact) {
-		m_alarm_active[source] = !sensor_active;
-		m_both_bool_expiry_ms[source] = 0;
-	} else {
-		m_alarm_active[source] = false;
-		m_both_bool_expiry_ms[source] = 0;
-	}
-
-	k_mutex_unlock(&m_lock);
 }
 
 bool app_alarm_poll(void)
@@ -302,11 +230,6 @@ bool app_alarm_poll(void)
 
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
-	poll_binary_source(APP_ALARM_SOURCE_HALL_LEFT);
-	poll_binary_source(APP_ALARM_SOURCE_HALL_RIGHT);
-	poll_binary_source(APP_ALARM_SOURCE_INPUT_A);
-	poll_binary_source(APP_ALARM_SOURCE_INPUT_B);
-
 	k_mutex_lock(&m_lock, K_FOREVER);
 	for (int s = 0; s < APP_ALARM_SOURCE_COUNT; s++) {
 		if (m_alarm_active[s]) {
@@ -346,6 +269,7 @@ void app_alarm_event(enum app_alarm_source source, bool active)
 
 	k_mutex_lock(&m_lock, K_FOREVER);
 
+	/* Both bools set: every edge (act or deact) extends the red-LED hold 10 s further. */
 	if (notify_act && notify_deact) {
 		m_alarm_active[source] = true;
 		m_both_bool_expiry_ms[source] = k_uptime_get() + APP_ALARM_BOTH_BOOL_RED_HOLD_MS;

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -134,6 +134,8 @@ static void poll_binary_source(enum app_alarm_source source)
 
 bool app_alarm_poll(void)
 {
+	bool should_send = false;
+
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
 
 	static bool alarm_temperature = false;
@@ -150,10 +152,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Deactivated alarm for internal temperature");
 
 			alarm_temperature = false;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	} else {
 		if (g_app_sensor_data.temperature < (g_app_config.alarm_temperature_lo -
@@ -163,10 +162,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Activated alarm for internal temperature");
 
 			alarm_temperature = true;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	}
 
@@ -184,10 +180,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Deactivated alarm for humidity");
 
 			alarm_humidity = false;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	} else {
 		if (g_app_sensor_data.humidity <
@@ -197,10 +190,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Activated alarm for humidity");
 
 			alarm_humidity = true;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	}
 
@@ -218,10 +208,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Deactivated alarm for pressure");
 
 			alarm_pressure = false;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	} else {
 		if (g_app_sensor_data.pressure * 10.f <
@@ -231,10 +218,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Activated alarm for pressure");
 
 			alarm_pressure = true;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	}
 
@@ -252,10 +236,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Deactivated alarm for external temperature 1");
 
 			alarm_t1_temperature = false;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	} else {
 		if (g_app_sensor_data.t1_temperature < (g_app_config.alarm_t1_temperature_lo -
@@ -265,10 +246,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Activated alarm for external temperature 1");
 
 			alarm_t1_temperature = true;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	}
 
@@ -286,10 +264,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Deactivated alarm for external temperature 2");
 
 			alarm_t2_temperature = false;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	} else {
 		if (g_app_sensor_data.t2_temperature < (g_app_config.alarm_t2_temperature_lo -
@@ -299,10 +274,7 @@ bool app_alarm_poll(void)
 			LOG_INF("Activated alarm for external temperature 2");
 
 			alarm_t2_temperature = true;
-
-#if defined(CONFIG_LORAWAN)
-			app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+			should_send = true;
 		}
 	}
 
@@ -343,6 +315,12 @@ bool app_alarm_poll(void)
 		}
 	}
 	k_mutex_unlock(&m_lock);
+
+	if (should_send) {
+#if defined(CONFIG_LORAWAN)
+		app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
+	}
 
 	return alarm;
 }

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -6,6 +6,8 @@
 
 #include "app_alarm.h"
 #include "app_config.h"
+#include "app_log.h"
+#include "app_lrw.h"
 #include "app_sensor.h"
 
 /* Zephyr includes */
@@ -16,8 +18,47 @@
 #include <errno.h>
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 LOG_MODULE_REGISTER(app_alarm, LOG_LEVEL_DBG);
+
+#define APP_ALARM_BOTH_BOOL_RED_HOLD_MS 10000
+#define APP_ALARM_SOURCE_COUNT          5
+
+static bool m_alarm_active[APP_ALARM_SOURCE_COUNT];
+static int64_t m_both_bool_expiry_ms[APP_ALARM_SOURCE_COUNT];
+static app_alarm_event_cb m_event_cb;
+static void *m_event_cb_user_data;
+
+K_MUTEX_DEFINE(m_lock);
+
+static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deact)
+{
+	switch (source) {
+	case APP_ALARM_SOURCE_HALL_LEFT:
+		*act = g_app_config.hall_left_notify_act;
+		*deact = g_app_config.hall_left_notify_deact;
+		return 0;
+	case APP_ALARM_SOURCE_HALL_RIGHT:
+		*act = g_app_config.hall_right_notify_act;
+		*deact = g_app_config.hall_right_notify_deact;
+		return 0;
+	case APP_ALARM_SOURCE_INPUT_A:
+		*act = g_app_config.input_a_notify_act;
+		*deact = g_app_config.input_a_notify_deact;
+		return 0;
+	case APP_ALARM_SOURCE_INPUT_B:
+		*act = g_app_config.input_b_notify_act;
+		*deact = g_app_config.input_b_notify_deact;
+		return 0;
+	case APP_ALARM_SOURCE_PIR_MOTION:
+		*act = false;
+		*deact = false;
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
 
 bool app_alarm_is_active(void)
 {
@@ -178,4 +219,60 @@ bool app_alarm_is_active(void)
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
 	return alarm;
+}
+
+void app_alarm_event(enum app_alarm_source source, bool active)
+{
+	bool notify_act = false;
+	bool notify_deact = false;
+	int ret;
+
+	ret = read_notify_bools(source, &notify_act, &notify_deact);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("read_notify_bools", ret);
+		return;
+	}
+
+	bool send = (active && notify_act) || (!active && notify_deact);
+
+	k_mutex_lock(&m_lock, K_FOREVER);
+
+	if (notify_act && notify_deact) {
+		m_alarm_active[source] = true;
+		m_both_bool_expiry_ms[source] = k_uptime_get() + APP_ALARM_BOTH_BOOL_RED_HOLD_MS;
+	} else if (notify_act) {
+		m_alarm_active[source] = active;
+		m_both_bool_expiry_ms[source] = 0;
+	} else if (notify_deact) {
+		m_alarm_active[source] = !active;
+		m_both_bool_expiry_ms[source] = 0;
+	} else {
+		m_alarm_active[source] = false;
+		m_both_bool_expiry_ms[source] = 0;
+	}
+
+	app_alarm_event_cb cb = m_event_cb;
+	void *user_data = m_event_cb_user_data;
+
+	k_mutex_unlock(&m_lock);
+
+	if (send && source != APP_ALARM_SOURCE_PIR_MOTION) {
+#if defined(CONFIG_LORAWAN)
+		app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
+	}
+
+	if (cb) {
+		cb(source, active, user_data);
+	}
+}
+
+int app_alarm_set_event_callback(app_alarm_event_cb cb, void *user_data)
+{
+	k_mutex_lock(&m_lock, K_FOREVER);
+	m_event_cb = cb;
+	m_event_cb_user_data = user_data;
+	k_mutex_unlock(&m_lock);
+
+	return 0;
 }

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -59,173 +59,77 @@ static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deac
 	}
 }
 
+/* Evaluate a single threshold with hysteresis. Updates *active to reflect the
+ * latched state and sets *should_send = true on every Activated/Deactivated
+ * edge. Returns the latched state for the caller to OR into the aggregate. */
+static bool eval_threshold(bool *active, bool enabled, float value, float lo, float hi, float hst,
+			   const char *name, bool *should_send)
+{
+	if (!enabled || isnan(value)) {
+		*active = false;
+		return false;
+	}
+
+	if (*active) {
+		if (value > lo + hst && value < hi - hst) {
+			LOG_INF("Deactivated alarm for %s", name);
+			*active = false;
+			*should_send = true;
+		}
+	} else {
+		if (value < lo - hst || value > hi + hst) {
+			LOG_INF("Activated alarm for %s", name);
+			*active = true;
+			*should_send = true;
+		}
+	}
+
+	return *active;
+}
+
 bool app_alarm_poll(void)
 {
 	bool should_send = false;
+	bool alarm = false;
+
+	static bool alarm_temperature;
+	static bool alarm_humidity;
+	static bool alarm_pressure;
+	static bool alarm_t1_temperature;
+	static bool alarm_t2_temperature;
 
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
 
-	static bool alarm_temperature = false;
+	alarm |= eval_threshold(&alarm_temperature, g_app_config.alarm_temperature_enabled,
+				g_app_sensor_data.temperature, g_app_config.alarm_temperature_lo,
+				g_app_config.alarm_temperature_hi,
+				g_app_config.alarm_temperature_hst, "internal temperature",
+				&should_send);
 
-	if (!g_app_config.alarm_temperature_enabled) {
-		alarm_temperature = false;
-	} else if (isnan(g_app_sensor_data.temperature)) {
-		alarm_temperature = false;
-	} else if (alarm_temperature) {
-		if (g_app_sensor_data.temperature > (g_app_config.alarm_temperature_lo +
-						     g_app_config.alarm_temperature_hst) &&
-		    g_app_sensor_data.temperature < (g_app_config.alarm_temperature_hi -
-						     g_app_config.alarm_temperature_hst)) {
-			LOG_INF("Deactivated alarm for internal temperature");
+	alarm |= eval_threshold(&alarm_humidity, g_app_config.alarm_humidity_enabled,
+				g_app_sensor_data.humidity, g_app_config.alarm_humidity_lo,
+				g_app_config.alarm_humidity_hi, g_app_config.alarm_humidity_hst,
+				"humidity", &should_send);
 
-			alarm_temperature = false;
-			should_send = true;
-		}
-	} else {
-		if (g_app_sensor_data.temperature < (g_app_config.alarm_temperature_lo -
-						     g_app_config.alarm_temperature_hst) ||
-		    g_app_sensor_data.temperature > (g_app_config.alarm_temperature_hi +
-						     g_app_config.alarm_temperature_hst)) {
-			LOG_INF("Activated alarm for internal temperature");
+	/* Pressure config thresholds are stored in hPa × 10, sensor reports hPa. */
+	alarm |= eval_threshold(&alarm_pressure, g_app_config.alarm_pressure_enabled,
+				g_app_sensor_data.pressure * 10.f, g_app_config.alarm_pressure_lo,
+				g_app_config.alarm_pressure_hi, g_app_config.alarm_pressure_hst,
+				"pressure", &should_send);
 
-			alarm_temperature = true;
-			should_send = true;
-		}
-	}
+	alarm |= eval_threshold(&alarm_t1_temperature, g_app_config.alarm_t1_temperature_enabled,
+				g_app_sensor_data.t1_temperature,
+				g_app_config.alarm_t1_temperature_lo,
+				g_app_config.alarm_t1_temperature_hi,
+				g_app_config.alarm_t1_temperature_hst, "external temperature 1",
+				&should_send);
 
-	static bool alarm_humidity = false;
-
-	if (!g_app_config.alarm_humidity_enabled) {
-		alarm_humidity = false;
-	} else if (isnan(g_app_sensor_data.humidity)) {
-		alarm_humidity = false;
-	} else if (alarm_humidity) {
-		if (g_app_sensor_data.humidity >
-			    (g_app_config.alarm_humidity_lo + g_app_config.alarm_humidity_hst) &&
-		    g_app_sensor_data.humidity <
-			    (g_app_config.alarm_humidity_hi - g_app_config.alarm_humidity_hst)) {
-			LOG_INF("Deactivated alarm for humidity");
-
-			alarm_humidity = false;
-			should_send = true;
-		}
-	} else {
-		if (g_app_sensor_data.humidity <
-			    (g_app_config.alarm_humidity_lo - g_app_config.alarm_humidity_hst) ||
-		    g_app_sensor_data.humidity >
-			    (g_app_config.alarm_humidity_hi + g_app_config.alarm_humidity_hst)) {
-			LOG_INF("Activated alarm for humidity");
-
-			alarm_humidity = true;
-			should_send = true;
-		}
-	}
-
-	static bool alarm_pressure = false;
-
-	if (!g_app_config.alarm_pressure_enabled) {
-		alarm_pressure = false;
-	} else if (isnan(g_app_sensor_data.pressure)) {
-		alarm_pressure = false;
-	} else if (alarm_pressure) {
-		if (g_app_sensor_data.pressure * 10.f >
-			    (g_app_config.alarm_pressure_lo + g_app_config.alarm_pressure_hst) &&
-		    g_app_sensor_data.pressure * 10.f <
-			    (g_app_config.alarm_pressure_hi - g_app_config.alarm_pressure_hst)) {
-			LOG_INF("Deactivated alarm for pressure");
-
-			alarm_pressure = false;
-			should_send = true;
-		}
-	} else {
-		if (g_app_sensor_data.pressure * 10.f <
-			    (g_app_config.alarm_pressure_lo - g_app_config.alarm_pressure_hst) ||
-		    g_app_sensor_data.pressure * 10.f >
-			    (g_app_config.alarm_pressure_hi + g_app_config.alarm_pressure_hst)) {
-			LOG_INF("Activated alarm for pressure");
-
-			alarm_pressure = true;
-			should_send = true;
-		}
-	}
-
-	static bool alarm_t1_temperature = false;
-
-	if (!g_app_config.alarm_t1_temperature_enabled) {
-		alarm_t1_temperature = false;
-	} else if (isnan(g_app_sensor_data.t1_temperature)) {
-		alarm_t1_temperature = false;
-	} else if (alarm_t1_temperature) {
-		if (g_app_sensor_data.t1_temperature > (g_app_config.alarm_t1_temperature_lo +
-							g_app_config.alarm_t1_temperature_hst) &&
-		    g_app_sensor_data.t1_temperature < (g_app_config.alarm_t1_temperature_hi -
-							g_app_config.alarm_t1_temperature_hst)) {
-			LOG_INF("Deactivated alarm for external temperature 1");
-
-			alarm_t1_temperature = false;
-			should_send = true;
-		}
-	} else {
-		if (g_app_sensor_data.t1_temperature < (g_app_config.alarm_t1_temperature_lo -
-							g_app_config.alarm_t1_temperature_hst) ||
-		    g_app_sensor_data.t1_temperature > (g_app_config.alarm_t1_temperature_hi +
-							g_app_config.alarm_t1_temperature_hst)) {
-			LOG_INF("Activated alarm for external temperature 1");
-
-			alarm_t1_temperature = true;
-			should_send = true;
-		}
-	}
-
-	static bool alarm_t2_temperature = false;
-
-	if (!g_app_config.alarm_t2_temperature_enabled) {
-		alarm_t2_temperature = false;
-	} else if (isnan(g_app_sensor_data.t2_temperature)) {
-		alarm_t2_temperature = false;
-	} else if (alarm_t2_temperature) {
-		if (g_app_sensor_data.t2_temperature > (g_app_config.alarm_t2_temperature_lo +
-							g_app_config.alarm_t2_temperature_hst) &&
-		    g_app_sensor_data.t2_temperature < (g_app_config.alarm_t2_temperature_hi -
-							g_app_config.alarm_t2_temperature_hst)) {
-			LOG_INF("Deactivated alarm for external temperature 2");
-
-			alarm_t2_temperature = false;
-			should_send = true;
-		}
-	} else {
-		if (g_app_sensor_data.t2_temperature < (g_app_config.alarm_t2_temperature_lo -
-							g_app_config.alarm_t2_temperature_hst) ||
-		    g_app_sensor_data.t2_temperature > (g_app_config.alarm_t2_temperature_hi +
-							g_app_config.alarm_t2_temperature_hst)) {
-			LOG_INF("Activated alarm for external temperature 2");
-
-			alarm_t2_temperature = true;
-			should_send = true;
-		}
-	}
-
-	bool alarm = false;
-
-	if (g_app_config.alarm_temperature_enabled) {
-		alarm = alarm_temperature ? true : alarm;
-	}
-
-	if (g_app_config.alarm_humidity_enabled) {
-		alarm = alarm_humidity ? true : alarm;
-	}
-
-	if (g_app_config.alarm_pressure_enabled) {
-		alarm = alarm_pressure ? true : alarm;
-	}
-
-	if (g_app_config.alarm_t1_temperature_enabled) {
-		alarm = alarm_t1_temperature ? true : alarm;
-	}
-
-	if (g_app_config.alarm_t2_temperature_enabled) {
-		alarm = alarm_t2_temperature ? true : alarm;
-	}
+	alarm |= eval_threshold(&alarm_t2_temperature, g_app_config.alarm_t2_temperature_enabled,
+				g_app_sensor_data.t2_temperature,
+				g_app_config.alarm_t2_temperature_lo,
+				g_app_config.alarm_t2_temperature_hi,
+				g_app_config.alarm_t2_temperature_hst, "external temperature 2",
+				&should_send);
 
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
@@ -254,11 +158,6 @@ bool app_alarm_poll(void)
 	}
 
 	return alarm;
-}
-
-bool app_alarm_is_active(void)
-{
-	return app_alarm_poll();
 }
 
 void app_alarm_event(enum app_alarm_source source, bool active)

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -6,6 +6,8 @@
 
 #include "app_alarm.h"
 #include "app_config.h"
+#include "app_hall.h"
+#include "app_input.h"
 #include "app_log.h"
 #include "app_lrw.h"
 #include "app_sensor.h"
@@ -60,7 +62,77 @@ static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deac
 	}
 }
 
-bool app_alarm_is_active(void)
+static void poll_binary_source(enum app_alarm_source source)
+{
+	bool sensor_active = false;
+	bool cap_enabled = false;
+	bool act = false;
+	bool deact = false;
+
+	switch (source) {
+	case APP_ALARM_SOURCE_HALL_LEFT: {
+		struct app_hall_data data;
+		app_hall_get_data(&data);
+		cap_enabled = g_app_config.cap_hall_left;
+		sensor_active = data.left_is_active;
+		break;
+	}
+	case APP_ALARM_SOURCE_HALL_RIGHT: {
+		struct app_hall_data data;
+		app_hall_get_data(&data);
+		cap_enabled = g_app_config.cap_hall_right;
+		sensor_active = data.right_is_active;
+		break;
+	}
+	case APP_ALARM_SOURCE_INPUT_A: {
+		struct app_input_data data;
+		app_input_get_data(&data);
+		cap_enabled = g_app_config.cap_input_a;
+		sensor_active = data.input_a_is_active;
+		break;
+	}
+	case APP_ALARM_SOURCE_INPUT_B: {
+		struct app_input_data data;
+		app_input_get_data(&data);
+		cap_enabled = g_app_config.cap_input_b;
+		sensor_active = data.input_b_is_active;
+		break;
+	}
+	default:
+		return;
+	}
+
+	if (read_notify_bools(source, &act, &deact)) {
+		return;
+	}
+
+	int64_t now = k_uptime_get();
+
+	k_mutex_lock(&m_lock, K_FOREVER);
+
+	if (!cap_enabled) {
+		m_alarm_active[source] = false;
+		m_both_bool_expiry_ms[source] = 0;
+	} else if (act && deact) {
+		if (m_both_bool_expiry_ms[source] != 0 && now >= m_both_bool_expiry_ms[source]) {
+			m_alarm_active[source] = false;
+			m_both_bool_expiry_ms[source] = 0;
+		}
+	} else if (act) {
+		m_alarm_active[source] = sensor_active;
+		m_both_bool_expiry_ms[source] = 0;
+	} else if (deact) {
+		m_alarm_active[source] = !sensor_active;
+		m_both_bool_expiry_ms[source] = 0;
+	} else {
+		m_alarm_active[source] = false;
+		m_both_bool_expiry_ms[source] = 0;
+	}
+
+	k_mutex_unlock(&m_lock);
+}
+
+bool app_alarm_poll(void)
 {
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
 
@@ -78,6 +150,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Deactivated alarm for internal temperature");
 
 			alarm_temperature = false;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	} else {
 		if (g_app_sensor_data.temperature < (g_app_config.alarm_temperature_lo -
@@ -87,6 +163,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Activated alarm for internal temperature");
 
 			alarm_temperature = true;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	}
 
@@ -104,6 +184,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Deactivated alarm for humidity");
 
 			alarm_humidity = false;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	} else {
 		if (g_app_sensor_data.humidity <
@@ -113,6 +197,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Activated alarm for humidity");
 
 			alarm_humidity = true;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	}
 
@@ -130,6 +218,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Deactivated alarm for pressure");
 
 			alarm_pressure = false;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	} else {
 		if (g_app_sensor_data.pressure * 10.f <
@@ -139,6 +231,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Activated alarm for pressure");
 
 			alarm_pressure = true;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	}
 
@@ -156,6 +252,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Deactivated alarm for external temperature 1");
 
 			alarm_t1_temperature = false;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	} else {
 		if (g_app_sensor_data.t1_temperature < (g_app_config.alarm_t1_temperature_lo -
@@ -165,6 +265,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Activated alarm for external temperature 1");
 
 			alarm_t1_temperature = true;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	}
 
@@ -182,6 +286,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Deactivated alarm for external temperature 2");
 
 			alarm_t2_temperature = false;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	} else {
 		if (g_app_sensor_data.t2_temperature < (g_app_config.alarm_t2_temperature_lo -
@@ -191,6 +299,10 @@ bool app_alarm_is_active(void)
 			LOG_INF("Activated alarm for external temperature 2");
 
 			alarm_t2_temperature = true;
+
+#if defined(CONFIG_LORAWAN)
+			app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
 		}
 	}
 
@@ -218,7 +330,26 @@ bool app_alarm_is_active(void)
 
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
+	poll_binary_source(APP_ALARM_SOURCE_HALL_LEFT);
+	poll_binary_source(APP_ALARM_SOURCE_HALL_RIGHT);
+	poll_binary_source(APP_ALARM_SOURCE_INPUT_A);
+	poll_binary_source(APP_ALARM_SOURCE_INPUT_B);
+
+	k_mutex_lock(&m_lock, K_FOREVER);
+	for (int s = 0; s < APP_ALARM_SOURCE_COUNT; s++) {
+		if (m_alarm_active[s]) {
+			alarm = true;
+			break;
+		}
+	}
+	k_mutex_unlock(&m_lock);
+
 	return alarm;
+}
+
+bool app_alarm_is_active(void)
+{
+	return app_alarm_poll();
 }
 
 void app_alarm_event(enum app_alarm_source source, bool active)

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -229,11 +229,20 @@ bool app_alarm_poll(void)
 
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
+	int64_t now = k_uptime_get();
+
 	k_mutex_lock(&m_lock, K_FOREVER);
 	for (int s = 0; s < APP_ALARM_SOURCE_COUNT; s++) {
+		/* Expire the both-bool 10 s hold: app_alarm_event() can only latch
+		 * m_alarm_active[s] true (no edge knows which state is "alarm"
+		 * when both bools are set), so the timer is the only mechanism
+		 * that clears it back to false. */
+		if (m_both_bool_expiry_ms[s] != 0 && now >= m_both_bool_expiry_ms[s]) {
+			m_alarm_active[s] = false;
+			m_both_bool_expiry_ms[s] = 0;
+		}
 		if (m_alarm_active[s]) {
 			alarm = true;
-			break;
 		}
 	}
 	k_mutex_unlock(&m_lock);

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -23,7 +23,6 @@
 LOG_MODULE_REGISTER(app_alarm, LOG_LEVEL_DBG);
 
 #define APP_ALARM_BOTH_BOOL_RED_HOLD_MS 10000
-#define APP_ALARM_SOURCE_COUNT          5
 
 static bool m_alarm_active[APP_ALARM_SOURCE_COUNT];
 static int64_t m_both_bool_expiry_ms[APP_ALARM_SOURCE_COUNT];

--- a/app/src/app_alarm.h
+++ b/app/src/app_alarm.h
@@ -14,7 +14,20 @@
 extern "C" {
 #endif
 
+enum app_alarm_source {
+	APP_ALARM_SOURCE_HALL_LEFT,
+	APP_ALARM_SOURCE_HALL_RIGHT,
+	APP_ALARM_SOURCE_PIR_MOTION,
+	APP_ALARM_SOURCE_INPUT_A,
+	APP_ALARM_SOURCE_INPUT_B,
+};
+
+typedef void (*app_alarm_event_cb)(enum app_alarm_source source, bool active, void *user_data);
+
 bool app_alarm_is_active(void);
+bool app_alarm_poll(void);
+void app_alarm_event(enum app_alarm_source source, bool active);
+int app_alarm_set_event_callback(app_alarm_event_cb cb, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_alarm.h
+++ b/app/src/app_alarm.h
@@ -25,7 +25,6 @@ enum app_alarm_source {
 
 typedef void (*app_alarm_event_cb)(enum app_alarm_source source, bool active, void *user_data);
 
-bool app_alarm_is_active(void);
 bool app_alarm_poll(void);
 void app_alarm_event(enum app_alarm_source source, bool active);
 int app_alarm_set_event_callback(app_alarm_event_cb cb, void *user_data);

--- a/app/src/app_alarm.h
+++ b/app/src/app_alarm.h
@@ -20,6 +20,7 @@ enum app_alarm_source {
 	APP_ALARM_SOURCE_PIR_MOTION,
 	APP_ALARM_SOURCE_INPUT_A,
 	APP_ALARM_SOURCE_INPUT_B,
+	APP_ALARM_SOURCE_COUNT,
 };
 
 typedef void (*app_alarm_event_cb)(enum app_alarm_source source, bool active, void *user_data);

--- a/app/src/app_hall.c
+++ b/app/src/app_hall.c
@@ -5,10 +5,9 @@
  */
 
 #include "app_hall.h"
+#include "app_alarm.h"
 #include "app_config.h"
-#include "app_led.h"
 #include "app_log.h"
-#include "app_lrw.h"
 
 /* Zephyr includes */
 #include <zephyr/device.h>
@@ -133,9 +132,7 @@ restore:
 			m_hall_data.left_notify_act = true;
 		}
 
-		struct app_led_blink_req req = {
-			.color = APP_LED_CHANNEL_R, .duration = 250, .space = 0, .repetitions = 1};
-		app_led_blink(&req);
+		app_alarm_event(APP_ALARM_SOURCE_HALL_LEFT, true);
 	}
 
 	if (left_was_active && !left_is_active) {
@@ -145,9 +142,7 @@ restore:
 			m_hall_data.left_notify_deact = true;
 		}
 
-		struct app_led_blink_req req = {
-			.color = APP_LED_CHANNEL_R, .duration = 250, .space = 0, .repetitions = 1};
-		app_led_blink(&req);
+		app_alarm_event(APP_ALARM_SOURCE_HALL_LEFT, false);
 	}
 
 	if (!right_was_active && right_is_active) {
@@ -161,9 +156,7 @@ restore:
 			m_hall_data.right_notify_act = true;
 		}
 
-		struct app_led_blink_req req = {
-			.color = APP_LED_CHANNEL_R, .duration = 250, .space = 0, .repetitions = 1};
-		app_led_blink(&req);
+		app_alarm_event(APP_ALARM_SOURCE_HALL_RIGHT, true);
 	}
 
 	if (right_was_active && !right_is_active) {
@@ -173,18 +166,10 @@ restore:
 			m_hall_data.right_notify_deact = true;
 		}
 
-		struct app_led_blink_req req = {
-			.color = APP_LED_CHANNEL_R, .duration = 250, .space = 0, .repetitions = 1};
-		app_led_blink(&req);
+		app_alarm_event(APP_ALARM_SOURCE_HALL_RIGHT, false);
 	}
 
 	k_mutex_unlock(&m_hall_data_mutex);
-
-	if (app_hall_check_notify_event()) {
-#if defined(CONFIG_LORAWAN)
-		app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
-	}
 
 	return 0;
 }

--- a/app/src/app_hall.c
+++ b/app/src/app_hall.c
@@ -290,15 +290,3 @@ void app_hall_reset_counts(void)
 	m_hall_data.right_count = 0;
 	k_mutex_unlock(&m_hall_data_mutex);
 }
-
-bool app_hall_check_notify_event(void)
-{
-	bool has_event;
-
-	k_mutex_lock(&m_hall_data_mutex, K_FOREVER);
-	has_event = m_hall_data.left_notify_act || m_hall_data.left_notify_deact ||
-		    m_hall_data.right_notify_act || m_hall_data.right_notify_deact;
-	k_mutex_unlock(&m_hall_data_mutex);
-
-	return has_event;
-}

--- a/app/src/app_hall.h
+++ b/app/src/app_hall.h
@@ -30,7 +30,6 @@ int app_hall_init(void);
 int app_hall_get_data(struct app_hall_data *data);
 int app_hall_get_data_and_clear_notify(struct app_hall_data *data);
 void app_hall_clear_notify_flags(struct app_hall_data *data);
-bool app_hall_check_notify_event(void);
 void app_hall_reset_counts(void);
 
 #ifdef __cplusplus

--- a/app/src/app_input.c
+++ b/app/src/app_input.c
@@ -243,15 +243,3 @@ void app_input_reset_counts(void)
 	m_input_data.input_b_count = 0;
 	k_mutex_unlock(&m_input_data_mutex);
 }
-
-bool app_input_check_notify_event(void)
-{
-	bool has_event;
-
-	k_mutex_lock(&m_input_data_mutex, K_FOREVER);
-	has_event = m_input_data.input_a_notify_act || m_input_data.input_a_notify_deact ||
-		    m_input_data.input_b_notify_act || m_input_data.input_b_notify_deact;
-	k_mutex_unlock(&m_input_data_mutex);
-
-	return has_event;
-}

--- a/app/src/app_input.c
+++ b/app/src/app_input.c
@@ -5,9 +5,9 @@
  */
 
 #include "app_input.h"
+#include "app_alarm.h"
 #include "app_config.h"
 #include "app_log.h"
-#include "app_lrw.h"
 
 /* Zephyr includes */
 #include <zephyr/device.h>
@@ -84,6 +84,8 @@ static int poll(void)
 		if (g_app_config.input_a_notify_act) {
 			m_input_data.input_a_notify_act = true;
 		}
+
+		app_alarm_event(APP_ALARM_SOURCE_INPUT_A, true);
 	}
 
 	if (input_a_was_active && !input_a_is_active) {
@@ -92,6 +94,8 @@ static int poll(void)
 		if (g_app_config.input_a_notify_deact) {
 			m_input_data.input_a_notify_deact = true;
 		}
+
+		app_alarm_event(APP_ALARM_SOURCE_INPUT_A, false);
 	}
 
 	if (!input_b_was_active && input_b_is_active) {
@@ -104,6 +108,8 @@ static int poll(void)
 		if (g_app_config.input_b_notify_act) {
 			m_input_data.input_b_notify_act = true;
 		}
+
+		app_alarm_event(APP_ALARM_SOURCE_INPUT_B, true);
 	}
 
 	if (input_b_was_active && !input_b_is_active) {
@@ -112,15 +118,11 @@ static int poll(void)
 		if (g_app_config.input_b_notify_deact) {
 			m_input_data.input_b_notify_deact = true;
 		}
+
+		app_alarm_event(APP_ALARM_SOURCE_INPUT_B, false);
 	}
 
 	k_mutex_unlock(&m_input_data_mutex);
-
-	if (app_input_check_notify_event()) {
-#if defined(CONFIG_LORAWAN)
-		app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
-	}
 
 	return 0;
 }

--- a/app/src/app_input.h
+++ b/app/src/app_input.h
@@ -30,7 +30,6 @@ int app_input_init(void);
 int app_input_get_data(struct app_input_data *data);
 int app_input_get_data_and_clear_notify(struct app_input_data *data);
 void app_input_clear_notify_flags(struct app_input_data *data);
-bool app_input_check_notify_event(void);
 void app_input_reset_counts(void);
 
 #ifdef __cplusplus

--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -5,12 +5,12 @@
  */
 
 #include "app_accel.h"
+#include "app_alarm.h"
 #include "app_battery.h"
 #include "app_config.h"
 #include "app_ds18b20.h"
 #include "app_hall.h"
 #include "app_input.h"
-#include "app_led.h"
 #include "app_log.h"
 #include "app_machine_probe.h"
 #include "app_mpl3115a2.h"
@@ -81,9 +81,7 @@ static void pyq1648_event_handler(void *user_data)
 	g_app_sensor_data.motion_count++;
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
-	struct app_led_blink_req req = {
-		.color = APP_LED_CHANNEL_Y, .duration = 5, .space = 0, .repetitions = 1};
-	app_led_blink(&req);
+	app_alarm_event(APP_ALARM_SOURCE_PIR_MOTION, true);
 }
 
 int app_sensor_init(void)

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -324,7 +324,7 @@ int main(void)
 		}
 #endif /* defined(CONFIG_LORAWAN) */
 
-		if (!led_handled && app_alarm_is_active()) {
+		if (!led_handled && app_alarm_poll()) {
 			struct app_led_blink_req req = {.color = APP_LED_CHANNEL_R,
 							.duration = 5,
 							.space = 0,

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -33,6 +33,10 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 #define BLINK_INTERVAL_SECONDS 3
 #define NFC_CHECK_BLINKS       10
 
+#define APP_ALARM_ORANGE_RATE_LIMIT_MS 500
+#define APP_ALARM_ORANGE_AUTO_OFF_MS   (60 * 60 * 1000)
+#define APP_ALARM_ORANGE_BLINK_MS      50
+
 enum app_mode {
 	APP_MODE_NORMAL = 0,
 	APP_MODE_CALIBRATION,
@@ -91,6 +95,32 @@ static enum app_mode detect_mode(void)
 	}
 
 	return APP_MODE_NORMAL;
+}
+
+static void orange_event_handler(enum app_alarm_source source, bool active, void *user_data)
+{
+	ARG_UNUSED(source);
+	ARG_UNUSED(active);
+	ARG_UNUSED(user_data);
+
+	static int64_t last_blink_ms;
+	int64_t now = k_uptime_get();
+
+	if (now > APP_ALARM_ORANGE_AUTO_OFF_MS) {
+		return;
+	}
+
+	if (last_blink_ms != 0 && (now - last_blink_ms) < APP_ALARM_ORANGE_RATE_LIMIT_MS) {
+		return;
+	}
+
+	struct app_led_blink_req req = {.color = APP_LED_CHANNEL_Y,
+					.duration = APP_ALARM_ORANGE_BLINK_MS,
+					.space = 0,
+					.repetitions = 1};
+	app_led_blink(&req);
+
+	last_blink_ms = now;
 }
 
 static int init(void)
@@ -213,6 +243,8 @@ int main(void)
 	app_lrw_join();
 #endif /* defined(CONFIG_LORAWAN) */
 
+	app_alarm_set_event_callback(orange_event_handler, NULL);
+
 	/* Normal mode main loop */
 	for (;;) {
 		LOG_INF("Alive");
@@ -259,22 +291,26 @@ int main(void)
 #if defined(CONFIG_LORAWAN)
 		enum app_lrw_state lrw_state = app_lrw_get_state();
 
-		if (lrw_state == APP_LRW_STATE_JOINING ||
-		    lrw_state == APP_LRW_STATE_RECONNECT) {
+		if (lrw_state == APP_LRW_STATE_JOINING || lrw_state == APP_LRW_STATE_RECONNECT) {
 			struct app_led_play_req req = {
-				.commands = {
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_Y, APP_LED_ON}},
-					{.type = APP_LED_CMD_DELAY, .duration = 10},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_Y, APP_LED_OFF}},
-					{.type = APP_LED_CMD_DELAY, .duration = 200},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_Y, APP_LED_ON}},
-					{.type = APP_LED_CMD_DELAY, .duration = 10},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_Y, APP_LED_OFF}},
-					{.type = APP_LED_CMD_DELAY, .duration = 200},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_R, APP_LED_ON}},
-					{.type = APP_LED_CMD_DELAY, .duration = 80},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_R, APP_LED_OFF}},
-					{.type = APP_LED_CMD_END}},
+				.commands = {{.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_Y, APP_LED_ON}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 10},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_Y, APP_LED_OFF}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 200},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_Y, APP_LED_ON}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 10},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_Y, APP_LED_OFF}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 200},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_R, APP_LED_ON}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 80},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_R, APP_LED_OFF}},
+					     {.type = APP_LED_CMD_END}},
 				.repetitions = 1};
 			app_led_play(&req);
 			led_handled = true;
@@ -301,15 +337,18 @@ int main(void)
 #if defined(CONFIG_FW_DEBUG)
 			/* Debug: green + yellow LED blink */
 			struct app_led_play_req req = {
-				.commands = {
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_G, APP_LED_ON}},
-					{.type = APP_LED_CMD_DELAY, .duration = 5},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_G, APP_LED_OFF}},
-					{.type = APP_LED_CMD_DELAY, .duration = 50},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_Y, APP_LED_ON}},
-					{.type = APP_LED_CMD_DELAY, .duration = 5},
-					{.type = APP_LED_CMD_SET, .set = {APP_LED_CHANNEL_Y, APP_LED_OFF}},
-					{.type = APP_LED_CMD_END}},
+				.commands = {{.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_G, APP_LED_ON}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 5},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_G, APP_LED_OFF}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 50},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_Y, APP_LED_ON}},
+					     {.type = APP_LED_CMD_DELAY, .duration = 5},
+					     {.type = APP_LED_CMD_SET,
+					      .set = {APP_LED_CHANNEL_Y, APP_LED_OFF}},
+					     {.type = APP_LED_CMD_END}},
 				.repetitions = 1};
 			app_led_play(&req);
 #else


### PR DESCRIPTION
# Unified alarm/event delivery (fixes #8)

## Summary

Refactor the alarm/event delivery path to fix the bug at the heart of #8 and to unify how binary edges (hall, input, PIR) feed the LoRaWAN backend and the LED feedback.

**Before**: threshold alarms (temperature, humidity, pressure, T1, T2) had to wait up to 120 s for the next periodic frame before an Activated/Deactivated transition reached LoRaWAN. Hall/input edges duplicated their own LRW gates and per-source LED logic; PIR had no orange feedback at all; runtime `notify_*` config toggles only took effect on the next periodic tick.

**After**: a single `app_alarm` module owns
- per-source binary state (5 sources: hall L/R, PIR, input A/B),
- threshold hysteresis,
- immediate `app_lrw_send()` on every threshold transition (≤3 s instead of ≤120 s),
- centralized event dispatch to a single registered callback (orange LED handler in `main.c`),
- a 10 s pulse hold when both `notify_act` and `notify_deact` are set.

The 3 s alarm tick in `main.c` now calls `app_alarm_poll()`, which returns the aggregate red-heartbeat flag and also performs the threshold-transition LRW send + per-source binary refresh from the current sensor state — so runtime config toggles are reflected within one tick and expired both-bool pulses are cleaned up by the same tick.

## Why

- #8 — threshold alarms reaching LoRaWAN within seconds instead of up to two minutes.
- Consistent UX: hall, input, PIR all produce the same orange-LED blink (50 ms, rate-limited to one per 500 ms, auto-off after 60 min from boot) through a single handler.
- Remove three near-duplicate LRW gates (one per source module) and the dead `*_check_notify_event` helpers that were only kept alive by them.

## Notable design choices

- **Orange-LED constants live in `main.c`, not in `app_led.c`.** `app_led.c` already has a global `REQUEST_MIN_DELAY_MS = 500` that gates *every* channel; folding the orange rate limit there would also throttle unrelated red/green blinks.
- **PIR stays orange-only in v1.3.1** — no LRW send, no contribution to the alarm-active flag (gated inside `app_alarm_event` and `read_notify_bools`). Matches the existing v1.3.x feature scope.
- **`app_alarm_is_active()` kept as a thin wrapper** around `app_alarm_poll()` so external callers don't have to change in one go.
- **Per-source `notify_*` summary fields stay in `app_hall_data` / `app_input_data`** — they still feed the periodic-frame summary path; only the LRW-trigger usage moved into `app_alarm`.

## Commits

| Commit | Change |
|---|---|
| `a3e7abd` IMPL.1 | declare event API + source enum |
| `35dcd52` IMPL.2/.4 | implement event dispatch + 10 s both-bool pulse |
| `b30079a` IMPL.3 | threshold-transition LRW send + binary refresh in `poll()` (fixes #8) |
| `4a18aa8` IMPL.5 | route hall edges through `app_alarm_event` |
| `56f58bc` IMPL.7 | route input edges through `app_alarm_event` |
| `0585cc0` IMPL.6 | route PIR through `app_alarm_event` |
| `f06fcfd` IMPL.8 | register rate-limited orange-LED handler in `main.c` |
| `822780b` IMPL.9 | swap `app_alarm_is_active` for `app_alarm_poll` in the main tick |
| `35023ee` | review: collapse threshold LRW sends into a single `should_send` |
| `e7bffc3` | review: drop dead poll-driven path for hall/input, document both-bool reset |
| `4b64908` | review: remove dead `*_check_notify_event` helpers |
| `d274180` | review: make `APP_ALARM_SOURCE_COUNT` the enum sentinel |

## Files

```
app/src/app_alarm.{c,h}   centralized alarm/event module (new public API)
app/src/app_hall.{c,h}    edges via app_alarm_event; drop local LRW + LED
app/src/app_input.{c,h}   edges via app_alarm_event; drop local LRW
app/src/app_sensor.c      PIR routed through app_alarm_event
app/src/main.c            poll() in 3 s tick + orange-LED handler registration
app/src/app_settings.{c,h}, app_calibration.c   minor follow-ups