### PR TITLE
v1.3.1: Fix US915/AU915 LoRaWAN - sub-band selection and region-change NVM reset

### DIFF
--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -20,6 +20,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/lorawan/lorawan.h>
 #include <zephyr/random/random.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -579,6 +580,59 @@ static void send_timer_handler(struct k_timer *timer)
 	k_work_submit_to_queue(&m_work_q, &m_send_work);
 }
 
+/* Clear the subset of Zephyr's LoRaWAN NVM keys (zephyr/subsys/lorawan/nvm/
+ * lorawan_nvm_settings.c:35-43) that would otherwise let lorawan_nvm_data_restore()
+ * inside lorawan_start() override the region we just set via lorawan_set_region().
+ * Crypto (DevNonce monotonicity), MacGroup1, and SecureElement are kept so the
+ * device does not look like a fresh provisioning to the network server.
+ * NetworkActivation lives in MacGroup2 -> device joins fresh every boot, which
+ * is the intended behaviour. */
+static void clear_stale_lorawan_nvm(void)
+{
+	static const char *const keys[] = {
+		"lorawan/nvm/MacGroup2",
+		"lorawan/nvm/RegionGroup1",
+		"lorawan/nvm/RegionGroup2",
+		"lorawan/nvm/ClassB",
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(keys); i++) {
+		int ret = settings_delete(keys[i]);
+		if (ret && ret != -ENOENT) {
+			LOG_ERR("Call `settings_delete` failed (%s): %d", keys[i], ret);
+			/* Continue - a leftover stale key is better than aborting boot. */
+		}
+	}
+}
+
+static int apply_subband(int sub_band)
+{
+	if (sub_band == 0) {
+		return 0;
+	}
+	if (sub_band < 1 || sub_band > 8) {
+		LOG_ERR("Invalid sub-band: %d", sub_band);
+		return -EINVAL;
+	}
+
+	uint16_t mask[6] = {0};
+	uint8_t base = (sub_band - 1) * 8;
+	for (uint8_t ch = base; ch < base + 8; ch++) {
+		mask[ch / 16] |= BIT(ch % 16);
+	}
+	uint8_t hi_ch = 64 + (sub_band - 1);
+	mask[hi_ch / 16] |= BIT(hi_ch % 16);
+
+	int ret = lorawan_set_channels_mask(mask, ARRAY_SIZE(mask));
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("lorawan_set_channels_mask", ret);
+		return ret;
+	}
+
+	LOG_INF("Applied sub-band %d", sub_band);
+	return 0;
+}
+
 int app_lrw_init(void)
 {
 	int ret;
@@ -588,6 +642,8 @@ int app_lrw_init(void)
 		LOG_ERR("Device not ready");
 		return -ENODEV;
 	}
+
+	clear_stale_lorawan_nvm();
 
 	enum lorawan_region region;
 
@@ -616,6 +672,15 @@ int app_lrw_init(void)
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("lorawan_start", ret);
 		return ret;
+	}
+
+	if (g_app_config.lrw_region == APP_CONFIG_LRW_REGION_US915 ||
+	    g_app_config.lrw_region == APP_CONFIG_LRW_REGION_AU915) {
+		ret = apply_subband(g_app_config.lrw_sub_band);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("apply_subband", ret);
+			return ret;
+		}
 	}
 
 	static struct lorawan_downlink_cb downlink_cb = {

--- a/app/src/app_nfc_ingest.c
+++ b/app/src/app_nfc_ingest.c
@@ -62,6 +62,16 @@ bool app_nfc_ingest(const NfcConfigMessage *message)
 			}
 		}
 
