### PR TITLE
v1.4.0: Command protocol Phase 2+3 + get_config (SetParam/GetParam/control/config dump)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -33,7 +33,109 @@ function _pbBytesToAscii(bytes) {
   return s;
 }
 
+function _pbBytesToHex(bytes) {
+  var s = "";
+  for (var i = 0; i < bytes.length; i++) {
+    var h = bytes[i].toString(16);
+    s += h.length === 1 ? "0" + h : h;
+  }
+  return s;
+}
+
+// Decode a little-endian IEEE-754 float32 (protobuf wire type 5).
+function _pbReadFloat(bytes, offset) {
+  var b0 = bytes[offset], b1 = bytes[offset + 1], b2 = bytes[offset + 2], b3 = bytes[offset + 3];
+  var bits = (b3 << 24) | (b2 << 16) | (b1 << 8) | b0;
+  var sign = bits < 0 ? -1 : 1;
+  var exp = (bits >>> 23) & 0xff;
+  var mant = bits & 0x7fffff;
+  var val;
+  if (exp === 0) {
+    val = mant * Math.pow(2, -149);
+  } else if (exp === 0xff) {
+    val = mant ? NaN : Infinity;
+  } else {
+    val = (mant + 0x800000) * Math.pow(2, exp - 150);
+  }
+  return { value: sign * val, next: offset + 4 };
+}
+
 var _BUILD_TYPES = ["main", "dev", "custom"];
