### PR TITLE
configen: move shell input validations into template

### DIFF
--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -35,6 +35,7 @@ struct app_config g_app_config;
 static const struct app_config m_app_config_defaults = {
 	.config_version = APP_CONFIG_VERSION,
 	.interval_report = 900,
+	.lrw_sub_band = 2,
 	.alarm_temperature_lo = 15.0f,
 	.alarm_temperature_hi = 25.0f,
 	.alarm_temperature_hst = 0.5f,
@@ -55,6 +56,7 @@ static const struct app_config m_app_config_defaults = {
 static struct app_config m_app_config = {
 	.config_version = APP_CONFIG_VERSION,
 	.interval_report = 900,
+	.lrw_sub_band = 2,
 	.alarm_temperature_lo = 15.0f,
 	.alarm_temperature_hi = 25.0f,
 	.alarm_temperature_hst = 0.5f,
@@ -110,6 +112,8 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.interval_report));
 	SETTINGS_SET("lrw-region", &m_app_config.lrw_region,
 		     sizeof(m_app_config.lrw_region));
+	SETTINGS_SET("lrw-sub-band", &m_app_config.lrw_sub_band,
+		     sizeof(m_app_config.lrw_sub_band));
 	SETTINGS_SET("lrw-network", &m_app_config.lrw_network,
 		     sizeof(m_app_config.lrw_network));
 	SETTINGS_SET("lrw-adr", &m_app_config.lrw_adr,
@@ -253,6 +257,8 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.interval_report));
 	EXPORT_FUNC("lrw-region", &m_app_config.lrw_region,
 		    sizeof(m_app_config.lrw_region));
+	EXPORT_FUNC("lrw-sub-band", &m_app_config.lrw_sub_band,
+		    sizeof(m_app_config.lrw_sub_band));
 	EXPORT_FUNC("lrw-network", &m_app_config.lrw_network,
 		    sizeof(m_app_config.lrw_network));
 	EXPORT_FUNC("lrw-adr", &m_app_config.lrw_adr,
@@ -522,6 +528,11 @@ static void print_lrw_region(const struct shell *shell)
 		break;
 	}
 	shell_print(shell, SETTINGS_PFX " lrw-region %s", str);
+}
+
+static void print_lrw_sub_band(const struct shell *shell)
+{
+	shell_print(shell, SETTINGS_PFX " lrw-sub-band %d", m_app_config.lrw_sub_band);
 }
 
 static void print_lrw_network(const struct shell *shell)
@@ -935,6 +946,7 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_interval_sample(shell);
 	print_interval_report(shell);
 	print_lrw_region(shell);
+	print_lrw_sub_band(shell);
 	print_lrw_network(shell);
 	print_lrw_adr(shell);
 	print_lrw_activation(shell);
@@ -1162,6 +1174,12 @@ static int cmd_lrw_region(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	return 0;
+}
+
+static int cmd_lrw_sub_band(const struct shell *shell, size_t argc, char **argv)
+{
+	return cmd_int(shell, argc, argv, &m_app_config.lrw_sub_band, 0, 8,
+		       print_lrw_sub_band);
 }
 
 static int cmd_lrw_network(const struct shell *shell, size_t argc, char **argv)
@@ -1714,6 +1732,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(lrw-region, NULL,
 	              "Get/Set LoRaWAN region (eu868/us915/au915).",
 	              cmd_lrw_region, 1, 1),
+
+	SHELL_CMD_ARG(lrw-sub-band, NULL,
+	              "Get/Set US915/AU915 sub-band (1-8, 0 = all channels). Default 2 matches TTN/Helium/ChirpStack.",
+	              cmd_lrw_sub_band, 1, 1),
 
 	SHELL_CMD_ARG(lrw-network, NULL,
 	              "Get/Set LoRaWAN network (public/private).",

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -104,20 +104,15 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.serial_number));
 	SETTINGS_SET("nonce-counter", &m_app_config.nonce_counter,
 		     sizeof(m_app_config.nonce_counter));
-	SETTINGS_SET("calibration", &m_app_config.calibration,
-		     sizeof(m_app_config.calibration));
+	SETTINGS_SET("calibration", &m_app_config.calibration, sizeof(m_app_config.calibration));
 	SETTINGS_SET("interval-sample", &m_app_config.interval_sample,
 		     sizeof(m_app_config.interval_sample));
 	SETTINGS_SET("interval-report", &m_app_config.interval_report,
 		     sizeof(m_app_config.interval_report));
-	SETTINGS_SET("lrw-region", &m_app_config.lrw_region,
-		     sizeof(m_app_config.lrw_region));
-	SETTINGS_SET("lrw-sub-band", &m_app_config.lrw_sub_band,
-		     sizeof(m_app_config.lrw_sub_band));
-	SETTINGS_SET("lrw-network", &m_app_config.lrw_network,
-		     sizeof(m_app_config.lrw_network));
-	SETTINGS_SET("lrw-adr", &m_app_config.lrw_adr,
-		     sizeof(m_app_config.lrw_adr));
+	SETTINGS_SET("lrw-region", &m_app_config.lrw_region, sizeof(m_app_config.lrw_region));
+	SETTINGS_SET("lrw-sub-band", &m_app_config.lrw_sub_band, sizeof(m_app_config.lrw_sub_band));
+	SETTINGS_SET("lrw-network", &m_app_config.lrw_network, sizeof(m_app_config.lrw_network));
+	SETTINGS_SET("lrw-adr", &m_app_config.lrw_adr, sizeof(m_app_config.lrw_adr));
 	SETTINGS_SET("lrw-activation", &m_app_config.lrw_activation,
 		     sizeof(m_app_config.lrw_activation));
 	SETTINGS_SET("lrw-deveui", m_app_config.lrw_deveui, sizeof(m_app_config.lrw_deveui));
@@ -201,10 +196,8 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.cap_hall_left));
 	SETTINGS_SET("cap-hall-right", &m_app_config.cap_hall_right,
 		     sizeof(m_app_config.cap_hall_right));
