### PR TITLE
Enter calibration mode when calibration flag is set in config

### DIFF
--- a/app/src/app_calibration.c
+++ b/app/src/app_calibration.c
@@ -11,6 +11,7 @@
 #include "app_log.h"
 #include "app_lrw.h"
 #include "app_machine_probe.h"
+#include "app_settings.h"
 #include "app_sht4x.h"
 #include "app_wdog.h"
 
@@ -21,7 +22,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/lorawan/lorawan.h>
-#include <zephyr/settings/settings.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/reboot.h>
 
@@ -227,6 +227,16 @@ int app_calibration_init(void)
 {
 	int ret;
 
+	/* One-shot: clear the persisted calibration flag in NVS without
+	 * rebooting, so the next boot (after the 2 h deadline, watchdog,
+	 * brown-out, etc.) lands in normal mode. g_app_config.calibration
+	 * stays true for the rest of this boot so app_lrw blocks normal TX. */
+	app_config()->calibration = false;
+	ret = app_settings_save(false);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("app_settings_save", ret);
+	}
+
 	/* Set calibration ABP keys */
 	g_app_config.calibration = true;
 	g_app_config.lrw_activation = APP_CONFIG_LRW_ACTIVATION_ABP;
@@ -308,17 +318,6 @@ void app_calibration_run(void)
 
 	for (;;) {
 		if (k_uptime_get() >= deadline) {
-			/* Natural end: clear persisted calibration flag in NVS so
-			 * the next boot lands in normal mode. The flag is kept
-			 * true throughout the run so that any unexpected reset
-			 * (watchdog, brown-out) re-enters calibration. */
-			bool cal_false = false;
-			int s_ret = settings_save_one("config/calibration",
-						      &cal_false, sizeof(cal_false));
-			if (s_ret) {
-				LOG_ERR_CALL_FAILED_INT("settings_save_one", s_ret);
-			}
-
 			sys_reboot(SYS_REBOOT_COLD);
 		}
 

--- a/app/src/app_calibration.c
+++ b/app/src/app_calibration.c
@@ -21,6 +21,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/lorawan/lorawan.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/reboot.h>
 
@@ -225,6 +226,25 @@ static void compose_calibration_payload(uint8_t *buf)
 int app_calibration_init(void)
 {
 	int ret;
+
+	/* One-shot: clear persisted calibration flag in NVS so the device
+	 * returns to normal mode on the next reboot. g_app_config.calibration
+	 * stays true for the rest of this boot so app_lrw blocks normal TX.
+	 * Must run before the assignment below, because settings_load_subtree
+	 * would otherwise overwrite the runtime flag back to false. */
+	{
+		bool cal_false = false;
+
+		ret = settings_save_one("config/calibration", &cal_false, sizeof(cal_false));
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("settings_save_one", ret);
+		} else {
+			ret = settings_load_subtree("config");
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("settings_load_subtree", ret);
+			}
+		}
+	}
 
 	/* Set calibration ABP keys */
 	g_app_config.calibration = true;

