### PR TITLE
Promote RTC shell to top-level `clock` command

### DIFF
--- a/app/src/app_clock.c
+++ b/app/src/app_clock.c
@@ -17,9 +17,14 @@
 #include <zephyr/lorawan/lorawan.h>
 #endif
 
+#if defined(CONFIG_SHELL)
+#include <zephyr/shell/shell.h>
+#endif
+
 /* Standard includes */
 #include <errno.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <time.h>
 
 LOG_MODULE_REGISTER(app_clock, LOG_LEVEL_INF);
@@ -134,3 +139,62 @@ int app_clock_set_unix(uint32_t unix_s)
 
 	return rtc_set_time(m_rtc, &rtc_tm);
 }
+
+#if defined(CONFIG_SHELL)
+static int cmd_clock_get(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	uint32_t unix_s;
+	int ret = app_clock_get_unix(&unix_s);
+	if (ret == -ENODATA) {
+		shell_warn(sh, "RTC not set yet (no time sync)");
+		return 0;
+	}
+	if (ret) {
+		shell_error(sh, "app_clock_get_unix failed: %d", ret);
+		return ret;
+	}
+
+	time_t t = (time_t)unix_s;
+	struct tm tm;
+	gmtime_r(&t, &tm);
+	shell_print(sh, "unix=%u  UTC %04d-%02d-%02d %02d:%02d:%02d", unix_s, tm.tm_year + 1900,
+		    tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+	return 0;
+}
+
+static int cmd_clock_set(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	uint32_t unix_s = (uint32_t)strtoul(argv[1], NULL, 10);
+	int ret = app_clock_set_unix(unix_s);
+	if (ret) {
+		shell_error(sh, "app_clock_set_unix failed: %d", ret);
+		return ret;
+	}
+	shell_print(sh, "RTC set to unix=%u", unix_s);
+	return 0;
+}
+
+static int cmd_clock_sync(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	app_clock_request_sync();
+	shell_print(sh, "DeviceTimeReq requested; RTC updates on the next downlink");
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_clock,
+	SHELL_CMD_ARG(get, NULL, "Read RTC time.", cmd_clock_get, 1, 0),
+	SHELL_CMD_ARG(set, NULL, "Set RTC time. Usage: set <unix>", cmd_clock_set, 2, 0),
+	SHELL_CMD_ARG(sync, NULL, "Request network time (LoRaWAN DeviceTimeReq).", cmd_clock_sync,
+		      1, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(clock, &sub_clock, "RTC wall-clock commands.", NULL);
+#endif /* defined(CONFIG_SHELL) */

--- a/app/src/app_tester.c
+++ b/app/src/app_tester.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "app_clock.h"
 #include "app_ds18b20.h"
 #include "app_hall.h"
 #include "app_input.h"
@@ -31,7 +30,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 LOG_MODULE_REGISTER(app_tester, LOG_LEVEL_DBG);
 
@@ -633,63 +631,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_led,
 		      cmd_switch_led, 3, 0),
 	SHELL_SUBCMD_SET_END);
 
-#if defined(CONFIG_RTC)
-static int cmd_clock_get(const struct shell *sh, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	uint32_t unix_s;
-	int ret = app_clock_get_unix(&unix_s);
-	if (ret == -ENODATA) {
-		shell_warn(sh, "RTC not set yet (no time sync)");
-		return 0;
-	}
-	if (ret) {
-		shell_error(sh, "app_clock_get_unix failed: %d", ret);
-		return ret;
-	}
-
-	time_t t = (time_t)unix_s;
-	struct tm tm;
-	gmtime_r(&t, &tm);
-	shell_print(sh, "unix=%u  UTC %04d-%02d-%02d %02d:%02d:%02d", unix_s, tm.tm_year + 1900,
-		    tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
-	return 0;
-}
-
-static int cmd_clock_set(const struct shell *sh, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-
-	uint32_t unix_s = (uint32_t)strtoul(argv[1], NULL, 10);
-	int ret = app_clock_set_unix(unix_s);
-	if (ret) {
-		shell_error(sh, "app_clock_set_unix failed: %d", ret);
-		return ret;
-	}
-	shell_print(sh, "RTC set to unix=%u", unix_s);
-	return 0;
-}
-
-static int cmd_clock_sync(const struct shell *sh, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	app_clock_request_sync();
-	shell_print(sh, "DeviceTimeReq requested; RTC updates on the next downlink");
-	return 0;
-}
-
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_clock,
-	SHELL_CMD_ARG(get, NULL, "Read RTC time.", cmd_clock_get, 1, 0),
-	SHELL_CMD_ARG(set, NULL, "Set RTC time. Usage: set <unix>", cmd_clock_set, 2, 0),
-	SHELL_CMD_ARG(sync, NULL, "Request network time (LoRaWAN DeviceTimeReq).", cmd_clock_sync,
-		      1, 0),
-	SHELL_SUBCMD_SET_END);
-#endif /* defined(CONFIG_RTC) */
-
 #ifdef CONFIG_APP_CMD_DEBUG_SHELL
 static int cmd_cmd_inject(const struct shell *sh, size_t argc, char **argv)
 {
@@ -754,9 +695,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #if defined(CONFIG_LORAWAN)
 	SHELL_CMD(lrw, &sub_lrw, "LoRaWAN commands.", NULL),
 #endif /* defined(CONFIG_LORAWAN) */
-#if defined(CONFIG_RTC)
-	SHELL_CMD(clock, &sub_clock, "RTC time commands.", NULL),
-#endif /* defined(CONFIG_RTC) */
 #ifdef CONFIG_APP_CMD_DEBUG_SHELL
 	SHELL_CMD_ARG(cmd, NULL,
 		      "Inject DownlinkCommand. Usage: cmd <lrw|nfc> <hex>",


### PR DESCRIPTION
## Summary

Moves the RTC shell out of the debug `tester clock` subcommand into a standalone top-level **`clock get/set/sync`** command, owned by the `app_clock` module itself.

Built on PR #41 (`app_clock`, merged). The module name stays `app_clock` — `clock` reads as wall-clock time (RTC + network sync), broader than the raw RTC peripheral.

## Changes

- **`app_clock.c`** — adds the `get`/`set`/`sync` handlers + `SHELL_CMD_REGISTER(clock, …)` under a `CONFIG_SHELL` guard. Logic moved verbatim from `app_tester.c` (no behavior change). The module now owns its own shell.
- **`app_tester.c`** — removes the clock handlers, the `sub_clock` set, the `tester clock` registration, and the now-unused `app_clock.h` / `<time.h>` includes.

## Verification

Debug build flashed; over RTT:

```
clock                     -> lists get/set/sync subcommands
clock get                 -> RTC not set yet (no time sync)
clock set 1780000000      -> RTC set to unix=1780000000
clock get                 -> unix=1780000002  UTC 2026-05-28 20:26:42
clock sync                -> DeviceTimeReq requested; RTC updates on the next downlink
```

Release build compiles cleanly (shell block compiled out): FLASH 52.54%, debug FLASH 89.04%.