-	SETTINGS_SET("cap-input-a", &m_app_config.cap_input_a,
-		     sizeof(m_app_config.cap_input_a));
-	SETTINGS_SET("cap-input-b", &m_app_config.cap_input_b,
-		     sizeof(m_app_config.cap_input_b));
+	SETTINGS_SET("cap-input-a", &m_app_config.cap_input_a, sizeof(m_app_config.cap_input_a));
+	SETTINGS_SET("cap-input-b", &m_app_config.cap_input_b, sizeof(m_app_config.cap_input_b));
 	SETTINGS_SET("cap-light-sensor", &m_app_config.cap_light_sensor,
 		     sizeof(m_app_config.cap_light_sensor));
 	SETTINGS_SET("cap-barometer", &m_app_config.cap_barometer,
@@ -249,20 +242,15 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.serial_number));
 	EXPORT_FUNC("nonce-counter", &m_app_config.nonce_counter,
 		    sizeof(m_app_config.nonce_counter));
-	EXPORT_FUNC("calibration", &m_app_config.calibration,
-		    sizeof(m_app_config.calibration));
+	EXPORT_FUNC("calibration", &m_app_config.calibration, sizeof(m_app_config.calibration));
 	EXPORT_FUNC("interval-sample", &m_app_config.interval_sample,
 		    sizeof(m_app_config.interval_sample));
 	EXPORT_FUNC("interval-report", &m_app_config.interval_report,
 		    sizeof(m_app_config.interval_report));
-	EXPORT_FUNC("lrw-region", &m_app_config.lrw_region,
-		    sizeof(m_app_config.lrw_region));
-	EXPORT_FUNC("lrw-sub-band", &m_app_config.lrw_sub_band,
-		    sizeof(m_app_config.lrw_sub_band));
-	EXPORT_FUNC("lrw-network", &m_app_config.lrw_network,
-		    sizeof(m_app_config.lrw_network));
-	EXPORT_FUNC("lrw-adr", &m_app_config.lrw_adr,
-		    sizeof(m_app_config.lrw_adr));
+	EXPORT_FUNC("lrw-region", &m_app_config.lrw_region, sizeof(m_app_config.lrw_region));
+	EXPORT_FUNC("lrw-sub-band", &m_app_config.lrw_sub_band, sizeof(m_app_config.lrw_sub_band));
+	EXPORT_FUNC("lrw-network", &m_app_config.lrw_network, sizeof(m_app_config.lrw_network));
+	EXPORT_FUNC("lrw-adr", &m_app_config.lrw_adr, sizeof(m_app_config.lrw_adr));
 	EXPORT_FUNC("lrw-activation", &m_app_config.lrw_activation,
 		    sizeof(m_app_config.lrw_activation));
 	EXPORT_FUNC("lrw-deveui", m_app_config.lrw_deveui, sizeof(m_app_config.lrw_deveui));
@@ -346,10 +334,8 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.cap_hall_left));
 	EXPORT_FUNC("cap-hall-right", &m_app_config.cap_hall_right,
 		    sizeof(m_app_config.cap_hall_right));
-	EXPORT_FUNC("cap-input-a", &m_app_config.cap_input_a,
-		    sizeof(m_app_config.cap_input_a));
-	EXPORT_FUNC("cap-input-b", &m_app_config.cap_input_b,
-		    sizeof(m_app_config.cap_input_b));
+	EXPORT_FUNC("cap-input-a", &m_app_config.cap_input_a, sizeof(m_app_config.cap_input_a));
+	EXPORT_FUNC("cap-input-b", &m_app_config.cap_input_b, sizeof(m_app_config.cap_input_b));
 	EXPORT_FUNC("cap-light-sensor", &m_app_config.cap_light_sensor,
 		    sizeof(m_app_config.cap_light_sensor));
 	EXPORT_FUNC("cap-barometer", &m_app_config.cap_barometer,
@@ -436,8 +422,8 @@ static int cmd_int(const struct shell *shell, size_t argc, char **argv, int *par
 	return 0;
 }
 
-static int cmd_float(const struct shell *shell, size_t argc, char **argv, float *param,
-		     float min, float max, print_func_t print_func)
+static int cmd_float(const struct shell *shell, size_t argc, char **argv, float *param, float min,
+		     float max, print_func_t print_func)
 {
 	if (argc == 1) {
 		if (print_func) {
@@ -468,7 +454,6 @@ static int cmd_float(const struct shell *shell, size_t argc, char **argv, float 
 	shell_print(shell, "%s", m_msg_cmd_success);
 	return 0;
 }
-
 
 static void print_secret_key(const struct shell *shell)
 {
@@ -554,8 +539,7 @@ static void print_lrw_network(const struct shell *shell)
 
 static void print_lrw_adr(const struct shell *shell)
 {
-	shell_print(shell, SETTINGS_PFX " lrw-adr %s",
-		    m_app_config.lrw_adr ? "true" : "false");
+	shell_print(shell, SETTINGS_PFX " lrw-adr %s", m_app_config.lrw_adr ? "true" : "false");
 }
 
 static void print_lrw_activation(const struct shell *shell)
@@ -593,8 +577,8 @@ static void print_lrw_joineui(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_joineui) + 1];
 
-	int ret =
-		bin2hex(m_app_config.lrw_joineui, sizeof(m_app_config.lrw_joineui), buf, sizeof(buf));
+	int ret = bin2hex(m_app_config.lrw_joineui, sizeof(m_app_config.lrw_joineui), buf,
+			  sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -635,8 +619,8 @@ static void print_lrw_devaddr(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_devaddr) + 1];
 
-	int ret =
-		bin2hex(m_app_config.lrw_devaddr, sizeof(m_app_config.lrw_devaddr), buf, sizeof(buf));
+	int ret = bin2hex(m_app_config.lrw_devaddr, sizeof(m_app_config.lrw_devaddr), buf,
+			  sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -649,8 +633,8 @@ static void print_lrw_nwkskey(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_nwkskey) + 1];
 
-	int ret =
-		bin2hex(m_app_config.lrw_nwkskey, sizeof(m_app_config.lrw_nwkskey), buf, sizeof(buf));
+	int ret = bin2hex(m_app_config.lrw_nwkskey, sizeof(m_app_config.lrw_nwkskey), buf,
+			  sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -663,8 +647,8 @@ static void print_lrw_appskey(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_appskey) + 1];
 
-	int ret =
-		bin2hex(m_app_config.lrw_appskey, sizeof(m_app_config.lrw_appskey), buf, sizeof(buf));
+	int ret = bin2hex(m_app_config.lrw_appskey, sizeof(m_app_config.lrw_appskey), buf,
+			  sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -1178,8 +1162,7 @@ static int cmd_lrw_region(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_lrw_sub_band(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_int(shell, argc, argv, &m_app_config.lrw_sub_band, 0, 8,
-		       print_lrw_sub_band);
+	return cmd_int(shell, argc, argv, &m_app_config.lrw_sub_band, 0, 8, print_lrw_sub_band);
 }
 
 static int cmd_lrw_network(const struct shell *shell, size_t argc, char **argv)
@@ -1447,147 +1430,158 @@ static int cmd_lrw_appskey(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_alarm_temperature_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_temperature_enabled, print_alarm_temperature_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_temperature_enabled,
+			print_alarm_temperature_enabled);
 }
 
 static int cmd_alarm_temperature_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_lo, -30.0f,
-			 70.0f, print_alarm_temperature_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_lo, -30.0f, 70.0f,
+			 print_alarm_temperature_lo);
 }
 
 static int cmd_alarm_temperature_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hi, -30.0f,
-			 70.0f, print_alarm_temperature_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hi, -30.0f, 70.0f,
+			 print_alarm_temperature_hi);
 }
 
 static int cmd_alarm_temperature_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hst, 0.0f,
-			 5.0f, print_alarm_temperature_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hst, 0.0f, 5.0f,
+			 print_alarm_temperature_hst);
 }
 
 static int cmd_alarm_humidity_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_humidity_enabled, print_alarm_humidity_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_humidity_enabled,