+
+// proto field tag -> name for ConfigDump.Application (floats marked in _APP_FLOAT)
+var _APP_NAMES = {
+  1: "calibration", 2: "interval_sample", 4: "interval_report",
+  5: "alarm_temperature_enabled", 6: "alarm_temperature_lo", 7: "alarm_temperature_hi", 8: "alarm_temperature_hst",
+  9: "alarm_humidity_enabled", 10: "alarm_humidity_lo", 11: "alarm_humidity_hi", 12: "alarm_humidity_hst",
+  13: "alarm_pressure_enabled", 14: "alarm_pressure_lo", 15: "alarm_pressure_hi", 16: "alarm_pressure_hst",
+  17: "alarm_t1_temperature_enabled", 18: "alarm_t1_temperature_lo", 19: "alarm_t1_temperature_hi", 20: "alarm_t1_temperature_hst",
+  21: "alarm_t2_temperature_enabled", 22: "alarm_t2_temperature_lo", 23: "alarm_t2_temperature_hi", 24: "alarm_t2_temperature_hst",
+  25: "hall_left_counter", 26: "hall_left_notify_act", 27: "hall_left_notify_deact",
+  28: "hall_right_counter", 29: "hall_right_notify_act", 30: "hall_right_notify_deact",
+  31: "input_a_counter", 32: "input_a_notify_act", 33: "input_a_notify_deact",
+  34: "input_b_counter", 35: "input_b_notify_act", 36: "input_b_notify_deact",
+  37: "corr_temperature", 38: "corr_t1_temperature", 39: "corr_t2_temperature",
+  40: "cap_hall_left", 41: "cap_hall_right", 42: "cap_input_a", 43: "cap_input_b",
+  44: "cap_light_sensor", 45: "cap_barometer", 46: "cap_pir_detector", 47: "cap_1w_thermometer", 48: "cap_1w_machine_probe"
+};
+var _LRW_NAMES = { 1: "region", 2: "network", 3: "adr", 4: "activation", 12: "sub_band" };
+var _LRW_HEX = { 5: "deveui", 6: "joineui", 9: "devaddr" };
+
+function _decodeLorawan(bytes, start, end) {
+  var o = {}, pos = start;
+  while (pos < end) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var f = tag.value >>> 3, w = tag.value & 0x7;
+    if (w === 0) {
+      var v = _pbReadVarint(bytes, pos); pos = v.next;
+      if (_LRW_NAMES[f]) o[_LRW_NAMES[f]] = v.value;
+    } else if (w === 2) {
+      var len = _pbReadVarint(bytes, pos); pos = len.next;
+      if (_LRW_HEX[f]) o[_LRW_HEX[f]] = _pbBytesToHex(bytes.slice(pos, pos + len.value));
+      pos += len.value;
+    } else { break; }
+  }
+  return o;
+}
+
+function _decodeApplication(bytes, start, end) {
+  var o = {}, pos = start;
+  while (pos < end) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var f = tag.value >>> 3, w = tag.value & 0x7;
+    if (w === 0) {
+      var v = _pbReadVarint(bytes, pos); pos = v.next;
+      if (_APP_NAMES[f]) o[_APP_NAMES[f]] = v.value;
+    } else if (w === 5) {
+      var fl = _pbReadFloat(bytes, pos); pos = fl.next;
+      if (_APP_NAMES[f]) o[_APP_NAMES[f]] = fl.value;
+    } else if (w === 2) {
+      var len = _pbReadVarint(bytes, pos); pos = len.next;
+      pos += len.value;
+    } else { break; }
+  }
+  return o;
+}
+
+function _decodeConfigDump(bytes, start, end) {
+  var cd = {}, pos = start;
+  while (pos < end) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var f = tag.value >>> 3, w = tag.value & 0x7;
+    if (w === 0) {
+      var v = _pbReadVarint(bytes, pos); pos = v.next;
+      if (f === 1) cd.page_index = v.value;
+      else if (f === 2) cd.page_count = v.value;
+    } else if (w === 2) {
+      var len = _pbReadVarint(bytes, pos); pos = len.next;
+      var e2 = pos + len.value;
+      if (f === 3) cd.lorawan = _decodeLorawan(bytes, pos, e2);
+      else if (f === 4) cd.application = _decodeApplication(bytes, pos, e2);
+      pos = e2;
+    } else { break; }
+  }
+  return cd;
+}
 
 function _decodeInfo(bytes, start, end) {
   var info = { fw_major: 0, fw_minor: 0, fw_patch: 0, build_type: 0, debug: false };
@@ -102,6 +204,7 @@ function decodeDownlinkResponse(bytes) {
       var end = pos + len.value;
       if (field === 2) resp.ack = {};
       else if (field === 3) resp.info = _decodeInfo(bytes, pos, end);
+      else if (field === 4) resp.config_dump = _decodeConfigDump(bytes, pos, end);
       else if (field === 6) resp.error = _decodeError(bytes, pos, end);
       pos = end;
     } else {

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -81,6 +81,38 @@ var _APP_NAMES = {
 var _LRW_NAMES = { 1: "region", 2: "network", 3: "adr", 4: "activation", 12: "sub_band" };
 var _LRW_HEX = { 5: "deveui", 6: "joineui", 9: "devaddr" };
 
+// Application tags carrying a float32 (protobuf wire type 5): alarm thresholds
+// and the correction offsets. Everything else in Application is a varint.
+var _APP_FLOAT = {
+  6: 1, 7: 1, 8: 1, 10: 1, 11: 1, 12: 1, 14: 1, 15: 1, 16: 1,
+  18: 1, 19: 1, 20: 1, 22: 1, 23: 1, 24: 1, 37: 1, 38: 1, 39: 1
+};
+
+// Reverse maps (name -> tag) for encoding SetParam. The LoRaWAN hex set adds the
+// secret keys (nwkkey/appkey/nwkskey/appskey) which the decoder deliberately
+// hides but which a downlink may legitimately set.
+var _LRW_HEX_ENC = { deveui: 5, joineui: 6, nwkkey: 7, appkey: 8, devaddr: 9, nwkskey: 10, appskey: 11 };
+var _LRW_ENUM = {
+  region: { EU868: 0, US915: 1, AU915: 2 },
+  network: { PUBLIC: 0, PRIVATE: 1 },
+  activation: { OTAA: 0, ABP: 1 }
+};
+function _invert(map) {
+  var out = {};
+  for (var k in map) { if (map.hasOwnProperty(k)) out[map[k]] = +k; }
+  return out;
+}
+var _APP_TAGS = _invert(_APP_NAMES);
+var _LRW_TAGS = _invert(_LRW_NAMES);
+
+// proto field tag -> command name in the DownlinkCommand body oneof.
+var _CMD_NAMES = {
+  2: "set_param", 3: "get_param", 4: "get_info", 5: "get_config",
+  6: "settings_save", 7: "reboot", 8: "factory_reset", 9: "force_send",
+  10: "reset_counters", 11: "req_history", 12: "clock_sync"
+};
+var _CMD_TAGS = _invert(_CMD_NAMES);
+
 function _decodeLorawan(bytes, start, end) {
   var o = {}, pos = start;
   while (pos < end) {
@@ -301,6 +333,263 @@ function decodeTelemetry(bytes) {
     }
   }
   return d;
+}
+
+// ---------------------------------------------------------------------------
+// Downlink encoding: build a DownlinkCommand (protobuf) on fPort 85 from a
+// human-friendly JSON object. Mirrors the dispatcher in app_cmd.c.
+//
+// Examples (the object passed as input.data):
+//   { "command": "get_info", "seq": 1 }
+//   { "command": "force_send" }
+//   { "command": "clock_sync" }
+//   { "command": "reboot" }                 // also settings_save / factory_reset
+//   { "command": "reset_counters", "hall_left": true, "input_a": true }
+//   { "command": "get_config", "page": 0 }
+//   { "command": "req_history", "from_unix": 1780000000, "to_unix": 1780003600 }
+//   { "command": "get_param", "lorawan_field": [3], "application_field": [4, 7] }
+//   { "command": "set_param", "seq": 5,
+//     "lorawan": { "adr": true },
+//     "application": { "interval_report": 120, "alarm_temperature_hi": 50.0 } }
+// ---------------------------------------------------------------------------
+
+function _encVarint(value) {
+  var out = [];
+  var v = value >>> 0;
+  // Handle values above 2^31 (e.g. unix time) via Math, not bit ops.
+  if (value > 0xffffffff || value < 0) {
+    v = Math.floor(value);
+    while (v > 127) { out.push((v % 128) + 128); v = Math.floor(v / 128); }
+    out.push(v);
+    return out;
+  }
+  while (v > 127) { out.push((v & 0x7f) | 0x80); v >>>= 7; }
+  out.push(v);
+  return out;
+}
+
+function _encTag(field, wire) {
+  return _encVarint((field << 3) | wire);
+}
+
+// Manual IEEE-754 float32 little-endian encoder (no DataView — sandbox-safe).
+function _encFloat(value) {
+  if (value === 0) {
+    var negZero = (1 / value) === -Infinity;
+    return [0, 0, 0, negZero ? 0x80 : 0];
+  }
+  var sign = 0;
+  if (value < 0) { sign = 1; value = -value; }
+  var exp = Math.floor(Math.log(value) / Math.LN2);
+  var mant = value / Math.pow(2, exp);
+  if (mant < 1) { exp--; mant = value / Math.pow(2, exp); }
+  if (mant >= 2) { exp++; mant = value / Math.pow(2, exp); }
+  var e = exp + 127, m;
+  if (e <= 0) {
+    m = Math.round(value / Math.pow(2, -126) * Math.pow(2, 23));
+    e = 0;
+  } else if (e >= 255) {
+    e = 255; m = 0;
+  } else {
+    m = Math.round((mant - 1) * Math.pow(2, 23));
+    if (m === 0x800000) { m = 0; e++; }
+  }
+  var bits = ((sign << 31) | (e << 23) | m) >>> 0;
+  return [bits & 0xff, (bits >>> 8) & 0xff, (bits >>> 16) & 0xff, (bits >>> 24) & 0xff];
+}
+
+function _encLenDelim(field, payload) {
+  return _encTag(field, 2).concat(_encVarint(payload.length)).concat(payload);
+}
+
+function _hexToBytes(hex) {
+  var out = [];
+  for (var i = 0; i + 1 < hex.length; i += 2) {
+    out.push(parseInt(hex.substr(i, 2), 16));
+  }
+  return out;
+}
+
+function _encLorawan(lrw) {
+  var out = [];
+  for (var name in lrw) {
+    if (!lrw.hasOwnProperty(name)) continue;
+    var val = lrw[name];
+    if (_LRW_HEX_ENC[name] !== undefined) {
+      out = out.concat(_encLenDelim(_LRW_HEX_ENC[name], _hexToBytes(val)));
+    } else if (_LRW_TAGS[name] !== undefined) {
+      var num = val;
+      if (typeof val === "string" && _LRW_ENUM[name]) num = _LRW_ENUM[name][val];
+      if (typeof val === "boolean") num = val ? 1 : 0;
+      out = out.concat(_encTag(_LRW_TAGS[name], 0)).concat(_encVarint(num));
+    }
+  }
+  return out;
+}
+
+function _encApplication(app) {
+  var out = [];
+  for (var name in app) {
+    if (!app.hasOwnProperty(name)) continue;
+    var tag = _APP_TAGS[name];
+    if (tag === undefined) continue;
+    var val = app[name];
+    if (_APP_FLOAT[tag]) {
+      out = out.concat(_encTag(tag, 5)).concat(_encFloat(val));
+    } else {
+      var num = (typeof val === "boolean") ? (val ? 1 : 0) : val;
+      out = out.concat(_encTag(tag, 0)).concat(_encVarint(num));
+    }
+  }
+  return out;
+}
+
+function encodeDownlinkCommand(cmd) {
+  var out = [];
+  if (cmd.seq) out = out.concat(_encTag(1, 0)).concat(_encVarint(cmd.seq));
+
+  var name = cmd.command;
+  var tag = _CMD_TAGS[name];
+  if (tag === undefined) {
+    return { bytes: null, error: "unknown command: " + name };
+  }
+
+  var body = [];
+  if (name === "set_param") {
+    if (cmd.lorawan) body = body.concat(_encLenDelim(1, _encLorawan(cmd.lorawan)));
+    if (cmd.application) body = body.concat(_encLenDelim(2, _encApplication(cmd.application)));
+  } else if (name === "get_param") {
+    // proto3 repeated scalars are packed (length-delimited) by default.
+    var lf = cmd.lorawan_field || [];
+    var af = cmd.application_field || [];
+    if (lf.length) {
+      var pl = [];
+      for (var i = 0; i < lf.length; i++) pl = pl.concat(_encVarint(lf[i]));
+      body = body.concat(_encLenDelim(1, pl));
+    }
+    if (af.length) {
+      var pa = [];
+      for (var j = 0; j < af.length; j++) pa = pa.concat(_encVarint(af[j]));
+      body = body.concat(_encLenDelim(2, pa));
+    }
+  } else if (name === "get_config") {
+    if (cmd.page) body = body.concat(_encTag(1, 0)).concat(_encVarint(cmd.page));
+  } else if (name === "reset_counters") {
+    if (cmd.hall_left) body = body.concat(_encTag(1, 0)).concat(_encVarint(1));
+    if (cmd.hall_right) body = body.concat(_encTag(2, 0)).concat(_encVarint(1));
+    if (cmd.input_a) body = body.concat(_encTag(3, 0)).concat(_encVarint(1));
+    if (cmd.input_b) body = body.concat(_encTag(4, 0)).concat(_encVarint(1));
+  } else if (name === "req_history") {
+    if (cmd.from_unix) body = body.concat(_encTag(1, 0)).concat(_encVarint(cmd.from_unix));
+    if (cmd.to_unix) body = body.concat(_encTag(2, 0)).concat(_encVarint(cmd.to_unix));
+  }
+  // get_info / settings_save / reboot / factory_reset / force_send / clock_sync: empty body.
+
+  out = out.concat(_encLenDelim(tag, body));
+  return { bytes: out, error: null };
+}
+
+function encodeDownlink(input) {
+  var cmd = input.data || {};
+  var r = encodeDownlinkCommand(cmd);
+  if (r.error) {
+    return { bytes: [], fPort: 85, warnings: [], errors: [r.error] };
+  }
+  return { bytes: r.bytes, fPort: 85, warnings: [], errors: [] };
+}
+
+// Decode a DownlinkCommand (so the LNS shows queued/sent downlinks readably).
+function decodeDownlinkCommand(bytes) {
+  var cmd = {};
+  var pos = 0;
+  while (pos < bytes.length) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var field = tag.value >>> 3, wire = tag.value & 0x7;
+    if (wire === 0) {
+      var v = _pbReadVarint(bytes, pos); pos = v.next;
+      if (field === 1) cmd.seq = v.value;
+    } else if (wire === 2) {
+      var len = _pbReadVarint(bytes, pos); pos = len.next;
+      var end = pos + len.value;
+      cmd.command = _CMD_NAMES[field] || ("field_" + field);
+      if (field === 2) { // set_param
+        var sp = {}, p = pos;
+        while (p < end) {
+          var t = _pbReadVarint(bytes, p); p = t.next;
+          var f2 = t.value >>> 3, w2 = t.value & 0x7;
+          if (w2 === 2) {
+            var l2 = _pbReadVarint(bytes, p); p = l2.next;
+            if (f2 === 1) sp.lorawan = _decodeLorawan(bytes, p, p + l2.value);
+            else if (f2 === 2) sp.application = _decodeApplication(bytes, p, p + l2.value);
+            p += l2.value;
+          } else { break; }
+        }
+        cmd.set_param = sp;
+      } else if (field === 3) { // get_param (repeated uint32, packed or not)
+        var gp = { lorawan_field: [], application_field: [] }, q = pos;
+        while (q < end) {
+          var t3 = _pbReadVarint(bytes, q); q = t3.next;
+          var f3 = t3.value >>> 3, w3 = t3.value & 0x7;
+          var dst = (f3 === 1) ? gp.lorawan_field : (f3 === 2) ? gp.application_field : null;
+          if (w3 === 0) {
+            var v3 = _pbReadVarint(bytes, q); q = v3.next;
+            if (dst) dst.push(v3.value);
+          } else if (w3 === 2) {
+            var pl3 = _pbReadVarint(bytes, q); q = pl3.next;
+            var e3 = q + pl3.value;
+            while (q < e3) { var pv = _pbReadVarint(bytes, q); q = pv.next; if (dst) dst.push(pv.value); }
+          } else { break; }
+        }
+        cmd.get_param = gp;
+      } else if (field === 5) { // get_config
+        var gc = {}, r2 = pos;
+        if (r2 < end) {
+          var t5 = _pbReadVarint(bytes, r2); r2 = t5.next;
+          if ((t5.value >>> 3) === 1 && (t5.value & 0x7) === 0) {
+            var v5 = _pbReadVarint(bytes, r2); gc.page = v5.value;
+          }
+        }
+        cmd.get_config = gc;
+      } else if (field === 10) { // reset_counters
+        var rc = {}, s = pos;
+        while (s < end) {
+          var t10 = _pbReadVarint(bytes, s); s = t10.next;
+          var f10 = t10.value >>> 3, w10 = t10.value & 0x7;
+          if (w10 === 0) {
+            var v10 = _pbReadVarint(bytes, s); s = v10.next;
+            if (f10 === 1) rc.hall_left = v10.value !== 0;
+            else if (f10 === 2) rc.hall_right = v10.value !== 0;
+            else if (f10 === 3) rc.input_a = v10.value !== 0;
+            else if (f10 === 4) rc.input_b = v10.value !== 0;
+          } else { break; }
+        }
+        cmd.reset_counters = rc;
+      } else if (field === 11) { // req_history
+        var rh = {}, u = pos;
+        while (u < end) {
+          var t11 = _pbReadVarint(bytes, u); u = t11.next;
+          var f11 = t11.value >>> 3, w11 = t11.value & 0x7;
+          if (w11 === 0) {
+            var v11 = _pbReadVarint(bytes, u); u = v11.next;
+            if (f11 === 1) rh.from_unix = v11.value;
+            else if (f11 === 2) rh.to_unix = v11.value;
+          } else { break; }
+        }
+        cmd.req_history = rh;
+      }
+      pos = end;
+    } else {
+      break;
+    }
+  }
+  return cmd;
+}
+
+function decodeDownlink(input) {
+  if (input.fPort === 85) {
+    return { data: decodeDownlinkCommand(input.bytes), warnings: [], errors: [] };
+  }
+  return { data: { bytes_hex: _pbBytesToHex(input.bytes) }, warnings: [], errors: [] };
 }
 
 function decodeUplink(input) {

--- a/app/src/app_clock.c
+++ b/app/src/app_clock.c
@@ -71,6 +71,13 @@ void app_clock_request_sync(void)
 #endif /* defined(CONFIG_LORAWAN) */
 }
 
+void app_clock_force_resync(void)
+{
+	/* Drop the guard so a fresh DeviceTimeReq is queued even if already synced. */
+	m_time_synced = false;
+	app_clock_request_sync();
+}
+
 void app_clock_handle_downlink(uint8_t flags)
 {
 #if defined(CONFIG_LORAWAN)

--- a/app/src/app_clock.h
+++ b/app/src/app_clock.h
@@ -23,6 +23,10 @@ int app_clock_init(void);
  * app_clock_handle_downlink(). No-op when CONFIG_LORAWAN is disabled. */
 void app_clock_request_sync(void);
 
+/* Force a re-sync: clear the synced guard and request DeviceTimeReq again.
+ * Used by the ClockSync downlink command. No-op when CONFIG_LORAWAN is off. */
+void app_clock_force_resync(void);
+
 /* Inspect a downlink's flags; if LORAWAN_TIME_UPDATED is set, read the network
  * time and set the RTC from it. Call from the LoRaWAN downlink callback.
  * No-op when CONFIG_LORAWAN is disabled. */

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -6,7 +6,11 @@
 
 #include "app_cmd.h"
 #include "app_config.h"
+#include "app_hall.h"
+#include "app_input.h"
 #include "app_log.h"
+#include "app_lrw.h"
+#include "app_nfc_ingest.h"
 
 /* Wall-clock source (PR #41, branch lrw-rtc-time). Until that lands on this
  * branch, app_clock.h is absent and Info.unix_time stays 0 (omitted by proto3).
@@ -77,8 +81,54 @@ static void make_error(DownlinkResponse *resp, DownlinkResponse_Error_Code code,
 	}
 }
 
+static void handle_set_param(const DownlinkCommand_SetParam *sp, DownlinkResponse *resp)
+{
+	uint32_t fault = 0;
+	int rc = 0;
+
+	if (sp->has_lorawan) {
+		rc = app_config_apply_lorawan(&sp->lorawan, &fault);
+	}
+	if (rc == 0 && sp->has_application) {
+		rc = app_config_apply_application(&sp->application, &fault);
+	}
+
+	if (rc) {
+		make_error(resp, DownlinkResponse_Error_Code_OUT_OF_RANGE, "invalid value");
+		resp->body.error.fault_field = fault;
+	} else {
+		resp->which_body = DownlinkResponse_ack_tag;
+	}
+}
+
+static void handle_get_param(const DownlinkCommand_GetParam *gp, DownlinkResponse *resp)
+{
+	resp->which_body = DownlinkResponse_config_dump_tag;
+	resp->body.config_dump.page_index = 0;
+	resp->body.config_dump.page_count = 1;
+
+	if (gp->lorawan_field_count > 0) {
+		resp->body.config_dump.has_lorawan = true;
+		app_config_fill_lorawan(&resp->body.config_dump.lorawan, gp->lorawan_field,
+					gp->lorawan_field_count);
+	}
+	if (gp->application_field_count > 0) {
+		resp->body.config_dump.has_application = true;
+		app_config_fill_application(&resp->body.config_dump.application,
+					    gp->application_field, gp->application_field_count);
+	}
+}
+
+static void handle_reset_counters(const DownlinkCommand_ResetCounters *rc, DownlinkResponse *resp)
+{
+	app_hall_reset_count(rc->has_hall_left && rc->hall_left,
+			     rc->has_hall_right && rc->hall_right);
+	app_input_reset_count(rc->has_input_a && rc->input_a, rc->has_input_b && rc->input_b);
+	resp->which_body = DownlinkResponse_ack_tag;
+}
+
 static void dispatch(enum app_cmd_transport transport, const DownlinkCommand *cmd,
-		     DownlinkResponse *resp)
+		     DownlinkResponse *resp, enum app_cmd_action *action)
 {
 	ARG_UNUSED(transport);
 
@@ -90,22 +140,63 @@ static void dispatch(enum app_cmd_transport transport, const DownlinkCommand *cm
 		fill_info(&resp->body.info);
 		break;
 
+	case DownlinkCommand_set_param_tag:
+		handle_set_param(&cmd->body.set_param, resp);
+		break;
+
+	case DownlinkCommand_get_param_tag:
+		handle_get_param(&cmd->body.get_param, resp);
+		break;
+
+	case DownlinkCommand_settings_save_tag:
+		resp->which_body = DownlinkResponse_ack_tag;
+		*action = APP_CMD_ACTION_SETTINGS_SAVE;
+		break;
+
+	case DownlinkCommand_reboot_tag:
+		resp->which_body = DownlinkResponse_ack_tag;
+		*action = APP_CMD_ACTION_REBOOT;
+		break;
+
+	case DownlinkCommand_factory_reset_tag:
+		resp->which_body = DownlinkResponse_ack_tag;
+		*action = APP_CMD_ACTION_FACTORY_RESET;
+		break;
+
+	case DownlinkCommand_force_send_tag:
+#if defined(CONFIG_LORAWAN)
+		app_lrw_send();
+#endif
+		resp->which_body = DownlinkResponse_ack_tag;
+		break;
+
+	case DownlinkCommand_reset_counters_tag:
+		handle_reset_counters(&cmd->body.reset_counters, resp);
+		break;
+
+	case DownlinkCommand_clock_sync_tag:
+#ifdef APP_CMD_HAVE_CLOCK
+		app_clock_force_resync();
+#endif
+		resp->which_body = DownlinkResponse_ack_tag;
+		break;
+
 	default:
-		LOG_WRN("Command tag %u not implemented in Phase 1", cmd->which_body);
-		make_error(resp, DownlinkResponse_Error_Code_UNKNOWN,
-			   "not implemented in phase 1");
+		LOG_WRN("Command tag %u not implemented", cmd->which_body);
+		make_error(resp, DownlinkResponse_Error_Code_UNKNOWN, "not implemented");
 		break;
 	}
 }
 
 int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t in_len,
-		   uint8_t *out, size_t out_cap, size_t *out_len)
+		   uint8_t *out, size_t out_cap, size_t *out_len, enum app_cmd_action *action)
 {
 	if (!in || !out || !out_len) {
 		return -EINVAL;
 	}
 
 	*out_len = 0;
+	enum app_cmd_action act = APP_CMD_ACTION_NONE;
 
 	DownlinkCommand cmd = DownlinkCommand_init_zero;
 	DownlinkResponse resp = DownlinkResponse_init_zero;
@@ -117,7 +208,7 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 		make_error(&resp, DownlinkResponse_Error_Code_BAD_REQUEST,
 			   PB_GET_ERROR(&istream));
 	} else {
-		dispatch(transport, &cmd, &resp);
+		dispatch(transport, &cmd, &resp, &act);
 	}
 
 	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
@@ -127,5 +218,8 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 	}
 
 	*out_len = ostream.bytes_written;
+	if (action) {
+		*action = act;
+	}
 	return 0;
 }

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -119,6 +119,91 @@ static void handle_get_param(const DownlinkCommand_GetParam *gp, DownlinkRespons
 	}
 }
 
+/* Dumpable config fields in fixed order, each with a conservative upper bound
+ * on its encoded size (field tag + value; hex fields include the length byte).
+ * Mirrors the non-secret fields emitted by app_config_fill_lorawan/application
+ * — a new config field needs a row here too (a codegen target once #44 lands).
+ * Drives get_config paging: greedy bin-pack into DR0-sized ConfigDump pages. */
+#define DUMP_SECTION_LORAWAN     0
+#define DUMP_SECTION_APPLICATION 1
+
+#define LRW(tag, size) {DUMP_SECTION_LORAWAN, (tag), (size)}
+#define APP2(tag)      {DUMP_SECTION_APPLICATION, (tag), 2}
+#define APP5(tag)      {DUMP_SECTION_APPLICATION, (tag), 5}
+
+static const struct {
+	uint8_t section;
+	uint8_t tag;
+	uint8_t size;
+} DUMP_FIELDS[] = {
+	/* Lorawan (non-secret): varints 2 B, deveui/joineui 18 B, devaddr 10 B */
+	LRW(1, 2), LRW(2, 2), LRW(3, 2), LRW(4, 2), LRW(5, 18), LRW(6, 18), LRW(9, 10), LRW(12, 2),
+	/* Application (tag 3 interval_aggreg has no config field — skipped, like
+	 * fill_application). Floats 5 B, everything else 2 B. */
+	APP2(1), APP2(2), APP2(4), APP2(5), APP5(6), APP5(7), APP5(8), APP2(9), APP5(10), APP5(11),
+	APP5(12), APP2(13), APP5(14), APP5(15), APP5(16), APP2(17), APP5(18), APP5(19), APP5(20),
+	APP2(21), APP5(22), APP5(23), APP5(24), APP2(25), APP2(26), APP2(27), APP2(28), APP2(29),
+	APP2(30), APP2(31), APP2(32), APP2(33), APP2(34), APP2(35), APP2(36), APP5(37), APP5(38),
+	APP5(39), APP2(40), APP2(41), APP2(42), APP2(43), APP2(44), APP2(45), APP2(46), APP2(47),
+	APP2(48),
+};
+
+/* Per-page byte budget for the field payload inside one ConfigDump. The encoded
+ * DownlinkResponse adds ~14 B of fixed overhead around these fields (seq +
+ * config_dump wrapper + page_index + page_count + the two submessage wrappers),
+ * so the on-air frame is roughly budget + 14. DR0 MTU is 51 B; 30 keeps the
+ * worst-case frame near 44 B with margin. Conservative — a page can never
+ * overflow (the largest single field is 18 B). */
+#define DUMP_PAGE_BUDGET 30
+
+static void handle_get_config(const DownlinkCommand_GetConfig *gc, DownlinkResponse *resp)
+{
+	uint32_t page = gc->has_page ? gc->page : 0;
+
+	uint32_t lrw_ids[8];
+	uint32_t app_ids[ARRAY_SIZE(DUMP_FIELDS)];
+	size_t n_lrw = 0, n_app = 0;
+
+	/* Single greedy pass: pack fields into pages by DUMP_PAGE_BUDGET, collect
+	 * the requested page's tags, and learn the total page count. */
+	uint32_t cur_page = 0, used = 0;
+	for (size_t i = 0; i < ARRAY_SIZE(DUMP_FIELDS); i++) {
+		if (used > 0 && used + DUMP_FIELDS[i].size > DUMP_PAGE_BUDGET) {
+			cur_page++;
+			used = 0;
+		}
+		used += DUMP_FIELDS[i].size;
+
+		if (cur_page == page) {
+			if (DUMP_FIELDS[i].section == DUMP_SECTION_LORAWAN) {
+				lrw_ids[n_lrw++] = DUMP_FIELDS[i].tag;
+			} else {
+				app_ids[n_app++] = DUMP_FIELDS[i].tag;
+			}
+		}
+	}
+	uint32_t page_count = cur_page + 1;
+
+	if (page >= page_count) {
+		make_error(resp, DownlinkResponse_Error_Code_OUT_OF_RANGE, "page");
+		resp->body.error.fault_field = 1;
+		return;
+	}
+
+	resp->which_body = DownlinkResponse_config_dump_tag;
+	resp->body.config_dump.page_index = page;
+	resp->body.config_dump.page_count = page_count;
+
+	if (n_lrw > 0) {
+		resp->body.config_dump.has_lorawan = true;
+		app_config_fill_lorawan(&resp->body.config_dump.lorawan, lrw_ids, n_lrw);
+	}
+	if (n_app > 0) {
+		resp->body.config_dump.has_application = true;
+		app_config_fill_application(&resp->body.config_dump.application, app_ids, n_app);
+	}
+}
+
 static void handle_reset_counters(const DownlinkCommand_ResetCounters *rc, DownlinkResponse *resp)
 {
 	app_hall_reset_count(rc->has_hall_left && rc->hall_left,
@@ -146,6 +231,10 @@ static void dispatch(enum app_cmd_transport transport, const DownlinkCommand *cm
 
 	case DownlinkCommand_get_param_tag:
 		handle_get_param(&cmd->body.get_param, resp);
+		break;
+
+	case DownlinkCommand_get_config_tag:
+		handle_get_config(&cmd->body.get_config, resp);
 		break;
 
 	case DownlinkCommand_settings_save_tag:

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -21,6 +21,15 @@ enum app_cmd_transport {
 	APP_CMD_TRANSPORT_SHELL_DEBUG,
 };
 
+/* Action the caller must perform AFTER the response has been sent (so the Ack
+ * leaves before the device reboots). Set by app_cmd_handle(). */
+enum app_cmd_action {
+	APP_CMD_ACTION_NONE = 0,
+	APP_CMD_ACTION_SETTINGS_SAVE, /* persist staged config + reboot */
+	APP_CMD_ACTION_REBOOT,        /* reboot (discards staged edits) */
+	APP_CMD_ACTION_FACTORY_RESET, /* erase NVS + reboot */
+};
+
 /* Decode a serialized DownlinkCommand from `in`, dispatch it, encode the
  * resulting DownlinkResponse into `out`.
  *
@@ -31,10 +40,15 @@ enum app_cmd_transport {
  *
  * On decode failure the function still returns 0 and encodes a
  * DownlinkResponse{ seq=0, error={ code=BAD_REQUEST } } into out.
+ *
+ * *action (if non-NULL) is set to a deferred action the caller must run after
+ * transmitting the response (reboot/save/factory-reset). APP_CMD_ACTION_NONE
+ * otherwise.
  */
 int app_cmd_handle(enum app_cmd_transport transport,
 		   const uint8_t *in, size_t in_len,
-		   uint8_t *out, size_t out_cap, size_t *out_len);
+		   uint8_t *out, size_t out_cap, size_t *out_len,
+		   enum app_cmd_action *action);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_hall.c
+++ b/app/src/app_hall.c
@@ -283,10 +283,19 @@ void app_hall_clear_notify_flags(struct app_hall_data *data)
 	k_mutex_unlock(&m_hall_data_mutex);
 }
 
-void app_hall_reset_counts(void)
+void app_hall_reset_count(bool left, bool right)
 {
 	k_mutex_lock(&m_hall_data_mutex, K_FOREVER);
-	m_hall_data.left_count = 0;
-	m_hall_data.right_count = 0;
+	if (left) {
+		m_hall_data.left_count = 0;
+	}
+	if (right) {
+		m_hall_data.right_count = 0;
+	}
 	k_mutex_unlock(&m_hall_data_mutex);
+}
+
+void app_hall_reset_counts(void)
+{
+	app_hall_reset_count(true, true);
 }

--- a/app/src/app_hall.h
+++ b/app/src/app_hall.h
@@ -31,6 +31,7 @@ int app_hall_get_data(struct app_hall_data *data);
 int app_hall_get_data_and_clear_notify(struct app_hall_data *data);
 void app_hall_clear_notify_flags(struct app_hall_data *data);
 void app_hall_reset_counts(void);
+void app_hall_reset_count(bool left, bool right);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_input.c
+++ b/app/src/app_input.c
@@ -236,10 +236,19 @@ void app_input_clear_notify_flags(struct app_input_data *data)
 	k_mutex_unlock(&m_input_data_mutex);
 }
 
-void app_input_reset_counts(void)
+void app_input_reset_count(bool input_a, bool input_b)
 {
 	k_mutex_lock(&m_input_data_mutex, K_FOREVER);
-	m_input_data.input_a_count = 0;
-	m_input_data.input_b_count = 0;
+	if (input_a) {
+		m_input_data.input_a_count = 0;
+	}
+	if (input_b) {
+		m_input_data.input_b_count = 0;
+	}
 	k_mutex_unlock(&m_input_data_mutex);
+}
+
+void app_input_reset_counts(void)
+{
+	app_input_reset_count(true, true);
 }

--- a/app/src/app_input.h
+++ b/app/src/app_input.h
@@ -31,6 +31,7 @@ int app_input_get_data(struct app_input_data *data);
 int app_input_get_data_and_clear_notify(struct app_input_data *data);
 void app_input_clear_notify_flags(struct app_input_data *data);
 void app_input_reset_counts(void);
+void app_input_reset_count(bool input_a, bool input_b);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -14,6 +14,7 @@
 #include "app_log.h"
 #include "app_lrw.h"
 #include "app_sensor.h"
+#include "app_settings.h"
 
 /* Zephyr includes */
 #include <zephyr/device.h>
@@ -25,6 +26,7 @@
 #include <zephyr/settings/settings.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/reboot.h>
 
 /* LoRaMac includes */
 #include <LoRaMac.h>
@@ -131,6 +133,10 @@ static uint8_t m_dl_request_buf[APP_LRW_REQUEST_BUF_SIZE];
 static size_t  m_dl_request_len;
 static struct k_work m_dl_request_work;
 
+/* Deferred reboot/save requested by a command handler; runs after the Ack TX. */
+static struct k_work_delayable m_post_cmd_work;
+static enum app_cmd_action m_post_cmd_action;
+
 
 static uint32_t calculate_rejoin_backoff(int attempt)
 {
@@ -161,15 +167,38 @@ static void downlink_success_work_handler(struct k_work *work)
 	}
 }
 
+static void post_cmd_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	switch (m_post_cmd_action) {
+	case APP_CMD_ACTION_SETTINGS_SAVE:
+		LOG_INF("Command: saving settings + reboot");
+		app_settings_save(true);
+		break;
+	case APP_CMD_ACTION_FACTORY_RESET:
+		LOG_INF("Command: factory reset + reboot");
+		app_settings_reset();
+		break;
+	case APP_CMD_ACTION_REBOOT:
+		LOG_INF("Command: reboot");
+		sys_reboot(SYS_REBOOT_COLD);
+		break;
+	default:
+		break;
+	}
+}
+
 static void dl_request_work_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
 
 	static uint8_t resp[APP_LRW_RESPONSE_BUF_SIZE];
 	size_t resp_len = 0;
+	enum app_cmd_action action = APP_CMD_ACTION_NONE;
 
 	int ret = app_cmd_handle(APP_CMD_TRANSPORT_LRW, m_dl_request_buf, m_dl_request_len,
-				 resp, sizeof(resp), &resp_len);
+				 resp, sizeof(resp), &resp_len, &action);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("app_cmd_handle", ret);
 		return;
