### PR TITLE
ci: bake numeric FW version + build-type enum into the image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,9 @@ jobs:
         working-directory: sticker
         shell: bash
         run: |
-          # build_type: 0=RELEASE (tag), 1=DEV (branch/PR). Local builds
-          # default to 2=CUSTOM in CMake when no override is passed.
+          # build_type (source): 0=MAIN (tag), 1=DEV (branch/PR). Local builds
+          # default to 2=CUSTOM in CMake. The debug/release config is a separate
+          # axis (CONFIG_FW_DEBUG), driven by the matrix, not this value.
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="v${GITHUB_REF#refs/tags/v}"
             BUILD_TYPE=0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,28 @@ jobs:
         working-directory: sticker
         shell: bash
         run: |
+          # build_type: 0=RELEASE (tag), 1=DEV (branch/PR). Local builds
+          # default to 2=CUSTOM in CMake when no override is passed.
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="v${GITHUB_REF#refs/tags/v}"
+            BUILD_TYPE=0
           else
             VERSION="$(git rev-parse --short HEAD)"
+            BUILD_TYPE=1
+          fi
+
+          MAJOR=0; MINOR=0; PATCH=0
+          if [[ "$VERSION" =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
           fi
 
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+          echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+          echo "build_type=$BUILD_TYPE" >> "$GITHUB_OUTPUT"
 
       - name: Build firmware
         working-directory: sticker/app
@@ -69,7 +84,10 @@ jobs:
           fi
 
           west build -p always -b sticker -- $ARGS \
-            -DAPP_VERSION_OVERRIDE=${{ steps.version.outputs.value }}
+            -DAPP_VERSION_MAJOR=${{ steps.version.outputs.major }} \
+            -DAPP_VERSION_MINOR=${{ steps.version.outputs.minor }} \
+            -DAPP_VERSION_PATCH=${{ steps.version.outputs.patch }} \
+            -DAPP_BUILD_TYPE=${{ steps.version.outputs.build_type }}
 
           mkdir -p ../artifacts
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,8 @@ jobs:
              ARGS=""
           fi
 
-          west build -p always -b sticker -- $ARGS
+          west build -p always -b sticker -- $ARGS \
+            -DAPP_VERSION_OVERRIDE=${{ steps.version.outputs.value }}
 
           mkdir -p ../artifacts
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,16 +53,23 @@ jobs:
           # build_type (source): 0=MAIN (tag), 1=DEV (branch/PR). Local builds
           # default to 2=CUSTOM in CMake. The debug/release config is a separate
           # axis (CONFIG_FW_DEBUG), driven by the matrix, not this value.
+          #
+          # VERSION names the artifact (tag for releases, short hash otherwise).
+          # SEMVER is what gets baked into the firmware: the tag for releases,
+          # else the latest tag (so branch builds report the release they build
+          # on top of, matching the local git-describe behaviour in CMake).
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="v${GITHUB_REF#refs/tags/v}"
             BUILD_TYPE=0
+            SEMVER="$VERSION"
           else
             VERSION="$(git rev-parse --short HEAD)"
             BUILD_TYPE=1
+            SEMVER="$(git describe --tags --abbrev=0 2>/dev/null || true)"
           fi
 
           MAJOR=0; MINOR=0; PATCH=0
-          if [[ "$VERSION" =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          if [[ "$SEMVER" =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,22 +9,24 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sticker)
 
-# Firmware version string baked into the image (logged at boot, reported by the
-# GetInfo command). CI passes the release tag or short commit hash via
-# -DAPP_VERSION_OVERRIDE (see .github/workflows/build.yml). Local builds fall
-# back to `git describe`, then to "dev" if git is unavailable.
-if(NOT DEFINED APP_VERSION_OVERRIDE)
-  execute_process(
-    COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} describe --always --dirty --tags
-    OUTPUT_VARIABLE APP_VERSION_OVERRIDE
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET)
+# Firmware version baked into the image (logged at boot, reported by the
+# GetInfo command). CI passes the numeric version components and build type
+# via -DAPP_VERSION_* / -DAPP_BUILD_TYPE (see .github/workflows/build.yml):
+#   tag v1.3.4 -> 1/3/4, type 0 (RELEASE)
+#   branch/PR  -> 0/0/0, type 1 (DEV)
+# Local builds without the override default to 0/0/0, type 2 (CUSTOM).
+if(NOT DEFINED APP_VERSION_MAJOR)
+  set(APP_VERSION_MAJOR 0)
+  set(APP_VERSION_MINOR 0)
+  set(APP_VERSION_PATCH 0)
+  set(APP_BUILD_TYPE 2)
 endif()
-if(NOT APP_VERSION_OVERRIDE)
-  set(APP_VERSION_OVERRIDE "dev")
-endif()
-add_compile_definitions(APP_VERSION_STRING="${APP_VERSION_OVERRIDE}")
-message(STATUS "Firmware version: ${APP_VERSION_OVERRIDE}")
+add_compile_definitions(
+  APP_VERSION_MAJOR=${APP_VERSION_MAJOR}
+  APP_VERSION_MINOR=${APP_VERSION_MINOR}
+  APP_VERSION_PATCH=${APP_VERSION_PATCH}
+  APP_BUILD_TYPE=${APP_BUILD_TYPE})
+message(STATUS "Firmware version: ${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH} (build type ${APP_BUILD_TYPE})")
 
 list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
 include(nanopb)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,6 +9,23 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sticker)
 
+# Firmware version string baked into the image (logged at boot, reported by the
+# GetInfo command). CI passes the release tag or short commit hash via
+# -DAPP_VERSION_OVERRIDE (see .github/workflows/build.yml). Local builds fall
+# back to `git describe`, then to "dev" if git is unavailable.
+if(NOT DEFINED APP_VERSION_OVERRIDE)
+  execute_process(
+    COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} describe --always --dirty --tags
+    OUTPUT_VARIABLE APP_VERSION_OVERRIDE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+endif()
+if(NOT APP_VERSION_OVERRIDE)
+  set(APP_VERSION_OVERRIDE "dev")
+endif()
+add_compile_definitions(APP_VERSION_STRING="${APP_VERSION_OVERRIDE}")
+message(STATUS "Firmware version: ${APP_VERSION_OVERRIDE}")
+
 list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/modules/nanopb)
 include(nanopb)
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -14,13 +14,26 @@ project(sticker)
 # via -DAPP_VERSION_* / -DAPP_BUILD_TYPE (see .github/workflows/build.yml):
 #   tag v1.3.4 -> 1/3/4, type 0 (MAIN)
 #   branch/PR  -> 0/0/0, type 1 (DEV)
-# Local builds without the override default to 0/0/0, type 2 (CUSTOM).
+# Local builds (no override) derive the version from the latest git tag and are
+# always type 2 (CUSTOM); they fall back to 0/0/0 if git/tags are unavailable.
 # The debug/release config is a separate axis (CONFIG_FW_DEBUG), not set here.
 if(NOT DEFINED APP_VERSION_MAJOR)
-  set(APP_VERSION_MAJOR 0)
-  set(APP_VERSION_MINOR 0)
-  set(APP_VERSION_PATCH 0)
-  set(APP_BUILD_TYPE 2)
+  set(APP_BUILD_TYPE 2) # CUSTOM
+  execute_process(
+    COMMAND git describe --tags --abbrev=0
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE APP_GIT_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(APP_GIT_TAG MATCHES "^v?([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+    set(APP_VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(APP_VERSION_MINOR ${CMAKE_MATCH_2})
+    set(APP_VERSION_PATCH ${CMAKE_MATCH_3})
+  else()
+    set(APP_VERSION_MAJOR 0)
+    set(APP_VERSION_MINOR 0)
+    set(APP_VERSION_PATCH 0)
+  endif()
 endif()
 add_compile_definitions(
   APP_VERSION_MAJOR=${APP_VERSION_MAJOR}

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -9,12 +9,13 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sticker)
 
-# Firmware version baked into the image (logged at boot, reported by the
-# GetInfo command). CI passes the numeric version components and build type
+# Firmware version + source baked into the image (logged at boot, reported by
+# the GetInfo command). CI passes the numeric version components and build type
 # via -DAPP_VERSION_* / -DAPP_BUILD_TYPE (see .github/workflows/build.yml):
-#   tag v1.3.4 -> 1/3/4, type 0 (RELEASE)
+#   tag v1.3.4 -> 1/3/4, type 0 (MAIN)
 #   branch/PR  -> 0/0/0, type 1 (DEV)
 # Local builds without the override default to 0/0/0, type 2 (CUSTOM).
+# The debug/release config is a separate axis (CONFIG_FW_DEBUG), not set here.
 if(NOT DEFINED APP_VERSION_MAJOR)
   set(APP_VERSION_MAJOR 0)
   set(APP_VERSION_MINOR 0)

--- a/app/src/app_version.h
+++ b/app/src/app_version.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 HARDWARIO a.s.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef APP_VERSION_H_
+#define APP_VERSION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Firmware version + build type baked into the image. The build injects these
+ * (CI passes -DAPP_VERSION_* / -DAPP_BUILD_TYPE, see app/CMakeLists.txt):
+ *   tag v1.3.4 -> 1/3/4, build type RELEASE
+ *   branch/PR  -> 0/0/0, build type DEV
+ * Local builds without the override default to 0/0/0, build type CUSTOM.
+ * The fallbacks below keep IDE/standalone tooling happy. */
+#ifndef APP_VERSION_MAJOR
+#define APP_VERSION_MAJOR 0
+#define APP_VERSION_MINOR 0
+#define APP_VERSION_PATCH 0
+#define APP_BUILD_TYPE    2
+#endif
+
+enum app_build_type {
+	APP_BUILD_TYPE_RELEASE = 0, /* tagged release build */
+	APP_BUILD_TYPE_DEV     = 1, /* CI build from a branch / PR */
+	APP_BUILD_TYPE_CUSTOM  = 2, /* local / modified firmware */
+};
+
+static inline const char *app_build_type_str(enum app_build_type type)
+{
+	switch (type) {
+	case APP_BUILD_TYPE_RELEASE:
+		return "release";
+	case APP_BUILD_TYPE_DEV:
+		return "dev";
+	case APP_BUILD_TYPE_CUSTOM:
+		return "custom";
+	default:
+		return "unknown";
+	}
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APP_VERSION_H_ */

--- a/app/src/app_version.h
+++ b/app/src/app_version.h
@@ -7,15 +7,21 @@
 #ifndef APP_VERSION_H_
 #define APP_VERSION_H_
 
+#include <stdbool.h>
+#include <zephyr/sys/util.h> /* IS_ENABLED */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* Firmware version + build type baked into the image. The build injects these
- * (CI passes -DAPP_VERSION_* / -DAPP_BUILD_TYPE, see app/CMakeLists.txt):
- *   tag v1.3.4 -> 1/3/4, build type RELEASE
- *   branch/PR  -> 0/0/0, build type DEV
- * Local builds without the override default to 0/0/0, build type CUSTOM.
+/* Firmware identity has two orthogonal axes:
+ *   1) version + source ("where the build came from") — injected by CI via
+ *      -DAPP_VERSION_* / -DAPP_BUILD_TYPE (see app/CMakeLists.txt):
+ *        tag v1.3.4 -> 1/3/4, build type MAIN
+ *        branch/PR  -> 0/0/0, build type DEV
+ *        local      -> 0/0/0, build type CUSTOM (CMake default)
+ *   2) configuration debug vs release — from CONFIG_FW_DEBUG (debug.conf sets
+ *      it y, release leaves it n), see app_version_is_debug().
  * The fallbacks below keep IDE/standalone tooling happy. */
 #ifndef APP_VERSION_MAJOR
 #define APP_VERSION_MAJOR 0
@@ -24,17 +30,18 @@ extern "C" {
 #define APP_BUILD_TYPE    2
 #endif
 
+/* Source of the build (orthogonal to the debug/release config). */
 enum app_build_type {
-	APP_BUILD_TYPE_RELEASE = 0, /* tagged release build */
-	APP_BUILD_TYPE_DEV     = 1, /* CI build from a branch / PR */
-	APP_BUILD_TYPE_CUSTOM  = 2, /* local / modified firmware */
+	APP_BUILD_TYPE_MAIN   = 0, /* tagged build from main */
+	APP_BUILD_TYPE_DEV    = 1, /* CI build from a branch / PR */
+	APP_BUILD_TYPE_CUSTOM = 2, /* local / modified firmware */
 };
 
 static inline const char *app_build_type_str(enum app_build_type type)
 {
 	switch (type) {
-	case APP_BUILD_TYPE_RELEASE:
-		return "release";
+	case APP_BUILD_TYPE_MAIN:
+		return "main";
 	case APP_BUILD_TYPE_DEV:
 		return "dev";
 	case APP_BUILD_TYPE_CUSTOM:
@@ -42,6 +49,12 @@ static inline const char *app_build_type_str(enum app_build_type type)
 	default:
 		return "unknown";
 	}
+}
+
+/* True for a debug build (debug.conf), false for release. */
+static inline bool app_version_is_debug(void)
+{
+	return IS_ENABLED(CONFIG_FW_DEBUG);
 }
 
 #ifdef __cplusplus

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -30,6 +30,12 @@
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
+/* Defined by the build (CI passes -DAPP_VERSION_OVERRIDE, see app/CMakeLists.txt).
+ * Fallback keeps IDE/standalone tooling happy. */
+#ifndef APP_VERSION_STRING
+#define APP_VERSION_STRING "dev"
+#endif
+
 #define BLINK_INTERVAL_SECONDS 3
 #define NFC_CHECK_BLINKS       10
 
@@ -141,6 +147,7 @@ int main(void)
 {
 	int ret;
 
+	LOG_INF("Firmware version: " APP_VERSION_STRING);
 	LOG_INF("Build time: " __DATE__ " " __TIME__);
 
 	/* Shared HW init */

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -142,8 +142,9 @@ int main(void)
 {
 	int ret;
 
-	LOG_INF("Firmware version: %d.%d.%d (%s)", APP_VERSION_MAJOR, APP_VERSION_MINOR,
-		APP_VERSION_PATCH, app_build_type_str(APP_BUILD_TYPE));
+	LOG_INF("Firmware version: %d.%d.%d (%s, %s)", APP_VERSION_MAJOR, APP_VERSION_MINOR,
+		APP_VERSION_PATCH, app_build_type_str(APP_BUILD_TYPE),
+		app_version_is_debug() ? "debug" : "release");
 	LOG_INF("Build time: " __DATE__ " " __TIME__);
 
 	/* Shared HW init */

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -8,6 +8,7 @@
 #include "app_battery.h"
 #include "app_calibration.h"
 #include "app_config.h"
+#include "app_version.h"
 #include "app_led.h"
 #include "app_log.h"
 #include "app_lrw.h"
@@ -29,15 +30,6 @@
 #include <stdint.h>
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
-
-/* Defined by the build (CI passes -DAPP_VERSION_* / -DAPP_BUILD_TYPE, see
- * app/CMakeLists.txt). Fallbacks keep IDE/standalone tooling happy. */
-#ifndef APP_VERSION_MAJOR
-#define APP_VERSION_MAJOR 0
-#define APP_VERSION_MINOR 0
-#define APP_VERSION_PATCH 0
-#define APP_BUILD_TYPE    2
-#endif
 
 #define BLINK_INTERVAL_SECONDS 3
 #define NFC_CHECK_BLINKS       10
@@ -150,8 +142,8 @@ int main(void)
 {
 	int ret;
 
-	LOG_INF("Firmware version: %d.%d.%d (build type %d)", APP_VERSION_MAJOR,
-		APP_VERSION_MINOR, APP_VERSION_PATCH, APP_BUILD_TYPE);
+	LOG_INF("Firmware version: %d.%d.%d (%s)", APP_VERSION_MAJOR, APP_VERSION_MINOR,
+		APP_VERSION_PATCH, app_build_type_str(APP_BUILD_TYPE));
 	LOG_INF("Build time: " __DATE__ " " __TIME__);
 
 	/* Shared HW init */

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -30,10 +30,13 @@
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
-/* Defined by the build (CI passes -DAPP_VERSION_OVERRIDE, see app/CMakeLists.txt).
- * Fallback keeps IDE/standalone tooling happy. */
-#ifndef APP_VERSION_STRING
-#define APP_VERSION_STRING "dev"
+/* Defined by the build (CI passes -DAPP_VERSION_* / -DAPP_BUILD_TYPE, see
+ * app/CMakeLists.txt). Fallbacks keep IDE/standalone tooling happy. */
+#ifndef APP_VERSION_MAJOR
+#define APP_VERSION_MAJOR 0
+#define APP_VERSION_MINOR 0
+#define APP_VERSION_PATCH 0
+#define APP_BUILD_TYPE    2
 #endif
 
 #define BLINK_INTERVAL_SECONDS 3
@@ -147,7 +150,8 @@ int main(void)
 {
 	int ret;
 
-	LOG_INF("Firmware version: " APP_VERSION_STRING);
+	LOG_INF("Firmware version: %d.%d.%d (build type %d)", APP_VERSION_MAJOR,
+		APP_VERSION_MINOR, APP_VERSION_PATCH, APP_BUILD_TYPE);
 	LOG_INF("Build time: " __DATE__ " " __TIME__);
 
 	/* Shared HW init */


### PR DESCRIPTION
## Summary

The firmware build had no knowledge of its own version. CI already computes the release tag (`v1.3.4`) but used it only to name artifacts/releases.

This PR bakes the firmware identity into the image and logs it at boot (and exposes it via the `GetInfo` command in #36). The identity has **two orthogonal axes**:

1. **Version + source** — three integers plus a source enum.
2. **Configuration** — debug vs release, derived from `CONFIG_FW_DEBUG`.

### 1. Version + source

The version is **three integers** (not a string), so `GetInfo.Info` carries them as `fw_major` / `fw_minor` / `fw_patch` (`uint32`) — no strings, no `max_size` buffer/MTU risk, trivial LNS decoding.

The source is the `app_build_type` enum (`app/src/app_version.h`):

```c
enum app_build_type {
    APP_BUILD_TYPE_MAIN   = 0,  // tagged build from main
    APP_BUILD_TYPE_DEV    = 1,  // CI build from a branch / PR
    APP_BUILD_TYPE_CUSTOM = 2,  // local / modified firmware
};
const char *app_build_type_str(enum app_build_type); // "main" / "dev" / "custom"
```

**Where the version number comes from** — consistent across all three build paths, each reporting the release tag it builds on top of:

- **CI tag build** — version from the tag; `build_type = MAIN`. Injected via `-DAPP_VERSION_*`.
- **CI branch / PR build** — version from the latest tag (`git describe --tags --abbrev=0`); `build_type = DEV`. The artifact is still named with the short commit hash.
- **Local build** — version from the latest tag (`git describe` inside CMake); `build_type = CUSTOM`.

All fall back to `0.0.0` only if git/tags are unavailable. Nothing is written to any source file — values are command-line defines (CI) or git-derived at configure time (local), baked into the ELF as `#define`s.

### 2. Debug vs release config

Independent of the source axis. The same version builds in both configs — the `Makefile` `deploy` target and the CI matrix produce `sticker-debug.hex` and `sticker-release.hex`. The flag comes from `CONFIG_FW_DEBUG` (set by `debug.conf`, off in release):

```c
bool app_version_is_debug(void); // IS_ENABLED(CONFIG_FW_DEBUG)
```

## Changes

- **`build.yml`** — derive the firmware version (tag, or latest tag for branches) and pass `-DAPP_VERSION_MAJOR/MINOR/PATCH` + `-DAPP_BUILD_TYPE`. The artifact name keeps the tag/short-hash.
- **`app/CMakeLists.txt`** — compile definitions; local builds derive the version from `git describe` and are always `CUSTOM`.
- **`app/src/app_version.h`** — version macros + `app_build_type` enum + `app_build_type_str()` + `app_version_is_debug()`.
- **`main.c`** — boot log `Firmware version: 1.3.4 (main, debug)`.

## Result

| Build trigger | version | source | config |
|---|---|---|---|
| CI tag `v1.3.4` | `1.3.4` | `main` | `debug` + `release` (matrix) |
| CI branch / PR | `1.3.4` (latest tag) | `dev` | `debug` + `release` (matrix) |
| Local `make debug` / `make release` | `1.3.4` (latest tag) | `custom` | per chosen target |
| No tags / no git | `0.0.0` | — | — |

## Notes

- Consumed by the `GetInfo` downlink command in #36 (`fill_info` fills `fw_major/minor/patch` + `build_type` + `debug`).
- Artifact/release naming (`hio-sticker-v1.3.4-*.hex`) is unchanged.
- Verified on hardware — see the RTT boot-log comment below.