+			print_alarm_humidity_enabled);
 }
 
 static int cmd_alarm_humidity_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_lo, 0.0f,
-			 100.0f, print_alarm_humidity_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_lo, 0.0f, 100.0f,
+			 print_alarm_humidity_lo);
 }
 
 static int cmd_alarm_humidity_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hi, 0.0f,
-			 100.0f, print_alarm_humidity_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hi, 0.0f, 100.0f,
+			 print_alarm_humidity_hi);
 }
 
 static int cmd_alarm_humidity_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hst, 0.0f,
-			 20.0f, print_alarm_humidity_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hst, 0.0f, 20.0f,
+			 print_alarm_humidity_hst);
 }
 
 static int cmd_alarm_pressure_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_pressure_enabled, print_alarm_pressure_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_pressure_enabled,
+			print_alarm_pressure_enabled);
 }
 
 static int cmd_alarm_pressure_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_lo, 500.0f,
-			 1200.0f, print_alarm_pressure_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_lo, 500.0f, 1200.0f,
+			 print_alarm_pressure_lo);
 }
 
 static int cmd_alarm_pressure_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hi, 500.0f,
-			 1200.0f, print_alarm_pressure_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hi, 500.0f, 1200.0f,
+			 print_alarm_pressure_hi);
 }
 
 static int cmd_alarm_pressure_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hst, 0.0f,
-			 50.0f, print_alarm_pressure_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hst, 0.0f, 50.0f,
+			 print_alarm_pressure_hst);
 }
 
 static int cmd_alarm_t1_temperature_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t1_temperature_enabled, print_alarm_t1_temperature_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t1_temperature_enabled,
+			print_alarm_t1_temperature_enabled);
 }
 
 static int cmd_alarm_t1_temperature_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_lo, -30.0f,
-			 70.0f, print_alarm_t1_temperature_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_lo, -30.0f, 70.0f,
+			 print_alarm_t1_temperature_lo);
 }
 
 static int cmd_alarm_t1_temperature_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hi, -30.0f,
-			 70.0f, print_alarm_t1_temperature_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hi, -30.0f, 70.0f,
+			 print_alarm_t1_temperature_hi);
 }
 
 static int cmd_alarm_t1_temperature_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hst, 0.0f,
-			 5.0f, print_alarm_t1_temperature_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hst, 0.0f, 5.0f,
+			 print_alarm_t1_temperature_hst);
 }
 
 static int cmd_alarm_t2_temperature_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t2_temperature_enabled, print_alarm_t2_temperature_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t2_temperature_enabled,
+			print_alarm_t2_temperature_enabled);
 }
 
 static int cmd_alarm_t2_temperature_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_lo, -30.0f,
-			 70.0f, print_alarm_t2_temperature_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_lo, -30.0f, 70.0f,
+			 print_alarm_t2_temperature_lo);
 }
 
 static int cmd_alarm_t2_temperature_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hi, -30.0f,
-			 70.0f, print_alarm_t2_temperature_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hi, -30.0f, 70.0f,
+			 print_alarm_t2_temperature_hi);
 }
 
 static int cmd_alarm_t2_temperature_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hst, 0.0f,
-			 5.0f, print_alarm_t2_temperature_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hst, 0.0f, 5.0f,
+			 print_alarm_t2_temperature_hst);
 }
 
 static int cmd_hall_left_counter(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_counter, print_hall_left_counter);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_counter,
+			print_hall_left_counter);
 }
 
 static int cmd_hall_left_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_act, print_hall_left_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_act,
+			print_hall_left_notify_act);
 }
 
 static int cmd_hall_left_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_deact, print_hall_left_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_deact,
+			print_hall_left_notify_deact);
 }
 
 static int cmd_hall_right_counter(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_counter, print_hall_right_counter);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_counter,
+			print_hall_right_counter);
 }
 
 static int cmd_hall_right_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_act, print_hall_right_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_act,
+			print_hall_right_notify_act);
 }
 
 static int cmd_hall_right_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_deact, print_hall_right_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_deact,
+			print_hall_right_notify_deact);
 }
 
 static int cmd_input_a_counter(const struct shell *shell, size_t argc, char **argv)
@@ -1597,12 +1591,14 @@ static int cmd_input_a_counter(const struct shell *shell, size_t argc, char **ar
 
 static int cmd_input_a_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_act, print_input_a_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_act,
+			print_input_a_notify_act);
 }
 
 static int cmd_input_a_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_deact, print_input_a_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_deact,
+			print_input_a_notify_deact);
 }
 
 static int cmd_input_b_counter(const struct shell *shell, size_t argc, char **argv)
@@ -1612,30 +1608,32 @@ static int cmd_input_b_counter(const struct shell *shell, size_t argc, char **ar
 
 static int cmd_input_b_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_act, print_input_b_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_act,
+			print_input_b_notify_act);
 }
 
 static int cmd_input_b_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_deact, print_input_b_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_deact,