@@ -180,6 +209,13 @@ static void dl_request_work_handler(struct k_work *work)
 		if (ret) {
 			LOG_ERR_CALL_FAILED_INT("app_lrw_queue_response", ret);
 		}
+	}
+
+	/* Defer reboot/save so the Ack uplink + its RX window finish first. */
+	if (action != APP_CMD_ACTION_NONE) {
+		m_post_cmd_action = action;
+		k_work_schedule_for_queue(&m_work_q, &m_post_cmd_work, K_SECONDS(8));
+		LOG_INF("Post-command action %d scheduled in 8s", (int)action);
 	}
 
 	/* Diagnostic: stack headroom after the heaviest work this queue runs.
@@ -886,6 +922,7 @@ int app_lrw_init(void)
 	k_work_init(&m_lc_response_work, lc_response_work_handler);
 	k_work_init(&m_send_with_lc_work, send_with_lc_work_handler);
 	k_work_init(&m_dl_request_work, dl_request_work_handler);
+	k_work_init_delayable(&m_post_cmd_work, post_cmd_work_handler);
 	k_work_init_delayable(&m_join_complete_work, join_complete_work_handler);
 
 	k_timer_init(&m_send_timer, send_timer_handler, NULL);

--- a/app/src/app_nfc_ingest.c
+++ b/app/src/app_nfc_ingest.c
@@ -13,11 +13,38 @@
 #include <zephyr/sys/util.h>
 
 /* Standard includes */
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 
 LOG_MODULE_REGISTER(app_nfc_ingest, LOG_LEVEL_DBG);
