### PR TITLE
app_lrw: feed AppKey into NwkKey slot for LoRaWAN 1.0.x OTAA

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -22,6 +22,21 @@ config FW_DEBUG
 	  When enabled, the periodic LED blink shows green + yellow
 	  instead of just green to indicate debug build.
 
+config APP_LORAWAN_1_1
+	bool "Use LoRaWAN 1.1.x crypto for OTAA"
+	default n
+	help
+	  Enable LoRaWAN 1.1.x crypto for OTAA join: feed `lrw_nwkkey` into
+	  the NwkKey slot (distinct from AppKey). When disabled (default,
+	  LoRaWAN 1.0.x), the firmware copies `lrw_appkey` into both the
+	  NwkKey and AppKey slots so the JoinRequest MIC is computed from
+	  AppKey — required for 1.0.x network servers (TTN, ChirpStack,
+	  Helium).
+
+	  Enabling this also requires the LoRaMac library to be built with
+	  USE_LRWAN_1_1_X_CRYPTO=1; the Kconfig only flips the app-level
+	  key wiring.
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -102,7 +102,7 @@ parameters:
   - name: lrw_nwkkey
     type: bytes
     size: 16
-    help: "Get/Set LoRaWAN NwkKey (32 hex digits). Used only when CONFIG_APP_LORAWAN_1_1=y; otherwise AppKey is used for both slots."
+    help: "Get/Set LoRaWAN NwkKey (32 hex digits)."
 
   - name: lrw_appkey
     type: bytes

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -102,7 +102,7 @@ parameters:
   - name: lrw_nwkkey
     type: bytes
     size: 16
-    help: "Get/Set LoRaWAN NwkKey (32 hex digits)."
+    help: "Get/Set LoRaWAN NwkKey (32 hex digits). Used only when CONFIG_APP_LORAWAN_1_1=y; otherwise AppKey is used for both slots."
 
   - name: lrw_appkey
     type: bytes

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -412,7 +412,16 @@ static void join_work_handler(struct k_work *work)
 		LOG_INF("Using OTAA activation");
 		config.mode = LORAWAN_ACT_OTAA;
 		config.otaa.join_eui = g_app_config.lrw_joineui;
+#if defined(CONFIG_APP_LORAWAN_1_1)
+		/* LoRaWAN 1.1.x: NwkKey and AppKey are distinct root keys. */
 		config.otaa.nwk_key = g_app_config.lrw_nwkkey;
+#else
+		/* LoRaWAN 1.0.x: NwkKey == AppKey. LoRaMac computes the
+		 * JoinRequest MIC from the NwkKey slot, so feeding AppKey into
+		 * both slots keeps the device compatible with 1.0.x network
+		 * servers (TTN, ChirpStack, Helium). */
+		config.otaa.nwk_key = g_app_config.lrw_appkey;
+#endif
 		config.otaa.app_key = g_app_config.lrw_appkey;
 	} else if (g_app_config.lrw_activation == APP_CONFIG_LRW_ACTIVATION_ABP) {
 		LOG_INF("Using ABP activation");


### PR DESCRIPTION
LoRaMac computes the JoinRequest MIC from the NwkKey slot regardless of LoRaWAN version. In 1.0.x there is no separate NwkKey — the spec says it equals AppKey. The Zephyr API still requires both fields, so if `lrw_nwkkey` was left at its default zero buffer the device sent JoinRequests with a zero-key MIC, which 1.0.x network servers (TTN, ChirpStack, Helium) silently drop. ABP was unaffected because session keys are pre-shared and don't go through join MIC.

Hard-wire `config.otaa.nwk_key = g_app_config.lrw_appkey` for OTAA so no extra setup is needed against 1.0.x networks. The `lrw_nwkkey` parameter is kept in YAML and on the NFC wire so the field is reachable once we move to 1.1.x.

Gate the future 1.1.x wiring behind a new `CONFIG_APP_LORAWAN_1_1` Kconfig (default n). When set to y, `lrw_nwkkey` is used as before; otherwise AppKey populates both slots. The Kconfig only flips the app-level key wiring — actually running 1.1.x also needs the LoRaMac library built with `USE_LRWAN_1_1_X_CRYPTO=1`, which isn't built here today.

The YAML help text on `lrw_nwkkey` is updated to reflect the gated behaviour; the regenerated `app_config.c` is intentionally left out of this commit — it will be picked up automatically when this branch is rebased onto a main that includes PR #33 (configen template fix).