+			print_input_b_notify_deact);
 }
 
 static int cmd_corr_temperature(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.corr_temperature, -5.0f,
-			 5.0f, print_corr_temperature);
+	return cmd_float(shell, argc, argv, &m_app_config.corr_temperature, -5.0f, 5.0f,
+			 print_corr_temperature);
 }
 
 static int cmd_corr_t1_temperature(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.corr_t1_temperature, -5.0f,
-			 5.0f, print_corr_t1_temperature);
+	return cmd_float(shell, argc, argv, &m_app_config.corr_t1_temperature, -5.0f, 5.0f,
+			 print_corr_t1_temperature);
 }
 
 static int cmd_corr_t2_temperature(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.corr_t2_temperature, -5.0f,
-			 5.0f, print_corr_t2_temperature);
+	return cmd_float(shell, argc, argv, &m_app_config.corr_t2_temperature, -5.0f, 5.0f,
+			 print_corr_t2_temperature);
 }
 
 static int cmd_cap_hall_left(const struct shell *shell, size_t argc, char **argv)
@@ -1675,12 +1673,14 @@ static int cmd_cap_pir_detector(const struct shell *shell, size_t argc, char **a
 
 static int cmd_cap_1w_thermometer(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_thermometer, print_cap_1w_thermometer);
+	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_thermometer,
+			print_cap_1w_thermometer);
 }
 
 static int cmd_cap_1w_machine_probe(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_machine_probe, print_cap_1w_machine_probe);
+	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_machine_probe,
+			print_cap_1w_machine_probe);
 }
 
 static int print_help(const struct shell *shell, size_t argc, char **argv)

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -102,14 +102,18 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.serial_number));
 	SETTINGS_SET("nonce-counter", &m_app_config.nonce_counter,
 		     sizeof(m_app_config.nonce_counter));
-	SETTINGS_SET("calibration", &m_app_config.calibration, sizeof(m_app_config.calibration));
+	SETTINGS_SET("calibration", &m_app_config.calibration,
+		     sizeof(m_app_config.calibration));
 	SETTINGS_SET("interval-sample", &m_app_config.interval_sample,
 		     sizeof(m_app_config.interval_sample));
 	SETTINGS_SET("interval-report", &m_app_config.interval_report,
 		     sizeof(m_app_config.interval_report));
-	SETTINGS_SET("lrw-region", &m_app_config.lrw_region, sizeof(m_app_config.lrw_region));
-	SETTINGS_SET("lrw-network", &m_app_config.lrw_network, sizeof(m_app_config.lrw_network));
-	SETTINGS_SET("lrw-adr", &m_app_config.lrw_adr, sizeof(m_app_config.lrw_adr));
+	SETTINGS_SET("lrw-region", &m_app_config.lrw_region,
+		     sizeof(m_app_config.lrw_region));
+	SETTINGS_SET("lrw-network", &m_app_config.lrw_network,
+		     sizeof(m_app_config.lrw_network));
+	SETTINGS_SET("lrw-adr", &m_app_config.lrw_adr,
+		     sizeof(m_app_config.lrw_adr));
 	SETTINGS_SET("lrw-activation", &m_app_config.lrw_activation,
 		     sizeof(m_app_config.lrw_activation));
 	SETTINGS_SET("lrw-deveui", m_app_config.lrw_deveui, sizeof(m_app_config.lrw_deveui));
@@ -193,8 +197,10 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.cap_hall_left));
 	SETTINGS_SET("cap-hall-right", &m_app_config.cap_hall_right,
 		     sizeof(m_app_config.cap_hall_right));
-	SETTINGS_SET("cap-input-a", &m_app_config.cap_input_a, sizeof(m_app_config.cap_input_a));
-	SETTINGS_SET("cap-input-b", &m_app_config.cap_input_b, sizeof(m_app_config.cap_input_b));
+	SETTINGS_SET("cap-input-a", &m_app_config.cap_input_a,
+		     sizeof(m_app_config.cap_input_a));
+	SETTINGS_SET("cap-input-b", &m_app_config.cap_input_b,
+		     sizeof(m_app_config.cap_input_b));
 	SETTINGS_SET("cap-light-sensor", &m_app_config.cap_light_sensor,
 		     sizeof(m_app_config.cap_light_sensor));
 	SETTINGS_SET("cap-barometer", &m_app_config.cap_barometer,
@@ -239,14 +245,18 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.serial_number));
 	EXPORT_FUNC("nonce-counter", &m_app_config.nonce_counter,
 		    sizeof(m_app_config.nonce_counter));
-	EXPORT_FUNC("calibration", &m_app_config.calibration, sizeof(m_app_config.calibration));
+	EXPORT_FUNC("calibration", &m_app_config.calibration,
+		    sizeof(m_app_config.calibration));
 	EXPORT_FUNC("interval-sample", &m_app_config.interval_sample,
 		    sizeof(m_app_config.interval_sample));
 	EXPORT_FUNC("interval-report", &m_app_config.interval_report,
 		    sizeof(m_app_config.interval_report));
-	EXPORT_FUNC("lrw-region", &m_app_config.lrw_region, sizeof(m_app_config.lrw_region));
-	EXPORT_FUNC("lrw-network", &m_app_config.lrw_network, sizeof(m_app_config.lrw_network));
-	EXPORT_FUNC("lrw-adr", &m_app_config.lrw_adr, sizeof(m_app_config.lrw_adr));
+	EXPORT_FUNC("lrw-region", &m_app_config.lrw_region,
+		    sizeof(m_app_config.lrw_region));
+	EXPORT_FUNC("lrw-network", &m_app_config.lrw_network,
+		    sizeof(m_app_config.lrw_network));
+	EXPORT_FUNC("lrw-adr", &m_app_config.lrw_adr,
+		    sizeof(m_app_config.lrw_adr));
 	EXPORT_FUNC("lrw-activation", &m_app_config.lrw_activation,
 		    sizeof(m_app_config.lrw_activation));
 	EXPORT_FUNC("lrw-deveui", m_app_config.lrw_deveui, sizeof(m_app_config.lrw_deveui));
@@ -330,8 +340,10 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.cap_hall_left));
 	EXPORT_FUNC("cap-hall-right", &m_app_config.cap_hall_right,
 		    sizeof(m_app_config.cap_hall_right));