+
+/* Record the first offending proto field tag and mark the result invalid. The
+ * apply still processes the remaining fields (best effort) so NFC ingest keeps
+ * its "skip invalid, apply the rest" behaviour; SetParam inspects fault_field. */
+#define FAULT(tag)                                                                                 \
+	do {                                                                                       \
+		if (fault_field && *fault_field == 0) {                                            \
+			*fault_field = (tag);                                                      \
+		}                                                                                  \
+		ret = -EINVAL;                                                                     \
+	} while (0)
+
+#define APPLY_BOOL(field)                                                                          \
+	if (src->has_##field) {                                                                    \
+		config->field = src->field;                                                        \
+	}
+
+#define APPLY_FLOAT(field, lo, hi, tag)                                                            \
+	if (src->has_##field) {                                                                    \
+		if (src->field >= (lo) && src->field <= (hi)) {                                    \
+			config->field = src->field;                                                \
+		} else {                                                                           \
+			LOG_WRN("Invalid " #field);                                                 \
+			FAULT(tag);                                                                \
+		}                                                                                  \
+	}
 
 static bool parse_hex_string(const char *hex_str, uint8_t *buf, size_t buf_len)
 {
@@ -40,542 +67,305 @@ static bool parse_hex_string(const char *hex_str, uint8_t *buf, size_t buf_len)
 	return true;
 }
 
-bool app_nfc_ingest(const NfcConfigMessage *message)
+int app_config_apply_lorawan(const NfcConfigMessage_Lorawan *src, uint32_t *fault_field)
 {
 	struct app_config *config = app_config();
+	int ret = 0;
 
+	if (fault_field) {
+		*fault_field = 0;
+	}
+
+	if (src->has_region) {
+		if ((int)src->region >= 0 && (int)src->region <= (int)APP_CONFIG_LRW_REGION_AU915) {
+			config->lrw_region = (enum app_config_lrw_region)src->region;
+		} else {
+			FAULT(1);
+		}
+	}
+	if (src->has_network) {
+		if ((int)src->network >= 0 &&
+		    (int)src->network <= (int)APP_CONFIG_LRW_NETWORK_PRIVATE) {
+			config->lrw_network = (enum app_config_lrw_network)src->network;
+		} else {
+			FAULT(2);
+		}
+	}
+	if (src->has_adr) {
+		config->lrw_adr = src->adr;
+	}
+	if (src->has_activation) {
+		if ((int)src->activation >= 0 &&
+		    (int)src->activation <= (int)APP_CONFIG_LRW_ACTIVATION_ABP) {
+			config->lrw_activation = (enum app_config_lrw_activation)src->activation;
+		} else {
+			FAULT(4);
+		}
+	}
+	if (src->has_deveui &&
+	    !parse_hex_string(src->deveui, config->lrw_deveui, sizeof(config->lrw_deveui))) {
+		FAULT(5);
+	}
+	if (src->has_joineui &&
+	    !parse_hex_string(src->joineui, config->lrw_joineui, sizeof(config->lrw_joineui))) {
+		FAULT(6);
+	}
+	if (src->has_nwkkey &&
+	    !parse_hex_string(src->nwkkey, config->lrw_nwkkey, sizeof(config->lrw_nwkkey))) {
+		FAULT(7);
+	}
+	if (src->has_appkey &&
+	    !parse_hex_string(src->appkey, config->lrw_appkey, sizeof(config->lrw_appkey))) {
+		FAULT(8);
+	}
+	if (src->has_devaddr &&
+	    !parse_hex_string(src->devaddr, config->lrw_devaddr, sizeof(config->lrw_devaddr))) {
+		FAULT(9);
+	}
+	if (src->has_nwkskey &&
+	    !parse_hex_string(src->nwkskey, config->lrw_nwkskey, sizeof(config->lrw_nwkskey))) {
+		FAULT(10);
+	}
+	if (src->has_appskey &&
+	    !parse_hex_string(src->appskey, config->lrw_appskey, sizeof(config->lrw_appskey))) {
+		FAULT(11);
+	}
+	if (src->has_sub_band) {
+		if (src->sub_band <= 8) {
+			config->lrw_sub_band = (int)src->sub_band;
+		} else {
+			FAULT(12);
+		}
+	}
+
+	return ret;
+}
+
+int app_config_apply_application(const NfcConfigMessage_Application *src, uint32_t *fault_field)
+{
+	struct app_config *config = app_config();
+	int ret = 0;
+
+	if (fault_field) {
+		*fault_field = 0;
+	}
+
+	APPLY_BOOL(calibration);
+
+	if (src->has_interval_sample) {
+		int val = src->interval_sample;
+
+		if (val == 0 || (val >= 5 && val <= 3600)) {
+			config->interval_sample = val;
+		} else {
+			FAULT(2);
+		}
+	}
+	/* interval_aggreg (tag 3) has no app_config counterpart — unsupported */
+	if (src->has_interval_report) {
+		int val = src->interval_report;
+
+		if (val >= 60 && val <= 86400) {
+			config->interval_report = val;
+		} else {
+			FAULT(4);
+		}
+	}
+
+	APPLY_BOOL(alarm_temperature_enabled);
+	APPLY_FLOAT(alarm_temperature_lo, -30.0f, 70.0f, 6);
+	APPLY_FLOAT(alarm_temperature_hi, -30.0f, 70.0f, 7);
+	APPLY_FLOAT(alarm_temperature_hst, 0.0f, 5.0f, 8);
+	APPLY_BOOL(alarm_humidity_enabled);
+	APPLY_FLOAT(alarm_humidity_lo, 0.0f, 100.0f, 10);
+	APPLY_FLOAT(alarm_humidity_hi, 0.0f, 100.0f, 11);
+	APPLY_FLOAT(alarm_humidity_hst, 0.0f, 20.0f, 12);
+	APPLY_BOOL(alarm_pressure_enabled);
+	APPLY_FLOAT(alarm_pressure_lo, 500.0f, 1200.0f, 14);
+	APPLY_FLOAT(alarm_pressure_hi, 500.0f, 1200.0f, 15);
+	APPLY_FLOAT(alarm_pressure_hst, 0.0f, 50.0f, 16);
+	APPLY_BOOL(alarm_t1_temperature_enabled);
+	APPLY_FLOAT(alarm_t1_temperature_lo, -30.0f, 70.0f, 18);
+	APPLY_FLOAT(alarm_t1_temperature_hi, -30.0f, 70.0f, 19);
+	APPLY_FLOAT(alarm_t1_temperature_hst, 0.0f, 5.0f, 20);
+	APPLY_BOOL(alarm_t2_temperature_enabled);
+	APPLY_FLOAT(alarm_t2_temperature_lo, -30.0f, 70.0f, 22);
+	APPLY_FLOAT(alarm_t2_temperature_hi, -30.0f, 70.0f, 23);
+	APPLY_FLOAT(alarm_t2_temperature_hst, 0.0f, 5.0f, 24);
+
+	APPLY_BOOL(hall_left_counter);
+	APPLY_BOOL(hall_left_notify_act);
+	APPLY_BOOL(hall_left_notify_deact);
+	APPLY_BOOL(hall_right_counter);
+	APPLY_BOOL(hall_right_notify_act);
+	APPLY_BOOL(hall_right_notify_deact);
+	APPLY_BOOL(input_a_counter);
+	APPLY_BOOL(input_a_notify_act);
+	APPLY_BOOL(input_a_notify_deact);
+	APPLY_BOOL(input_b_counter);
+	APPLY_BOOL(input_b_notify_act);
+	APPLY_BOOL(input_b_notify_deact);
+
+	APPLY_FLOAT(corr_temperature, -5.0f, 5.0f, 37);
+	APPLY_FLOAT(corr_t1_temperature, -5.0f, 5.0f, 38);
+	APPLY_FLOAT(corr_t2_temperature, -5.0f, 5.0f, 39);
+
+	APPLY_BOOL(cap_hall_left);
+	APPLY_BOOL(cap_hall_right);
+	APPLY_BOOL(cap_input_a);
+	APPLY_BOOL(cap_input_b);
+	APPLY_BOOL(cap_light_sensor);
+	APPLY_BOOL(cap_barometer);
+	APPLY_BOOL(cap_pir_detector);
+	APPLY_BOOL(cap_1w_thermometer);
+	APPLY_BOOL(cap_1w_machine_probe);
+
+	/* Cross-validate alarm lo/hi pairs — disable the alarm if lo >= hi */
+	if (config->alarm_temperature_lo >= config->alarm_temperature_hi) {
+		config->alarm_temperature_enabled = false;
+	}
+	if (config->alarm_humidity_lo >= config->alarm_humidity_hi) {
+		config->alarm_humidity_enabled = false;
+	}
+	if (config->alarm_pressure_lo >= config->alarm_pressure_hi) {
+		config->alarm_pressure_enabled = false;
+	}
+	if (config->alarm_t1_temperature_lo >= config->alarm_t1_temperature_hi) {
+		config->alarm_t1_temperature_enabled = false;
+	}
+	if (config->alarm_t2_temperature_lo >= config->alarm_t2_temperature_hi) {
+		config->alarm_t2_temperature_enabled = false;
+	}
+
+	return ret;
+}
+
+static bool requested(const uint32_t *ids, size_t n, uint32_t tag)
+{
+	for (size_t i = 0; i < n; i++) {
+		if (ids[i] == tag) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void app_config_fill_lorawan(NfcConfigMessage_Lorawan *dst, const uint32_t *ids, size_t n)
+{
+	const struct app_config *c = app_config();
+
+	if (requested(ids, n, 1)) {
+		dst->has_region = true;
+		dst->region = (NfcConfigMessage_Lorawan_Region)c->lrw_region;
+	}
+	if (requested(ids, n, 2)) {
+		dst->has_network = true;
+		dst->network = (NfcConfigMessage_Lorawan_Network)c->lrw_network;
+	}
+	if (requested(ids, n, 3)) {
+		dst->has_adr = true;
+		dst->adr = c->lrw_adr;
+	}
+	if (requested(ids, n, 4)) {
+		dst->has_activation = true;
+		dst->activation = (NfcConfigMessage_Lorawan_Activation)c->lrw_activation;
+	}
+	if (requested(ids, n, 5)) {
+		dst->has_deveui = true;
+		bin2hex(c->lrw_deveui, sizeof(c->lrw_deveui), dst->deveui, sizeof(dst->deveui));
+	}
+	if (requested(ids, n, 6)) {
+		dst->has_joineui = true;
+		bin2hex(c->lrw_joineui, sizeof(c->lrw_joineui), dst->joineui, sizeof(dst->joineui));
+	}
+	/* nwkkey/appkey/nwkskey/appskey (tags 7,8,10,11) are secrets — not dumped */
+	if (requested(ids, n, 9)) {
+		dst->has_devaddr = true;
+		bin2hex(c->lrw_devaddr, sizeof(c->lrw_devaddr), dst->devaddr, sizeof(dst->devaddr));
+	}
+	if (requested(ids, n, 12)) {
+		dst->has_sub_band = true;
+		dst->sub_band = (uint32_t)c->lrw_sub_band;
+	}
+}
+
+#define FILL_BOOL(tag, field)                                                                      \
+	if (requested(ids, n, tag)) {                                                              \
+		dst->has_##field = true;                                                            \
+		dst->field = c->field;                                                             \
+	}
+#define FILL_NUM(tag, field)                                                                       \
+	if (requested(ids, n, tag)) {                                                              \
+		dst->has_##field = true;                                                            \
+		dst->field = c->field;                                                             \
+	}
+
+void app_config_fill_application(NfcConfigMessage_Application *dst, const uint32_t *ids, size_t n)
+{
+	const struct app_config *c = app_config();
+
+	FILL_BOOL(1, calibration);
+	FILL_NUM(2, interval_sample);
+	FILL_NUM(4, interval_report);
+	FILL_BOOL(5, alarm_temperature_enabled);
+	FILL_NUM(6, alarm_temperature_lo);
+	FILL_NUM(7, alarm_temperature_hi);
+	FILL_NUM(8, alarm_temperature_hst);
+	FILL_BOOL(9, alarm_humidity_enabled);
+	FILL_NUM(10, alarm_humidity_lo);
+	FILL_NUM(11, alarm_humidity_hi);
+	FILL_NUM(12, alarm_humidity_hst);
+	FILL_BOOL(13, alarm_pressure_enabled);
+	FILL_NUM(14, alarm_pressure_lo);
+	FILL_NUM(15, alarm_pressure_hi);
+	FILL_NUM(16, alarm_pressure_hst);
+	FILL_BOOL(17, alarm_t1_temperature_enabled);
+	FILL_NUM(18, alarm_t1_temperature_lo);
+	FILL_NUM(19, alarm_t1_temperature_hi);
+	FILL_NUM(20, alarm_t1_temperature_hst);
+	FILL_BOOL(21, alarm_t2_temperature_enabled);
+	FILL_NUM(22, alarm_t2_temperature_lo);
+	FILL_NUM(23, alarm_t2_temperature_hi);
+	FILL_NUM(24, alarm_t2_temperature_hst);
+	FILL_BOOL(25, hall_left_counter);
+	FILL_BOOL(26, hall_left_notify_act);
+	FILL_BOOL(27, hall_left_notify_deact);
+	FILL_BOOL(28, hall_right_counter);
+	FILL_BOOL(29, hall_right_notify_act);
+	FILL_BOOL(30, hall_right_notify_deact);
+	FILL_BOOL(31, input_a_counter);
+	FILL_BOOL(32, input_a_notify_act);
+	FILL_BOOL(33, input_a_notify_deact);
+	FILL_BOOL(34, input_b_counter);
+	FILL_BOOL(35, input_b_notify_act);
+	FILL_BOOL(36, input_b_notify_deact);
+	FILL_NUM(37, corr_temperature);
+	FILL_NUM(38, corr_t1_temperature);
+	FILL_NUM(39, corr_t2_temperature);
+	FILL_BOOL(40, cap_hall_left);
+	FILL_BOOL(41, cap_hall_right);
+	FILL_BOOL(42, cap_input_a);
+	FILL_BOOL(43, cap_input_b);
+	FILL_BOOL(44, cap_light_sensor);
+	FILL_BOOL(45, cap_barometer);
+	FILL_BOOL(46, cap_pir_detector);
+	FILL_BOOL(47, cap_1w_thermometer);
+	FILL_BOOL(48, cap_1w_machine_probe);
+}
+
+bool app_nfc_ingest(const NfcConfigMessage *message)
+{
 	if (message->has_factory && message->factory) {
 		LOG_INF("Factory reset requested via NFC");
 		return true;
 	}
 
+	/* NFC keeps best-effort semantics: apply valid fields, ignore invalid. */
 	if (message->has_lorawan) {
-		if (message->lorawan.has_region) {
-			LOG_INF_PARAM_INT("lorawan.region", message->lorawan.region);
-			if ((int)message->lorawan.region >= 0 &&
-			    (int)message->lorawan.region <= (int)APP_CONFIG_LRW_REGION_AU915) {
-				config->lrw_region =
-					(enum app_config_lrw_region)message->lorawan.region;
-			} else {
-				LOG_WRN("Ignoring invalid lorawan.region: %d",
-					message->lorawan.region);
-			}
-		}
-
-		if (message->lorawan.has_sub_band) {
-			LOG_INF_PARAM_INT("lorawan.sub_band", message->lorawan.sub_band);
-			if (message->lorawan.sub_band <= 8) {
-				config->lrw_sub_band = (int)message->lorawan.sub_band;
-			} else {
-				LOG_WRN("Ignoring invalid lorawan.sub_band: %u",
-					message->lorawan.sub_band);
-			}
-		}
-
-		if (message->lorawan.has_network) {
-			LOG_INF_PARAM_INT("lorawan.network", message->lorawan.network);
-			if ((int)message->lorawan.network >= 0 &&
-			    (int)message->lorawan.network <= (int)APP_CONFIG_LRW_NETWORK_PRIVATE) {
-				config->lrw_network =
-					(enum app_config_lrw_network)message->lorawan.network;
-			} else {
-				LOG_WRN("Ignoring invalid lorawan.network: %d",
-					message->lorawan.network);
-			}
-		}
-
-		if (message->lorawan.has_adr) {
-			LOG_INF_PARAM_BOOL("lorawan.adr", message->lorawan.adr);
-			config->lrw_adr = message->lorawan.adr;
-		}
-
-		if (message->lorawan.has_activation) {
-			LOG_INF_PARAM_INT("lorawan.activation", message->lorawan.activation);
-			if ((int)message->lorawan.activation >= 0 &&
-			    (int)message->lorawan.activation <= (int)APP_CONFIG_LRW_ACTIVATION_ABP) {
-				config->lrw_activation =
-					(enum app_config_lrw_activation)
-						message->lorawan.activation;
-			} else {
-				LOG_WRN("Ignoring invalid lorawan.activation: %d",
-					message->lorawan.activation);
-			}
-		}
-
-		if (message->lorawan.has_deveui) {
-			LOG_INF_PARAM_STR("lorawan.deveui", message->lorawan.deveui);
-			if (!parse_hex_string(message->lorawan.deveui, config->lrw_deveui,
-					      sizeof(config->lrw_deveui))) {
-				LOG_ERR("Failed to parse lorawan.deveui");
-			}
-		}
-
-		if (message->lorawan.has_joineui) {
-			LOG_INF_PARAM_STR("lorawan.joineui", message->lorawan.joineui);
-			if (!parse_hex_string(message->lorawan.joineui, config->lrw_joineui,
-					      sizeof(config->lrw_joineui))) {
-				LOG_ERR("Failed to parse lorawan.joineui");
-			}
-		}
-
-		if (message->lorawan.has_nwkkey) {
-			LOG_INF_PARAM_STR("lorawan.nwkkey", message->lorawan.nwkkey);
-			if (!parse_hex_string(message->lorawan.nwkkey, config->lrw_nwkkey,
-					      sizeof(config->lrw_nwkkey))) {
-				LOG_ERR("Failed to parse lorawan.nwkkey");
-			}
-		}
-
-		if (message->lorawan.has_appkey) {
-			LOG_INF_PARAM_STR("lorawan.appkey", message->lorawan.appkey);
-			if (!parse_hex_string(message->lorawan.appkey, config->lrw_appkey,
-					      sizeof(config->lrw_appkey))) {
-				LOG_ERR("Failed to parse lorawan.appkey");
-			}
-		}
-
-		if (message->lorawan.has_devaddr) {
-			LOG_INF_PARAM_STR("lorawan.devaddr", message->lorawan.devaddr);
-			if (!parse_hex_string(message->lorawan.devaddr, config->lrw_devaddr,
-					      sizeof(config->lrw_devaddr))) {
-				LOG_ERR("Failed to parse lorawan.devaddr");
-			}
-		}
-
-		if (message->lorawan.has_nwkskey) {
-			LOG_INF_PARAM_STR("lorawan.nwkskey", message->lorawan.nwkskey);
-			if (!parse_hex_string(message->lorawan.nwkskey, config->lrw_nwkskey,
-					      sizeof(config->lrw_nwkskey))) {
-				LOG_ERR("Failed to parse lorawan.nwkskey");
-			}
-		}
-
-		if (message->lorawan.has_appskey) {
-			LOG_INF_PARAM_STR("lorawan.appskey", message->lorawan.appskey);
-			if (!parse_hex_string(message->lorawan.appskey, config->lrw_appskey,
-					      sizeof(config->lrw_appskey))) {
-				LOG_ERR("Failed to parse lorawan.appskey");
-			}
-		}
+		app_config_apply_lorawan(&message->lorawan, NULL);
 	}
-
 	if (message->has_application) {
-		if (message->application.has_calibration) {
-			LOG_INF_PARAM_BOOL("application.calibration",
-					   message->application.calibration);
-			config->calibration = message->application.calibration;
-		}
-
-		if (message->application.has_interval_sample) {
-			int val = message->application.interval_sample;
-
-			LOG_INF_PARAM_INT("application.interval_sample", val);
-			if (val == 0 || (val >= 5 && val <= 3600)) {
-				config->interval_sample = val;
-			} else {
-				LOG_WRN("Ignoring invalid interval_sample: %d", val);
-			}
-		}
-
-		if (message->application.has_interval_report) {
-			int val = message->application.interval_report;
-
-			LOG_INF_PARAM_INT("application.interval_report", val);
-			if (val >= 60 && val <= 86400) {
-				config->interval_report = val;
-			} else {
-				LOG_WRN("Ignoring invalid interval_report: %d", val);
-			}
-		}
-
-		if (message->application.has_alarm_temperature_enabled) {
-			LOG_INF_PARAM_BOOL("application.alarm_temperature_enabled",
-					   message->application.alarm_temperature_enabled);
-			config->alarm_temperature_enabled =
-				message->application.alarm_temperature_enabled;
-		}
-
-		if (message->application.has_alarm_temperature_lo) {
-			float val = message->application.alarm_temperature_lo;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_temperature_lo", val);
-			if (val >= -30.0f && val <= 70.0f) {
-				config->alarm_temperature_lo = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_temperature_lo");
-			}
-		}
-
-		if (message->application.has_alarm_temperature_hi) {
-			float val = message->application.alarm_temperature_hi;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_temperature_hi", val);
-			if (val >= -30.0f && val <= 70.0f) {
-				config->alarm_temperature_hi = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_temperature_hi");
-			}
-		}
-
-		if (message->application.has_alarm_temperature_hst) {
-			float val = message->application.alarm_temperature_hst;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_temperature_hst", val);
-			if (val >= 0.0f && val <= 5.0f) {
-				config->alarm_temperature_hst = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_temperature_hst");
-			}
-		}
-
-		if (message->application.has_alarm_humidity_enabled) {
-			LOG_INF_PARAM_BOOL("application.alarm_humidity_enabled",
-					   message->application.alarm_humidity_enabled);
-			config->alarm_humidity_enabled =
-				message->application.alarm_humidity_enabled;
-		}
-
-		if (message->application.has_alarm_humidity_lo) {
-			float val = message->application.alarm_humidity_lo;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_humidity_lo", val);
-			if (val >= 0.0f && val <= 100.0f) {
-				config->alarm_humidity_lo = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_humidity_lo");
-			}
-		}
-
-		if (message->application.has_alarm_humidity_hi) {
-			float val = message->application.alarm_humidity_hi;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_humidity_hi", val);
-			if (val >= 0.0f && val <= 100.0f) {
-				config->alarm_humidity_hi = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_humidity_hi");
-			}
-		}
-
-		if (message->application.has_alarm_humidity_hst) {
-			float val = message->application.alarm_humidity_hst;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_humidity_hst", val);
-			if (val >= 0.0f && val <= 20.0f) {
-				config->alarm_humidity_hst = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_humidity_hst");
-			}
-		}
-
-		if (message->application.has_alarm_pressure_enabled) {
-			LOG_INF_PARAM_BOOL("application.alarm_pressure_enabled",
-					   message->application.alarm_pressure_enabled);
-			config->alarm_pressure_enabled =
-				message->application.alarm_pressure_enabled;
-		}
-
-		if (message->application.has_alarm_pressure_lo) {
-			float val = message->application.alarm_pressure_lo;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_pressure_lo", val);
-			if (val >= 500.0f && val <= 1200.0f) {
-				config->alarm_pressure_lo = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_pressure_lo");
-			}
-		}
-
-		if (message->application.has_alarm_pressure_hi) {
-			float val = message->application.alarm_pressure_hi;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_pressure_hi", val);
-			if (val >= 500.0f && val <= 1200.0f) {
-				config->alarm_pressure_hi = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_pressure_hi");
-			}
-		}
-
-		if (message->application.has_alarm_pressure_hst) {
-			float val = message->application.alarm_pressure_hst;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_pressure_hst", val);
-			if (val >= 0.0f && val <= 50.0f) {
-				config->alarm_pressure_hst = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_pressure_hst");
-			}
-		}
-
-		if (message->application.has_alarm_t1_temperature_enabled) {
-			LOG_INF_PARAM_BOOL("application.alarm_t1_temperature_enabled",
-					   message->application.alarm_t1_temperature_enabled);
-			config->alarm_t1_temperature_enabled =
-				message->application.alarm_t1_temperature_enabled;
-		}
-
-		if (message->application.has_alarm_t1_temperature_lo) {
-			float val = message->application.alarm_t1_temperature_lo;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_t1_temperature_lo", val);
-			if (val >= -30.0f && val <= 70.0f) {
-				config->alarm_t1_temperature_lo = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_t1_temperature_lo");
-			}
-		}
-
-		if (message->application.has_alarm_t1_temperature_hi) {
-			float val = message->application.alarm_t1_temperature_hi;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_t1_temperature_hi", val);
-			if (val >= -30.0f && val <= 70.0f) {
-				config->alarm_t1_temperature_hi = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_t1_temperature_hi");
-			}
-		}
-
-		if (message->application.has_alarm_t1_temperature_hst) {
-			float val = message->application.alarm_t1_temperature_hst;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_t1_temperature_hst", val);
-			if (val >= 0.0f && val <= 5.0f) {
-				config->alarm_t1_temperature_hst = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_t1_temperature_hst");
-			}
-		}
-
-		if (message->application.has_alarm_t2_temperature_enabled) {
-			LOG_INF_PARAM_BOOL("application.alarm_t2_temperature_enabled",
-					   message->application.alarm_t2_temperature_enabled);
-			config->alarm_t2_temperature_enabled =
-				message->application.alarm_t2_temperature_enabled;
-		}
-
-		if (message->application.has_alarm_t2_temperature_lo) {
-			float val = message->application.alarm_t2_temperature_lo;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_t2_temperature_lo", val);
-			if (val >= -30.0f && val <= 70.0f) {
-				config->alarm_t2_temperature_lo = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_t2_temperature_lo");
-			}
-		}
-
-		if (message->application.has_alarm_t2_temperature_hi) {
-			float val = message->application.alarm_t2_temperature_hi;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_t2_temperature_hi", val);
-			if (val >= -30.0f && val <= 70.0f) {
-				config->alarm_t2_temperature_hi = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_t2_temperature_hi");
-			}
-		}
-
-		if (message->application.has_alarm_t2_temperature_hst) {
-			float val = message->application.alarm_t2_temperature_hst;
-
-			LOG_INF_PARAM_FLOAT("application.alarm_t2_temperature_hst", val);
-			if (val >= 0.0f && val <= 5.0f) {
-				config->alarm_t2_temperature_hst = val;
-			} else {
-				LOG_WRN("Ignoring invalid alarm_t2_temperature_hst");
-			}
-		}
-
-		if (message->application.has_hall_left_counter) {
-			LOG_INF_PARAM_BOOL("application.hall_left_counter",
-					   message->application.hall_left_counter);
-			config->hall_left_counter = message->application.hall_left_counter;
-		}
-
-		if (message->application.has_hall_left_notify_act) {
-			LOG_INF_PARAM_BOOL("application.hall_left_notify_act",
-					   message->application.hall_left_notify_act);
-			config->hall_left_notify_act = message->application.hall_left_notify_act;
-		}
-
-		if (message->application.has_hall_left_notify_deact) {
-			LOG_INF_PARAM_BOOL("application.hall_left_notify_deact",
-					   message->application.hall_left_notify_deact);
-			config->hall_left_notify_deact =
-				message->application.hall_left_notify_deact;
-		}
-
-		if (message->application.has_hall_right_counter) {
-			LOG_INF_PARAM_BOOL("application.hall_right_counter",
-					   message->application.hall_right_counter);
-			config->hall_right_counter = message->application.hall_right_counter;
-		}
-
-		if (message->application.has_hall_right_notify_act) {
-			LOG_INF_PARAM_BOOL("application.hall_right_notify_act",
-					   message->application.hall_right_notify_act);
-			config->hall_right_notify_act = message->application.hall_right_notify_act;
-		}
-
-		if (message->application.has_hall_right_notify_deact) {
-			LOG_INF_PARAM_BOOL("application.hall_right_notify_deact",
-					   message->application.hall_right_notify_deact);
-			config->hall_right_notify_deact =
-				message->application.hall_right_notify_deact;
-		}
-
-		if (message->application.has_input_a_counter) {
-			LOG_INF_PARAM_BOOL("application.input_a_counter",
-					   message->application.input_a_counter);
-			config->input_a_counter = message->application.input_a_counter;
-		}
-
-		if (message->application.has_input_a_notify_act) {
-			LOG_INF_PARAM_BOOL("application.input_a_notify_act",
-					   message->application.input_a_notify_act);
-			config->input_a_notify_act = message->application.input_a_notify_act;
-		}
-
-		if (message->application.has_input_a_notify_deact) {
-			LOG_INF_PARAM_BOOL("application.input_a_notify_deact",
-					   message->application.input_a_notify_deact);
-			config->input_a_notify_deact =
-				message->application.input_a_notify_deact;
-		}
-
-		if (message->application.has_input_b_counter) {
-			LOG_INF_PARAM_BOOL("application.input_b_counter",
-					   message->application.input_b_counter);
-			config->input_b_counter = message->application.input_b_counter;
-		}
-
-		if (message->application.has_input_b_notify_act) {
-			LOG_INF_PARAM_BOOL("application.input_b_notify_act",
-					   message->application.input_b_notify_act);
-			config->input_b_notify_act = message->application.input_b_notify_act;
-		}
-
-		if (message->application.has_input_b_notify_deact) {
-			LOG_INF_PARAM_BOOL("application.input_b_notify_deact",
-					   message->application.input_b_notify_deact);
-			config->input_b_notify_deact =
-				message->application.input_b_notify_deact;
-		}
-
-		if (message->application.has_corr_temperature) {
-			float val = message->application.corr_temperature;
-
-			LOG_INF_PARAM_FLOAT("application.corr_temperature", val);
-			if (val >= -5.0f && val <= 5.0f) {
-				config->corr_temperature = val;
-			} else {
-				LOG_WRN("Ignoring invalid corr_temperature");
-			}
-		}
-
-		if (message->application.has_corr_t1_temperature) {
-			float val = message->application.corr_t1_temperature;
-
-			LOG_INF_PARAM_FLOAT("application.corr_t1_temperature", val);
-			if (val >= -5.0f && val <= 5.0f) {
-				config->corr_t1_temperature = val;
-			} else {
-				LOG_WRN("Ignoring invalid corr_t1_temperature");
-			}
-		}
-
-		if (message->application.has_corr_t2_temperature) {
-			float val = message->application.corr_t2_temperature;
-
-			LOG_INF_PARAM_FLOAT("application.corr_t2_temperature", val);
-			if (val >= -5.0f && val <= 5.0f) {
-				config->corr_t2_temperature = val;
-			} else {
-				LOG_WRN("Ignoring invalid corr_t2_temperature");
-			}
-		}
-
-		if (message->application.has_cap_hall_left) {
-			LOG_INF_PARAM_BOOL("application.cap_hall_left",
-					   message->application.cap_hall_left);
-			config->cap_hall_left = message->application.cap_hall_left;
-		}
-
-		if (message->application.has_cap_hall_right) {
-			LOG_INF_PARAM_BOOL("application.cap_hall_right",
-					   message->application.cap_hall_right);
-			config->cap_hall_right = message->application.cap_hall_right;
-		}
-
-		if (message->application.has_cap_input_a) {
-			LOG_INF_PARAM_BOOL("application.cap_input_a",
-					   message->application.cap_input_a);
-			config->cap_input_a = message->application.cap_input_a;
-		}
-
-		if (message->application.has_cap_input_b) {
-			LOG_INF_PARAM_BOOL("application.cap_input_b",
-					   message->application.cap_input_b);
-			config->cap_input_b = message->application.cap_input_b;
-		}
-
-		if (message->application.has_cap_light_sensor) {
-			LOG_INF_PARAM_BOOL("application.cap_light_sensor",
-					   message->application.cap_light_sensor);
-			config->cap_light_sensor = message->application.cap_light_sensor;
-		}
-
-		if (message->application.has_cap_barometer) {
-			LOG_INF_PARAM_BOOL("application.cap_barometer",
-					   message->application.cap_barometer);
-			config->cap_barometer = message->application.cap_barometer;
-		}
-
-		if (message->application.has_cap_pir_detector) {
-			LOG_INF_PARAM_BOOL("application.cap_pir_detector",
-					   message->application.cap_pir_detector);
-			config->cap_pir_detector = message->application.cap_pir_detector;
-		}
-
-		if (message->application.has_cap_1w_thermometer) {
-			LOG_INF_PARAM_BOOL("application.cap_1w_thermometer",
-					   message->application.cap_1w_thermometer);
-			config->cap_1w_thermometer = message->application.cap_1w_thermometer;
-		}
-
-		if (message->application.has_cap_1w_machine_probe) {
-			LOG_INF_PARAM_BOOL("application.cap_1w_machine_probe",
-					   message->application.cap_1w_machine_probe);
-			config->cap_1w_machine_probe = message->application.cap_1w_machine_probe;
-		}
-	}
-
-	/* Cross-validate alarm lo/hi pairs — reject if lo >= hi */
-	if (config->alarm_temperature_lo >= config->alarm_temperature_hi) {
-		LOG_WRN("alarm_temperature_lo >= hi, disabling alarm");
-		config->alarm_temperature_enabled = false;
-	}
-
-	if (config->alarm_humidity_lo >= config->alarm_humidity_hi) {
-		LOG_WRN("alarm_humidity_lo >= hi, disabling alarm");
-		config->alarm_humidity_enabled = false;
-	}
-
-	if (config->alarm_pressure_lo >= config->alarm_pressure_hi) {
-		LOG_WRN("alarm_pressure_lo >= hi, disabling alarm");
-		config->alarm_pressure_enabled = false;
-	}
-
-	if (config->alarm_t1_temperature_lo >= config->alarm_t1_temperature_hi) {
-		LOG_WRN("alarm_t1_temperature_lo >= hi, disabling alarm");
-		config->alarm_t1_temperature_enabled = false;
-	}
-
-	if (config->alarm_t2_temperature_lo >= config->alarm_t2_temperature_hi) {
-		LOG_WRN("alarm_t2_temperature_lo >= hi, disabling alarm");
-		config->alarm_t2_temperature_enabled = false;
+		app_config_apply_application(&message->application, NULL);
 	}
 
 	return false;

--- a/app/src/app_nfc_ingest.h
+++ b/app/src/app_nfc_ingest.h
@@ -7,6 +7,9 @@
 #ifndef APP_NFC_INGEST_H_
 #define APP_NFC_INGEST_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "src/nfc_config.pb.h"
 
 #ifdef __cplusplus
@@ -14,6 +17,18 @@ extern "C" {
 #endif
 
 bool app_nfc_ingest(const NfcConfigMessage *message);
+
+/* Apply LoRaWAN / Application config fields into the staging config (app_config()).
+ * Valid fields are written; an invalid one is skipped and (if fault_field is
+ * non-NULL) its proto field tag is recorded in *fault_field (first offender).
+ * Returns 0 if all present fields were valid, -EINVAL otherwise. */
+int app_config_apply_lorawan(const NfcConfigMessage_Lorawan *src, uint32_t *fault_field);
+int app_config_apply_application(const NfcConfigMessage_Application *src, uint32_t *fault_field);
+
+/* Populate dst with only the requested fields (by proto field tag in ids[0..n))
+ * from the staging config, setting their has_* flags. Secret keys are not dumped. */
+void app_config_fill_lorawan(NfcConfigMessage_Lorawan *dst, const uint32_t *ids, size_t n);
+void app_config_fill_application(NfcConfigMessage_Application *dst, const uint32_t *ids, size_t n);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_tester.c
+++ b/app/src/app_tester.c
@@ -667,13 +667,20 @@ static int cmd_cmd_inject(const struct shell *sh, size_t argc, char **argv)
 
 	static uint8_t out[64];
 	size_t out_len = 0;
-	int ret = app_cmd_handle(transport, in, in_len, out, sizeof(out), &out_len);
+	enum app_cmd_action action = APP_CMD_ACTION_NONE;
+	int ret = app_cmd_handle(transport, in, in_len, out, sizeof(out), &out_len, &action);
 	if (ret) {
 		shell_error(sh, "app_cmd_handle failed: %d", ret);
 		return ret;
 	}
 
 	LOG_HEXDUMP_INF(out, out_len, "DownlinkResponse:");
+
+	/* Don't reboot the bench from a shell inject — just report what an LRW
+	 * downlink would trigger. Use `settings save` / `settings reset` to apply. */
+	if (action != APP_CMD_ACTION_NONE) {
+		shell_print(sh, "deferred action %d (not executed from shell inject)", (int)action);
+	}
 
 #if defined(CONFIG_LORAWAN)
 	if (transport == APP_CMD_TRANSPORT_LRW && out_len > 0) {

--- a/app/src/app_tester.c
+++ b/app/src/app_tester.c
@@ -632,20 +632,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_led,
 	SHELL_SUBCMD_SET_END);
 
 #ifdef CONFIG_APP_CMD_DEBUG_SHELL
-static int cmd_cmd_inject(const struct shell *sh, size_t argc, char **argv)
+static int cmd_cmd_inject(const struct shell *sh, enum app_cmd_transport transport,
+			  const char *hex)
 {
-	enum app_cmd_transport transport;
-
-	if (strcmp(argv[1], "lrw") == 0) {
-		transport = APP_CMD_TRANSPORT_LRW;
-	} else if (strcmp(argv[1], "nfc") == 0) {
-		transport = APP_CMD_TRANSPORT_NFC;
-	} else {
-		shell_error(sh, "Unknown transport `%s` (expected lrw|nfc)", argv[1]);
-		return -EINVAL;
-	}
-
-	const char *hex = argv[2];
 	size_t hex_len = strlen(hex);
 
 	if (hex_len == 0 || (hex_len % 2) != 0) {
@@ -693,6 +682,23 @@ static int cmd_cmd_inject(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
+
+static int cmd_cmd_lrw(const struct shell *sh, size_t argc, char **argv)
+{
+	return cmd_cmd_inject(sh, APP_CMD_TRANSPORT_LRW, argv[1]);
+}
+
+static int cmd_cmd_nfc(const struct shell *sh, size_t argc, char **argv)
+{
+	return cmd_cmd_inject(sh, APP_CMD_TRANSPORT_NFC, argv[1]);
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd,
+	SHELL_CMD_ARG(lrw, NULL, "Inject over LoRaWAN transport. Usage: lrw <hex>",
+		      cmd_cmd_lrw, 2, 0),
+	SHELL_CMD_ARG(nfc, NULL, "Inject over NFC transport. Usage: nfc <hex>",
+		      cmd_cmd_nfc, 2, 0),
+	SHELL_SUBCMD_SET_END);
 #endif /* CONFIG_APP_CMD_DEBUG_SHELL */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
@@ -703,9 +709,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(lrw, &sub_lrw, "LoRaWAN commands.", NULL),
 #endif /* defined(CONFIG_LORAWAN) */
 #ifdef CONFIG_APP_CMD_DEBUG_SHELL
-	SHELL_CMD_ARG(cmd, NULL,
-		      "Inject DownlinkCommand. Usage: cmd <lrw|nfc> <hex>",
-		      cmd_cmd_inject, 3, 0),
+	SHELL_CMD(cmd, &sub_cmd, "Inject DownlinkCommand (protobuf hex).", NULL),
 #endif
 	SHELL_SUBCMD_SET_END);
 

--- a/app/src/nfc_config.options.in
+++ b/app/src/nfc_config.options.in
@@ -8,3 +8,8 @@ NfcConfigMessage.Lorawan.appskey max_length:32
 
 DownlinkResponse.Error.detail       max_size:32
 DownlinkResponse.HistoryFrame.samples max_size:48
+
+# GetParam field-id lists as static arrays (no nanopb callback). A batch is
+# bounded by the LoRaWAN downlink size anyway, so 16 ids each is plenty.
+DownlinkCommand.GetParam.lorawan_field     max_count:16
+DownlinkCommand.GetParam.application_field max_count:16

--- a/app/src/nfc_config.proto
+++ b/app/src/nfc_config.proto
@@ -107,6 +107,7 @@ message DownlinkCommand {
         ForceSend       force_send       = 9;
         ResetCounters   reset_counters   = 10;
         ReqHistory      req_history      = 11;
+        ClockSync       clock_sync       = 12;
     }
 
     message SetParam {
@@ -132,6 +133,7 @@ message DownlinkCommand {
         optional bool input_b    = 4;
     }
     message ReqHistory   { optional uint32 from_unix = 1; optional uint32 to_unix = 2; }
+    message ClockSync    { }
 }
 
 message DownlinkResponse {


### PR DESCRIPTION
Fills in the runtime command set on top of the Phase 1 dispatcher (#36, merged). Implements the rest of #35's bidirectional command protocol over LoRaWAN port 85 + NFC.

## What
- **SetParam** — batch-apply staged LoRaWAN/Application config via shared `app_config_apply_*` (extracted from NFC ingest); `Ack` on success, `Error{OUT_OF_RANGE, fault_field}` on the first invalid proto tag.
- **GetParam** — batch-read requested field IDs into `ConfigDump` (secrets not dumped).
- **get_config** — paginated full-config dump (deterministic size-budgeted paging; host walks pages 0..N-1 and unions them).
- **SettingsSave / Reboot / FactoryReset** — `Ack` first, then a deferred action (8 s delayable work) so the response leaves before persist+reboot / reboot / NVS erase. LRW-gated; shell inject only logs.
- **ForceSend** (trigger uplink), **ResetCounters** (per-side hall/input), **ClockSync** (re-arm DeviceTimeReq).
- `tester cmd` is now a subcommand menu (`tester cmd lrw|nfc <hex>`).
- `ttn.js`: `encodeDownlink` (JSON command → protobuf on fPort 85) + `decodeDownlink` + `decodeDownlinkResponse`.

## Validated on hardware (debug, via RTT)
- Shell inject: batch SetParam→Ack, batch GetParam→ConfigDump (exact values), invalid→`Error{OUT_OF_RANGE, fault_field=4}`, control commands Ack + side effects.
- Over-the-air (TTN ABP): SetParam downlink on port 85 → Ack on port 85.

## Rebase note
Rebased onto current `v1.4.0` (after #50 protobuf telemetry + #45 clock shell). Only conflict was `app/decoder/ttn.js` — resolved so the telemetry codec (fPort 2 `decodeTelemetry`, #50) and command codec (fPort 85 `encode/decodeDownlink`, this PR) coexist; `decodeUplink` routes by port (1=legacy bitmap, 2=Telemetry, 85=command response). Builds clean: debug 88.19% / 87.34%, release 54.91% / 64.78%. Decoder round-trip re-verified.

Closes the Phase 2+3 scope of #35.