--- a/app/src/app_calibration.c
+++ b/app/src/app_calibration.c
@@ -227,25 +227,6 @@ int app_calibration_init(void)
 {
 	int ret;
 
-	/* One-shot: clear persisted calibration flag in NVS so the device
-	 * returns to normal mode on the next reboot. g_app_config.calibration
-	 * stays true for the rest of this boot so app_lrw blocks normal TX.
-	 * Must run before the assignment below, because settings_load_subtree
-	 * would otherwise overwrite the runtime flag back to false. */
-	{
-		bool cal_false = false;
-
-		ret = settings_save_one("config/calibration", &cal_false, sizeof(cal_false));
-		if (ret) {
-			LOG_ERR_CALL_FAILED_INT("settings_save_one", ret);
-		} else {
-			ret = settings_load_subtree("config");
-			if (ret) {
-				LOG_ERR_CALL_FAILED_INT("settings_load_subtree", ret);
-			}
-		}
-	}
-
 	/* Set calibration ABP keys */
 	g_app_config.calibration = true;
 	g_app_config.lrw_activation = APP_CONFIG_LRW_ACTIVATION_ABP;
@@ -327,6 +308,17 @@ void app_calibration_run(void)
 
 	for (;;) {
 		if (k_uptime_get() >= deadline) {
+			/* Natural end: clear persisted calibration flag in NVS so
+			 * the next boot lands in normal mode. The flag is kept
+			 * true throughout the run so that any unexpected reset
+			 * (watchdog, brown-out) re-enters calibration. */
+			bool cal_false = false;
+			int s_ret = settings_save_one("config/calibration",
+						      &cal_false, sizeof(cal_false));
+			if (s_ret) {
+				LOG_ERR_CALL_FAILED_INT("settings_save_one", s_ret);
+			}
+
 			sys_reboot(SYS_REBOOT_COLD);
 		}
 

--- a/app/src/app_settings.c
+++ b/app/src/app_settings.c
@@ -156,14 +156,9 @@ SHELL_CMD_REGISTER(settings, &sub_settings, "Settings commands.", print_help);
 
 #endif /* defined(CONFIG_SHELL) */
 
-int app_settings_save(void)
+int app_settings_save(bool reboot)
 {
-	return save(true);
-}
-
-int app_settings_write(void)
-{
-	return save(false);
+	return save(reboot);
 }
 
 int app_settings_reset(void)

--- a/app/src/app_settings.c
+++ b/app/src/app_settings.c
@@ -161,6 +161,11 @@ int app_settings_save(void)
 	return save(true);
 }
 
+int app_settings_write(void)
+{
+	return save(false);
+}
+
 int app_settings_reset(void)
 {
 	return reset(true);

--- a/app/src/app_settings.h
+++ b/app/src/app_settings.h
@@ -7,12 +7,14 @@
 #ifndef APP_SETTINGS_H_
 #define APP_SETTINGS_H_
 
+/* Standard includes */
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int app_settings_save(void);
-int app_settings_write(void);
+int app_settings_save(bool reboot);
 int app_settings_reset(void);
 
 #ifdef __cplusplus

--- a/app/src/app_settings.h
+++ b/app/src/app_settings.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 int app_settings_save(void);
+int app_settings_write(void);
 int app_settings_reset(void);
 
 #ifdef __cplusplus

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -20,7 +20,6 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/settings/settings.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/reboot.h>
 
@@ -167,35 +166,7 @@ int main(void)
 	if (action == APP_NFC_ACTION_SAVE) {
 		play_carousel_nfc();
 
-		if (app_config()->calibration) {
-			/* Calibration requested via NFC — persist without
-			 * reboot, refresh g_app_config from NVS, and jump
-			 * directly into calibration on this same boot. */
-			ret = app_settings_write();
-			if (ret) {
-				LOG_ERR_CALL_FAILED_INT("app_settings_write", ret);
-				die();
-			}
-
-			ret = settings_load_subtree("config");
-			if (ret) {
-				LOG_ERR_CALL_FAILED_INT("settings_load_subtree", ret);
-				die();
-			}
-
-			LOG_WRN("Calibration requested via NFC — entering calibration mode");
-
-			ret = app_calibration_init();
-			if (ret) {
-				LOG_ERR_CALL_FAILED_INT("app_calibration_init", ret);
-				die();
-			}
-
-			app_calibration_run();
-			/* Never reached */
-		}
-
-		ret = app_settings_save();
+		ret = app_settings_save(true);
 		if (ret) {
 			LOG_ERR_CALL_FAILED_INT("app_settings_save", ret);
 			die();
@@ -269,7 +240,7 @@ int main(void)
 			if (action == APP_NFC_ACTION_SAVE) {
 				play_carousel_nfc();
 
-				ret = app_settings_save();
+				ret = app_settings_save(true);
 				if (ret) {
 					LOG_ERR_CALL_FAILED_INT("app_settings_save", ret);
 				}

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -20,6 +20,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/reboot.h>
 
@@ -165,6 +166,34 @@ int main(void)
 
 	if (action == APP_NFC_ACTION_SAVE) {
 		play_carousel_nfc();
+
+		if (app_config()->calibration) {
+			/* Calibration requested via NFC — persist without
+			 * reboot, refresh g_app_config from NVS, and jump
+			 * directly into calibration on this same boot. */
+			ret = app_settings_write();
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("app_settings_write", ret);
+				die();
+			}
+
+			ret = settings_load_subtree("config");
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("settings_load_subtree", ret);
+				die();
+			}
+
+			LOG_WRN("Calibration requested via NFC — entering calibration mode");
+
+			ret = app_calibration_init();
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("app_calibration_init", ret);
+				die();
+			}
+
+			app_calibration_run();
+			/* Never reached */
+		}
 
 		ret = app_settings_save();
 		if (ret) {

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -90,6 +90,11 @@ static enum app_mode detect_mode(void)
 		return APP_MODE_CALIBRATION;
 	}
 
+	if (g_app_config.calibration) {
+		LOG_WRN("Calibration flag set in config — entering calibration mode");
+		return APP_MODE_CALIBRATION;
+	}
+
 	return APP_MODE_NORMAL;
 }
 


### PR DESCRIPTION
detect_mode() previously only triggered calibration mode on dual-magnet detection. Setting `config calibration true` over the shell or via the sticker-configurator NFC tag persisted the flag but did not actually enter the calibration runtime — it only blocked normal LoRaWAN TX via the early-return in app_lrw send_work_handler, leaving the factory tester with no calibration uplinks.

Make detect_mode() also honor g_app_config.calibration (populated from NVS at boot via h_set/h_commit) so both the shell+save and NFC paths reach app_calibration_init/run.

Clear the persisted flag at the top of app_calibration_init() with settings_save_one + settings_load_subtree (same pattern app_lrw uses for last-applied-region) so calibration is a one-shot run: the device returns to normal mode after the duration expires or on any subsequent reboot, without needing a follow-up NFC write or shell command.

NFC wire format (nfc_config.proto, app_nfc_ingest.c) is unchanged so the sticker-configurator NFC application keeps working.