-	EXPORT_FUNC("cap-input-a", &m_app_config.cap_input_a, sizeof(m_app_config.cap_input_a));
-	EXPORT_FUNC("cap-input-b", &m_app_config.cap_input_b, sizeof(m_app_config.cap_input_b));
+	EXPORT_FUNC("cap-input-a", &m_app_config.cap_input_a,
+		    sizeof(m_app_config.cap_input_a));
+	EXPORT_FUNC("cap-input-b", &m_app_config.cap_input_b,
+		    sizeof(m_app_config.cap_input_b));
 	EXPORT_FUNC("cap-light-sensor", &m_app_config.cap_light_sensor,
 		    sizeof(m_app_config.cap_light_sensor));
 	EXPORT_FUNC("cap-barometer", &m_app_config.cap_barometer,
@@ -418,8 +430,8 @@ static int cmd_int(const struct shell *shell, size_t argc, char **argv, int *par
 	return 0;
 }
 
-static int cmd_float(const struct shell *shell, size_t argc, char **argv, float *param, float min,
-		     float max, print_func_t print_func)
+static int cmd_float(const struct shell *shell, size_t argc, char **argv, float *param,
+		     float min, float max, print_func_t print_func)
 {
 	if (argc == 1) {
 		if (print_func) {
@@ -450,6 +462,7 @@ static int cmd_float(const struct shell *shell, size_t argc, char **argv, float 
 	shell_print(shell, "%s", m_msg_cmd_success);
 	return 0;
 }
+
 
 static void print_secret_key(const struct shell *shell)
 {
@@ -530,7 +543,8 @@ static void print_lrw_network(const struct shell *shell)
 
 static void print_lrw_adr(const struct shell *shell)
 {
-	shell_print(shell, SETTINGS_PFX " lrw-adr %s", m_app_config.lrw_adr ? "true" : "false");
+	shell_print(shell, SETTINGS_PFX " lrw-adr %s",
+		    m_app_config.lrw_adr ? "true" : "false");
 }
 
 static void print_lrw_activation(const struct shell *shell)
@@ -568,8 +582,8 @@ static void print_lrw_joineui(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_joineui) + 1];
 
-	int ret = bin2hex(m_app_config.lrw_joineui, sizeof(m_app_config.lrw_joineui), buf,
-			  sizeof(buf));
+	int ret =
+		bin2hex(m_app_config.lrw_joineui, sizeof(m_app_config.lrw_joineui), buf, sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -610,8 +624,8 @@ static void print_lrw_devaddr(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_devaddr) + 1];
 
-	int ret = bin2hex(m_app_config.lrw_devaddr, sizeof(m_app_config.lrw_devaddr), buf,
-			  sizeof(buf));
+	int ret =
+		bin2hex(m_app_config.lrw_devaddr, sizeof(m_app_config.lrw_devaddr), buf, sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -624,8 +638,8 @@ static void print_lrw_nwkskey(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_nwkskey) + 1];
 
-	int ret = bin2hex(m_app_config.lrw_nwkskey, sizeof(m_app_config.lrw_nwkskey), buf,
-			  sizeof(buf));
+	int ret =
+		bin2hex(m_app_config.lrw_nwkskey, sizeof(m_app_config.lrw_nwkskey), buf, sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -638,8 +652,8 @@ static void print_lrw_appskey(const struct shell *shell)
 {
 	char buf[2 * sizeof(m_app_config.lrw_appskey) + 1];
 
-	int ret = bin2hex(m_app_config.lrw_appskey, sizeof(m_app_config.lrw_appskey), buf,
-			  sizeof(buf));
+	int ret =
+		bin2hex(m_app_config.lrw_appskey, sizeof(m_app_config.lrw_appskey), buf, sizeof(buf));
 	if (!ret) {
 		LOG_ERR("Call `bin2hex` failed: %d", ret);
 		return;
@@ -1036,13 +1050,14 @@ static int cmd_serial_number(const struct shell *shell, size_t argc, char **argv
 	}
 
 	errno = 0;
-	unsigned long val = strtoul(argv[1], NULL, 10);
-	if (errno == ERANGE || val > UINT32_MAX) {
+	unsigned long value = strtoul(argv[1], NULL, 10);
+
+	if (errno == ERANGE || value > UINT32_MAX) {
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
 
-	m_app_config.serial_number = (uint32_t)val;
+	m_app_config.serial_number = (uint32_t)value;
 
 	return 0;
 }
@@ -1072,7 +1087,7 @@ static int cmd_nonce_counter(const struct shell *shell, size_t argc, char **argv
 		return -EINVAL;
 	}
 
-	if (value > UINT32_MAX) {
+	if (value < 0 || value > UINT32_MAX) {
 		shell_error(shell, "%s", m_msg_invalid_range);
 		return -EINVAL;
 	}
@@ -1102,7 +1117,7 @@ static int cmd_interval_sample(const struct shell *shell, size_t argc, char **ar
 	char *endptr;
 	int a = strtol(argv[1], &endptr, 10);
 
-	if (*endptr != '\0') {
+	if (*endptr != '\0' || endptr == argv[1]) {
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
@@ -1226,7 +1241,7 @@ static int cmd_lrw_deveui(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1256,7 +1271,7 @@ static int cmd_lrw_joineui(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1286,7 +1301,7 @@ static int cmd_lrw_nwkkey(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1316,7 +1331,7 @@ static int cmd_lrw_appkey(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1346,7 +1361,7 @@ static int cmd_lrw_devaddr(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1376,7 +1391,7 @@ static int cmd_lrw_nwkskey(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1406,7 +1421,7 @@ static int cmd_lrw_appskey(const struct shell *shell, size_t argc, char **argv)
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -1414,158 +1429,147 @@ static int cmd_lrw_appskey(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_alarm_temperature_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_temperature_enabled,
-			print_alarm_temperature_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_temperature_enabled, print_alarm_temperature_enabled);
 }
 
 static int cmd_alarm_temperature_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_lo, -30.0f, 70.0f,
-			 print_alarm_temperature_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_lo, -30.0f,
+			 70.0f, print_alarm_temperature_lo);
 }
 
 static int cmd_alarm_temperature_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hi, -30.0f, 70.0f,
-			 print_alarm_temperature_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hi, -30.0f,
+			 70.0f, print_alarm_temperature_hi);
 }
 
 static int cmd_alarm_temperature_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hst, 0.0f, 5.0f,
-			 print_alarm_temperature_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_temperature_hst, 0.0f,
+			 5.0f, print_alarm_temperature_hst);
 }
 
 static int cmd_alarm_humidity_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_humidity_enabled,
-			print_alarm_humidity_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_humidity_enabled, print_alarm_humidity_enabled);
 }
 
 static int cmd_alarm_humidity_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_lo, 0.0f, 100.0f,
-			 print_alarm_humidity_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_lo, 0.0f,
+			 100.0f, print_alarm_humidity_lo);
 }
 
 static int cmd_alarm_humidity_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hi, 0.0f, 100.0f,
-			 print_alarm_humidity_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hi, 0.0f,
+			 100.0f, print_alarm_humidity_hi);
 }
 
 static int cmd_alarm_humidity_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hst, 0.0f, 20.0f,
-			 print_alarm_humidity_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_humidity_hst, 0.0f,
+			 20.0f, print_alarm_humidity_hst);
 }
 
 static int cmd_alarm_pressure_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_pressure_enabled,
-			print_alarm_pressure_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_pressure_enabled, print_alarm_pressure_enabled);
 }
 
 static int cmd_alarm_pressure_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_lo, 500.0f, 1200.0f,
-			 print_alarm_pressure_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_lo, 500.0f,
+			 1200.0f, print_alarm_pressure_lo);
 }
 
 static int cmd_alarm_pressure_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hi, 500.0f, 1200.0f,
