### PR TITLE
v1.3.1: Sensor sample timer not started when any sensor init fails

### DIFF
--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -216,7 +216,7 @@ int app_sensor_init(void)
 			   K_THREAD_STACK_SIZEOF(m_sensor_work_stack),
 			   K_LOWEST_APPLICATION_THREAD_PRIO, NULL);
 
-	if (!res && g_app_config.interval_sample) {
+	if (g_app_config.interval_sample) {
 		k_timer_start(&m_sensor_timer, K_SECONDS(1),
 			      K_SECONDS(g_app_config.interval_sample));
 	}


### PR DESCRIPTION
The !res guard meant any single sensor init failure (missing 1-Wire probe, absent barometer, etc.) prevented the sample timer from starting at all — silencing every other sensor and sending all-NaN LoRaWAN uplinks.

app_sensor_init() already uses a non-fatal res = res ? res : ret pattern, and main.c logs a warning on partial failure rather than calling die(). app_sensor_sample() per-call error handling keeps failed sensors at NaN while letting the rest deliver real data — which app_compose.c already filters out via !isnan() checks before encoding the LRW payload.

Drop the !res gate so working sensors keep reporting regardless of which ones failed init.