+		if (message->lorawan.has_sub_band) {
+			LOG_INF_PARAM_INT("lorawan.sub_band", message->lorawan.sub_band);
+			if (message->lorawan.sub_band <= 8) {
+				config->lrw_sub_band = (int)message->lorawan.sub_band;
+			} else {
+				LOG_WRN("Ignoring invalid lorawan.sub_band: %u",
+					message->lorawan.sub_band);
+			}
+		}
+
 		if (message->lorawan.has_network) {
 			LOG_INF_PARAM_INT("lorawan.network", message->lorawan.network);
 			if ((int)message->lorawan.network >= 0 &&

--- a/app/src/nfc_config.proto
+++ b/app/src/nfc_config.proto
@@ -38,6 +38,7 @@ message NfcConfigMessage {
         optional string devaddr = 9;
         optional string nwkskey = 10;
         optional string appskey = 11;
+        optional uint32 sub_band = 12;
     }
 
     message Application {


### PR DESCRIPTION
# US915/AU915 sub-band support + region-switch NVM reset (fixes #22)

## Summary

Make US915 and AU915 devices actually join public LoRaWAN networks, fix region switching, and pick up a handful of related LoRaWAN/decoder/sensor follow-ups.

The headline bug: a US915 device shipped on TTN/Helium/ChirpStack would almost never join. Two independent root causes had to be fixed together:

1. **No channel mask was applied.** US915/AU915 expose 72 channels in 8 sub-bands; public networks only listen on **sub-band 2** (channels 8–15 + 65). Without `lorawan_set_channels_mask()`, the stack hops across all 64 125 kHz channels and join requests almost never overlap with the gateway. Now `apply_subband()` runs after `lorawan_start()` succeeds and narrows the mask to the configured sub-band.
2. **Zephyr's NVM persisted the wrong region.** With `CONFIG_LORAWAN_NVM_SETTINGS=y`, `lorawan/nvm/MacGroup2` holds the LoRaMacRegion and `lorawan_start()` restores it *after* `lorawan_set_region()` — so switching `eu868 → us915 → eu868` left the device behaving as US915. The fix clears a small subset of `lorawan/nvm/*` keys on every boot before the region is applied.

## Why

- #22 — US915/AU915 boards can't join public networks out of the box.
- Region switching has been silently broken since `CONFIG_LORAWAN_NVM_SETTINGS=y` landed; nobody noticed because most devices stay in one region.
- Same touch surface also picks up #32 (sensor timer aborted on any partial init failure) and a ChirpStack v3 decoder wrapper that customers asked for.

## What's new

### Config

- **`lrw_sub_band`** (default `2`, range `0..8`)
  - `2` matches TTN, Helium, ChirpStack, Senet NA → works out of the box on every public NA/AU network.
  - `0` keeps Zephyr's default mask for private multi-sub-band deployments.
  - Ingestable from NFC via the new optional `sub_band` field (#12) in the `Lorawan` protobuf, with the same validation pattern as the surrounding region/network/activation fields.
- **No `APP_CONFIG_VERSION` check.** Devices upgrading from an older firmware get the new `lrw_sub_band` field from its `.c`-init default (`2`) via the settings subsystem's per-field fallback — no struct-version bump needed, no reset-to-defaults on upgrade, existing LoRaWAN credentials / serial / secret key / alarm thresholds are preserved.

### Region-switch NVM reset

Unconditionally `settings_delete` four keys on every boot:

- `lorawan/nvm/MacGroup2` (region + activation state)
- `lorawan/nvm/RegionGroup1` / `RegionGroup2`
- `lorawan/nvm/ClassB`

Crypto, MacGroup1, and SecureElement are kept so **DevNonce monotonicity** is preserved — the device doesn't look like a fresh provisioning to the network server. `NetworkActivation` lives in `MacGroup2`, so the trade-off is **OTAA re-join on every boot** in exchange for a much simpler flow than the earlier `last_applied_region` bookkeeping (see "Design evolution" below).

### Other fixes bundled

- **#32 — `app_sensor` partial-init fix.** The `!res` guard meant a single sensor failing init (missing 1-Wire probe, absent barometer, …) aborted the entire sample timer and shipped all-NaN LRW frames. `app_sensor_init()` already uses the `res = res ? res : ret` cumulative-error pattern and `main.c` only warns on partial failure; the timer should follow suit. NaN values are filtered in `app_compose.c` before encoding.
- **`lorawan_set_channels_mask` size argument.** Zephyr expects the *element count* (`LORAWAN_CHANNELS_MASK_SIZE_US915 = 6`), not `sizeof(mask)` in bytes — the byte form silently failed with `-EINVAL`.
- **Public LoRaWAN sync word** is now the default; the private sync word is only used when explicitly configured. **Calibration mode** force-overrides back to public regardless of config.
- **`ttn.js` ChirpStack v3 wrapper.** Adds a `Decode(fPort, bytes, variables)` shim alongside the existing `decodeUplink()` so the same file works on TTN v3 and ChirpStack v3.

## Design evolution worth knowing

The region-change NVM reset went through two designs before the merged one:

1. **First attempt — `last_applied_region` tracked in config.** Clear NVM only when the stored region differed from the running one. Worked, but required a hidden+readonly YAML flag, a generated print/cmd stub, a `settings_save_one` + `settings_load_subtree("config")` dance so `app_config.c`'s private `m_app_config` wouldn't export the stale value on a later `settings_save()`, and an `APP_CONFIG_VERSION` bump-and-revert cycle in the intermediate commits — the bump (`31ea8f0`) forced reset-to-defaults on upgrade, the revert (`b806a19`) kept the value at 1 to avoid that.
2. **Final — drop `last_applied_region` and the version field entirely; clear unconditionally on every boot** (`1764415`). Costs one OTAA re-join per power cycle; saves the whole bookkeeping mechanism plus the version-check scaffolding. Review feedback explicitly preferred this.

The `apply_subband()` callsite also moved: it was originally between `lorawan_set_region()` and `lorawan_start()`, but `LoRaMacInitialization()` runs *inside* `lorawan_start()` — the MIB write was hitting an uninitialized stack and getting rejected with `-EINVAL` (`bb903b0`). Moved to **after** `lorawan_start()` succeeds. The mask still lands correctly in both cases (fresh region: empty NVM, region default → narrowed; stable region: NVM-restored mask → overwritten idempotently).

`apply_subband()` argument was also widened from `uint8_t` to `int` with an explicit `< 1 || > 8` range check (early return on `0` for "all channels"), matching the `int` field type of `g_app_config.lrw_sub_band` and removing the silent narrow at the call site.

## Commits (chronological)

| Commit | Change |
|---|---|
| `dad8663` | switch to private LoRaWAN sync word only when explicitly configured |
| `4472360` | force public LoRaWAN network in calibration mode |
| `179c370` | add Decode wrapper for ChirpStack v3 compatibility in `ttn.js` |
| `54b20b3` | `app_sensor`: start sample timer even on partial init failure (#32) |
| `c67feab` | add `lrw_sub_band` and `last_applied_region` config fields |
| `95afce6` | fix US915/AU915 sub-band and region-change NVM reset |
| `74ad766` | ingest `lrw_sub_band` from NFC |
| `13c7622` | fix `lorawan_set_channels_mask` size argument (count, not bytes) |
| `bb903b0` | call `apply_subband()` after `lorawan_start()` |
| `31ea8f0` | restore `APP_CONFIG_VERSION` check after `lrw_sub_band` addition |
| `b806a19` | revert `APP_CONFIG_VERSION` bump from 2 back to 1 |
| `1764415` | drop `last_applied_region`; clear `lorawan/nvm` subset on every boot |