-			 print_alarm_pressure_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hi, 500.0f,
+			 1200.0f, print_alarm_pressure_hi);
 }
 
 static int cmd_alarm_pressure_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hst, 0.0f, 50.0f,
-			 print_alarm_pressure_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_pressure_hst, 0.0f,
+			 50.0f, print_alarm_pressure_hst);
 }
 
 static int cmd_alarm_t1_temperature_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t1_temperature_enabled,
-			print_alarm_t1_temperature_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t1_temperature_enabled, print_alarm_t1_temperature_enabled);
 }
 
 static int cmd_alarm_t1_temperature_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_lo, -30.0f, 70.0f,
-			 print_alarm_t1_temperature_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_lo, -30.0f,
+			 70.0f, print_alarm_t1_temperature_lo);
 }
 
 static int cmd_alarm_t1_temperature_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hi, -30.0f, 70.0f,
-			 print_alarm_t1_temperature_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hi, -30.0f,
+			 70.0f, print_alarm_t1_temperature_hi);
 }
 
 static int cmd_alarm_t1_temperature_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hst, 0.0f, 5.0f,
-			 print_alarm_t1_temperature_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t1_temperature_hst, 0.0f,
+			 5.0f, print_alarm_t1_temperature_hst);
 }
 
 static int cmd_alarm_t2_temperature_enabled(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t2_temperature_enabled,
-			print_alarm_t2_temperature_enabled);
+	return cmd_bool(shell, argc, argv, &m_app_config.alarm_t2_temperature_enabled, print_alarm_t2_temperature_enabled);
 }
 
 static int cmd_alarm_t2_temperature_lo(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_lo, -30.0f, 70.0f,
-			 print_alarm_t2_temperature_lo);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_lo, -30.0f,
+			 70.0f, print_alarm_t2_temperature_lo);
 }
 
 static int cmd_alarm_t2_temperature_hi(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hi, -30.0f, 70.0f,
-			 print_alarm_t2_temperature_hi);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hi, -30.0f,
+			 70.0f, print_alarm_t2_temperature_hi);
 }
 
 static int cmd_alarm_t2_temperature_hst(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hst, 0.0f, 5.0f,
-			 print_alarm_t2_temperature_hst);
+	return cmd_float(shell, argc, argv, &m_app_config.alarm_t2_temperature_hst, 0.0f,
+			 5.0f, print_alarm_t2_temperature_hst);
 }
 
 static int cmd_hall_left_counter(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_counter,
-			print_hall_left_counter);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_counter, print_hall_left_counter);
 }
 
 static int cmd_hall_left_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_act,
-			print_hall_left_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_act, print_hall_left_notify_act);
 }
 
 static int cmd_hall_left_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_deact,
-			print_hall_left_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_left_notify_deact, print_hall_left_notify_deact);
 }
 
 static int cmd_hall_right_counter(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_counter,
-			print_hall_right_counter);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_counter, print_hall_right_counter);
 }
 
 static int cmd_hall_right_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_act,
-			print_hall_right_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_act, print_hall_right_notify_act);
 }
 
 static int cmd_hall_right_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_deact,
-			print_hall_right_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.hall_right_notify_deact, print_hall_right_notify_deact);
 }
 
 static int cmd_input_a_counter(const struct shell *shell, size_t argc, char **argv)
@@ -1575,14 +1579,12 @@ static int cmd_input_a_counter(const struct shell *shell, size_t argc, char **ar
 
 static int cmd_input_a_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_act,
-			print_input_a_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_act, print_input_a_notify_act);
 }
 
 static int cmd_input_a_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_deact,
-			print_input_a_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_a_notify_deact, print_input_a_notify_deact);
 }
 
 static int cmd_input_b_counter(const struct shell *shell, size_t argc, char **argv)
@@ -1592,32 +1594,30 @@ static int cmd_input_b_counter(const struct shell *shell, size_t argc, char **ar
 
 static int cmd_input_b_notify_act(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_act,
-			print_input_b_notify_act);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_act, print_input_b_notify_act);
 }
 
 static int cmd_input_b_notify_deact(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_deact,
-			print_input_b_notify_deact);
+	return cmd_bool(shell, argc, argv, &m_app_config.input_b_notify_deact, print_input_b_notify_deact);
 }
 
 static int cmd_corr_temperature(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.corr_temperature, -5.0f, 5.0f,
-			 print_corr_temperature);
+	return cmd_float(shell, argc, argv, &m_app_config.corr_temperature, -5.0f,
+			 5.0f, print_corr_temperature);
 }
 
 static int cmd_corr_t1_temperature(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.corr_t1_temperature, -5.0f, 5.0f,
-			 print_corr_t1_temperature);
+	return cmd_float(shell, argc, argv, &m_app_config.corr_t1_temperature, -5.0f,
+			 5.0f, print_corr_t1_temperature);
 }
 
 static int cmd_corr_t2_temperature(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_float(shell, argc, argv, &m_app_config.corr_t2_temperature, -5.0f, 5.0f,
-			 print_corr_t2_temperature);
+	return cmd_float(shell, argc, argv, &m_app_config.corr_t2_temperature, -5.0f,
+			 5.0f, print_corr_t2_temperature);
 }
 
 static int cmd_cap_hall_left(const struct shell *shell, size_t argc, char **argv)
@@ -1657,14 +1657,12 @@ static int cmd_cap_pir_detector(const struct shell *shell, size_t argc, char **a
 
 static int cmd_cap_1w_thermometer(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_thermometer,
-			print_cap_1w_thermometer);
+	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_thermometer, print_cap_1w_thermometer);
 }
 
 static int cmd_cap_1w_machine_probe(const struct shell *shell, size_t argc, char **argv)
 {
-	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_machine_probe,
-			print_cap_1w_machine_probe);
+	return cmd_bool(shell, argc, argv, &m_app_config.cap_1w_machine_probe, print_cap_1w_machine_probe);
 }
 
 static int print_help(const struct shell *shell, size_t argc, char **argv)

--- a/app/src/app_config.h
+++ b/app/src/app_config.h
@@ -44,6 +44,7 @@ struct app_config {
 	int interval_sample;
 	int interval_report;
 	enum app_config_lrw_region lrw_region;
+	int lrw_sub_band;
 	enum app_config_lrw_network lrw_network;
 	bool lrw_adr;
 	enum app_config_lrw_activation lrw_activation;

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -76,6 +76,13 @@ parameters:
     enum: lrw_region
     help: "Get/Set LoRaWAN region (eu868/us915/au915)."
 
+  - name: lrw_sub_band
+    type: int
+    default: 2
+    min: 0
+    max: 8
+    help: "Get/Set US915/AU915 sub-band (1-8, 0 = all channels). Default 2 matches TTN/Helium/ChirpStack."
+
   - name: lrw_network
     type: enum
     enum: lrw_network

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -5,6 +5,7 @@ module:
   settings_prefix: config
   shell_command: config
   log_module: app_config
+  version: 1
 
 enums:
   lrw_region:

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -480,6 +480,26 @@ class Configen(WestCommand):
                 f.write(source_content)
             log.inf(f"Generated: {source_path}")
 
+            self._clang_format([header_path, source_path])
+
+    def _clang_format(self, paths):
+        """Run clang-format on generated files if available."""
+        import shutil
+        import subprocess
+
+        clang_format = shutil.which("clang-format")
+        if not clang_format:
+            log.wrn("clang-format not found in PATH; skipping formatting. "
+                    "Generated output will use template wrap style.")
+            return
+
+        try:
+            subprocess.run([clang_format, "-i", *[str(p) for p in paths]],
+                           check=True)
+            log.inf(f"Formatted with clang-format: {', '.join(p.name for p in paths)}")
+        except subprocess.CalledProcessError as e:
+            log.wrn(f"clang-format failed: {e}; generated files left as-is")
+
     def _validate_param(self, param):
         """Validate a parameter definition."""
         name = param.get("name")

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -63,7 +63,13 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 		return -EINVAL;
 	}
 
-	{{ param | c_type(module.name) }} a = {{ param | parse_func }}(argv[1], NULL, 10);
+	char *endptr;
+	{{ param | c_type(module.name) }} a = {{ param | parse_func }}(argv[1], &endptr, 10);
+
+	if (*endptr != '\0' || endptr == argv[1]) {
+		shell_error(shell, "%s", m_msg_invalid_value);
+		return -EINVAL;
+	}
 
 {% if param.extras.zero_allowed %}
 	if (a != 0 && (a < {{ param | min_value }} || a > {{ param | max_value }})) {
@@ -138,7 +144,19 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 	}
 {% endif %}
 
-	m_{{ module.name }}.{{ param.name | c_name }} = {{ param | parse_func }}(argv[1], NULL, 10);
+	errno = 0;
+{% if param.type == 'uint64' %}
+	unsigned long long value = {{ param | parse_func }}(argv[1], NULL, 10);
+{% else %}
+	unsigned long value = {{ param | parse_func }}(argv[1], NULL, 10);
+{% endif %}
+
+	if (errno == ERANGE || value > {{ param | max_value }}) {
+		shell_error(shell, "%s", m_msg_invalid_value);
+		return -EINVAL;
+	}
+
+	m_{{ module.name }}.{{ param.name | c_name }} = ({{ param | c_type(module.name) }})value;
 
 	return 0;
 {% elif param.type == 'uint' %}
@@ -152,6 +170,11 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 
 	if (argc != 2) {
 		shell_error(shell, "%s", m_msg_invalid_args);
+		return -EINVAL;
+	}
+
+	if (argv[1][0] == '-') {
+		shell_error(shell, "%s", m_msg_invalid_range);
 		return -EINVAL;
 	}
 
@@ -257,7 +280,7 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 	if (!ret) {
 		LOG_ERR("Call `hex2bin` failed: %d", ret);
 		shell_error(shell, "%s", m_msg_invalid_value);
-		return ret;
+		return -EINVAL;
 	}
 
 	return 0;
@@ -324,7 +347,19 @@ LOG_MODULE_REGISTER({{ module.log_module | default(module.name) }}, LOG_LEVEL_DB
 
 struct {{ module.name }} g_{{ module.name }};
 
+{% if module.version is defined %}
+static const struct {{ module.name }} m_{{ module.name }}_defaults = {
+	.config_version = {{ module.name | upper }}_VERSION,
+{% for param in parameters if param.default is defined %}
+	.{{ param.name | c_name }} = {{ param | default_value(module.name) }},
+{% endfor %}
+};
+
+{% endif %}
 static struct {{ module.name }} m_{{ module.name }} = {
+{% if module.version is defined %}
+	.config_version = {{ module.name | upper }}_VERSION,
+{% endif %}
 {% for param in parameters if param.default is defined %}
 	.{{ param.name | c_name }} = {{ param | default_value(module.name) }},
 {% endfor %}
@@ -353,6 +388,10 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		}                                                                                  \
 	} while (0)
 
+{% if module.version is defined %}
+	SETTINGS_SET("config-version", &m_{{ module.name }}.config_version,
+		     sizeof(m_{{ module.name }}.config_version));
+{% endif %}
 {% for param in parameters %}
 {% if param.type == 'bytes' or param.type == 'string' %}
 	SETTINGS_SET("{{ param.name | settings_key }}", m_{{ module.name }}.{{ param.name | c_name }}, sizeof(m_{{ module.name }}.{{ param.name | c_name }}));
@@ -371,6 +410,14 @@ static int h_commit(void)
 {
 	LOG_DBG("Loaded settings in full");
 
+{% if module.version is defined %}
+	if (m_{{ module.name }}.config_version != {{ module.name | upper }}_VERSION) {
+		LOG_WRN("Config version mismatch (stored=%u, expected=%u), resetting to defaults",
+			m_{{ module.name }}.config_version, {{ module.name | upper }}_VERSION);
+		m_{{ module.name }} = m_{{ module.name }}_defaults;
+	}
+
+{% endif %}
 	memcpy(&g_{{ module.name }}, &m_{{ module.name }}, sizeof(g_{{ module.name }}));
 	return 0;
 }
@@ -382,6 +429,10 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		(void)export_func(SETTINGS_PFX "/" _key, _var, _size);                             \
 	} while (0)
 
+{% if module.version is defined %}
+	EXPORT_FUNC("config-version", &m_{{ module.name }}.config_version,
+		    sizeof(m_{{ module.name }}.config_version));
+{% endif %}
 {% for param in parameters %}
 {% if param.type == 'bytes' or param.type == 'string' %}
 	EXPORT_FUNC("{{ param.name | settings_key }}", m_{{ module.name }}.{{ param.name | c_name }}, sizeof(m_{{ module.name }}.{{ param.name | c_name }}));

--- a/scripts/west_commands/templates/config.h.j2
+++ b/scripts/west_commands/templates/config.h.j2
@@ -24,8 +24,15 @@ enum {{ module.name }}_{{ enum_name | c_name }} {
 {% endfor %}
 };
 {% endfor %}
+{% if module.version is defined %}
+
+#define {{ module.name | upper }}_VERSION {{ module.version }}
+{% endif %}
 
 struct {{ module.name }} {
+{% if module.version is defined %}
+	uint32_t config_version;
+{% endif %}
 {% for param in parameters %}
 {{ param | struct_field(module.name) }}
 {% endfor %}


### PR DESCRIPTION
## Summary

Owns all `app_config.yml` / configen-related changes for the v1.3.x line, so feature PRs can stay scoped to their own modules. Two things landed:

1. **Six validation fixes** moved from hand-patched `app_config.c` into the configen template, so future `west configen` runs preserve them.
2. **`lrw_sub_band` param** added to YAML up front (instead of being part of PR #30), so PR #30 can drop all its YAML/configen churn and stay focused on `app_lrw.c` + NFC + proto.

## Template fixes (`scripts/west_commands/templates/config.c.j2`)

- `bytes` branch returns `-EINVAL` on `hex2bin` failure (was `return ret` where `ret == 0` on failure → silently signaled success to the shell).
- `is_unsigned + extras` branch checks `errno == ERANGE` and max-value overflow after `strtoul`.
- `is_unsigned` branch rejects negative input via `argv[1][0] == '-'` (the existing `value < 0` check is dead code on 32-bit `unsigned long`).
- `is_signed + extras` branch validates `strtol` output via `endptr`.
- Optional `module.version` knob emits `MODULE_VERSION` define, defaults struct, `config-version` SETTINGS_SET / EXPORT_FUNC, and `h_commit` mismatch-reset path.

## Template fixes (`scripts/west_commands/templates/config.h.j2`)

- Emit `MODULE_VERSION` define and `config_version` field when `module.version` is set in YAML.

## YAML changes (`app/src/app_config.yml`)

- Set `module.version: 1` — enables the `config_version` schema-migration mechanism that previously existed as hand-edits in `app_config.c`.
- Add `lrw_sub_band` (int, default 2, range 0–8) — US915/AU915 sub-band selector.

## Regenerated `app/src/app_config.c`

- Picks up all six template fixes and the two new fields.
- Propagates the `hex2bin` `-EINVAL` fix to six additional `bytes` parameters (`lrw_deveui`, `lrw_joineui`, `lrw_devaddr`, `lrw_nwkskey`, `lrw_appskey`, `lrw_appkey`) where the original manual patch never landed.

## Why a YAML-only PR for `lrw_sub_band`

PR #30 originally bundled the YAML field with the C-side mask logic and produced a noisy regen diff in `app_config.c` that obscured the actual change. Landing the YAML side first here, with a clean regen, lets PR #30 drop the YAML/configen part entirely and review just the `app_lrw.c` mask code + NFC ingest + proto change.

## Why this PR exists at all (root cause)

Six earlier commits on `main` patched the auto-generated `app_config.c` directly, despite its `/* WARNING: This file is auto-generated by west configen. Do not modify manually. */` header. Re-implemented here in the template:

- `bf4f52b` Reject negative input in nonce_counter shell command
- `2fb31d6` Add UINT32_MAX range check for nonce_counter shell command
- `084ba5b` Reject serial number values exceeding UINT32_MAX
- `dc81d8f` Return -EINVAL on hex2bin failure in secret key handler
- `fa8e370` Validate strtol input in cmd_interval_sample
- `7228225` Add NVS config version check to reset defaults on mismatch

## Relationship to other PRs

- **Blocks PR #30** (issue #22) — after this lands, PR #30 needs only a rebase and can drop both YAML edits and the two manual `app_config.c` patch-up commits (`Restore APP_CONFIG_VERSION check…` and `Revert APP_CONFIG_VERSION bump…`).
- Independent of PR #29 (issue #8) and PR #32 (issue #19) — those don't touch `app_config.c`.

## Test plan

- [x] `west configen sticker/app/src/app_config.yml -o sticker/app/src/` produces a clean diff: validation additions, `config_version` mechanism, `lrw_sub_band` field — no whitespace churn vs the previously-hand-edited `app_config.c`.
- [x] `app_config.h` differs from pre-PR state only by the added `config_version` and `lrw_sub_band` fields.
- [x] Pristine `west build -b sticker sticker/app --pristine` succeeds, 0 warnings, FLASH 50.24 %.
- [x] Cross-checked against PR #30: applying PR #30's `app_lrw.c` + NFC changes on top of this branch yields a working build with the sub-band mask correctly applied.

## Recommended follow-up

Consider a CI guard that runs `west configen --check` and fails the build when `app_config.c` is out of sync with `app_config.yml` + template. That would have caught the original drift and would prevent it from happening again.