### PR TITLE
v1.4.0: Protobuf telemetry on fPort 2 — capability-driven, dynamic sizing + multi-frame split (#37)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -134,47 +134,67 @@ function decodeTelemetry(bytes) {
       break;
     }
     var v = _pbReadVarint(bytes, pos); pos = v.next;
+    var f;
     switch (field) {
+      // system
       case 1:  d.voltage = v.value / 50; break;
-      case 2:  d.temperature = _pbZigzag(v.value) / 100; break;
-      case 3:  d.humidity = v.value / 2; break;
-      case 4:  d.illuminance = v.value * 2; break;
+      case 2:  if (v.value & (1 << 0)) d.boot = true; break;   // system_flags
+      // internal (SHT4x)
+      case 3:  d.temperature = _pbZigzag(v.value) / 100; break;
+      case 4:  d.humidity = v.value / 2; break;
+      // barometer
       case 5:  d.pressure = v.value / 1000; break;
       case 6:  d.altitude = _pbZigzag(v.value) / 10; break;
-      case 7:  d.ext_temperature_1 = _pbZigzag(v.value) / 100; break;
-      case 8:  d.ext_temperature_2 = _pbZigzag(v.value) / 100; break;
-      case 9:  d.machine_probe_temperature_1 = _pbZigzag(v.value) / 100; break;
-      case 10: d.machine_probe_temperature_2 = _pbZigzag(v.value) / 100; break;
-      case 11: d.machine_probe_humidity_1 = v.value / 2; break;
-      case 12: d.machine_probe_humidity_2 = v.value / 2; break;
-      case 13: d.orientation = v.value; break;
-      case 14: d.motion_count = v.value; break;
-      case 15: d.hall_left_count = v.value; break;
-      case 16: d.hall_right_count = v.value; break;
-      case 17: d.input_a_count = v.value; break;
-      case 18: d.input_b_count = v.value; break;
+      // light
+      case 7:  d.illuminance = v.value * 2; break;
+      // accel
+      case 8:  d.orientation = v.value; break;
+      // pir
+      case 9:  d.motion_count = v.value; break;
+      // 1-wire ext
+      case 10: d.ext_temperature_1 = _pbZigzag(v.value) / 100; break;
+      case 11: d.ext_temperature_2 = _pbZigzag(v.value) / 100; break;
+      // machine probe 1
+      case 12: d.machine_probe_temperature_1 = _pbZigzag(v.value) / 100; break;
+      case 13: d.machine_probe_humidity_1 = v.value / 2; break;
+      case 14: if (v.value & (1 << 0)) d.machine_probe_tilt_alert_1 = true; break;
+      // machine probe 2
+      case 15: d.machine_probe_temperature_2 = _pbZigzag(v.value) / 100; break;
+      case 16: d.machine_probe_humidity_2 = v.value / 2; break;
+      case 17: if (v.value & (1 << 0)) d.machine_probe_tilt_alert_2 = true; break;
+      // hall left
+      case 18: d.hall_left_count = v.value; break;
       case 19:
-        // Expose only the flags that are set, so the output mirrors the sparse
-        // payload (a missing flag means false). Avoids implying sensors that
-        // aren't connected exist.
-        var f = v.value;
-        if (f & (1 << 0))  d.boot = true;
-        if (f & (1 << 1))  d.machine_probe_tilt_alert_1 = true;
-        if (f & (1 << 2))  d.machine_probe_tilt_alert_2 = true;
-        if (f & (1 << 3))  d.hall_left_notify_act = true;
-        if (f & (1 << 4))  d.hall_left_notify_deact = true;
-        if (f & (1 << 5))  d.hall_left_is_active = true;
-        if (f & (1 << 6))  d.hall_right_notify_act = true;
-        if (f & (1 << 7))  d.hall_right_notify_deact = true;
-        if (f & (1 << 8))  d.hall_right_is_active = true;
-        if (f & (1 << 9))  d.input_a_notify_act = true;
-        if (f & (1 << 10)) d.input_a_notify_deact = true;
-        if (f & (1 << 11)) d.input_a_is_active = true;
-        if (f & (1 << 12)) d.input_b_notify_act = true;
-        if (f & (1 << 13)) d.input_b_notify_deact = true;
-        if (f & (1 << 14)) d.input_b_is_active = true;
+        f = v.value;
+        if (f & (1 << 0)) d.hall_left_notify_act = true;
+        if (f & (1 << 1)) d.hall_left_notify_deact = true;
+        if (f & (1 << 2)) d.hall_left_is_active = true;
         break;
-      default: break; /* unknown field: ignore */
+      // hall right
+      case 20: d.hall_right_count = v.value; break;
+      case 21:
+        f = v.value;
+        if (f & (1 << 0)) d.hall_right_notify_act = true;
+        if (f & (1 << 1)) d.hall_right_notify_deact = true;
+        if (f & (1 << 2)) d.hall_right_is_active = true;
+        break;
+      // input A
+      case 22: d.input_a_count = v.value; break;
+      case 23:
+        f = v.value;
+        if (f & (1 << 0)) d.input_a_notify_act = true;
+        if (f & (1 << 1)) d.input_a_notify_deact = true;
+        if (f & (1 << 2)) d.input_a_is_active = true;
+        break;
+      // input B
+      case 24: d.input_b_count = v.value; break;
+      case 25:
+        f = v.value;
+        if (f & (1 << 0)) d.input_b_notify_act = true;
+        if (f & (1 << 1)) d.input_b_notify_deact = true;
+        if (f & (1 << 2)) d.input_b_is_active = true;
+        break;
+      default: break; /* unknown field: ignore (forward-compatible) */
     }
   }
   return d;

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -111,12 +111,87 @@ function decodeDownlinkResponse(bytes) {
   return resp;
 }
 
+// Zig-zag decode for protobuf sint32.
+function _pbZigzag(n) {
+  return (n >>> 1) ^ -(n & 1);
+}
+
+// fPort 2: flat protobuf Telemetry (periodic / event-triggered report). Keys
+// match the legacy fPort-1 bitmap decoder so dashboards stay stable. Unknown
+// fields are skipped (forward-compatible with newer firmware).
+function decodeTelemetry(bytes) {
+  var d = {};
+  var pos = 0;
+  while (pos < bytes.length) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var field = tag.value >>> 3;
+    var wire = tag.value & 0x7;
+    if (wire !== 0) {
+      // Forward-compat: skip an unknown non-varint field.
+      if (wire === 2) { var l = _pbReadVarint(bytes, pos); pos = l.next + l.value; continue; }
+      if (wire === 5) { pos += 4; continue; }
+      if (wire === 1) { pos += 8; continue; }
+      break;
+    }
+    var v = _pbReadVarint(bytes, pos); pos = v.next;
+    switch (field) {
+      case 1:  d.voltage = v.value / 50; break;
+      case 2:  d.temperature = _pbZigzag(v.value) / 100; break;
+      case 3:  d.humidity = v.value / 2; break;
+      case 4:  d.illuminance = v.value * 2; break;
+      case 5:  d.pressure = v.value / 1000; break;
+      case 6:  d.altitude = _pbZigzag(v.value) / 10; break;
+      case 7:  d.ext_temperature_1 = _pbZigzag(v.value) / 100; break;
+      case 8:  d.ext_temperature_2 = _pbZigzag(v.value) / 100; break;
+      case 9:  d.machine_probe_temperature_1 = _pbZigzag(v.value) / 100; break;
+      case 10: d.machine_probe_temperature_2 = _pbZigzag(v.value) / 100; break;
+      case 11: d.machine_probe_humidity_1 = v.value / 2; break;
+      case 12: d.machine_probe_humidity_2 = v.value / 2; break;
+      case 13: d.orientation = v.value; break;
+      case 14: d.motion_count = v.value; break;
+      case 15: d.hall_left_count = v.value; break;
+      case 16: d.hall_right_count = v.value; break;
+      case 17: d.input_a_count = v.value; break;
+      case 18: d.input_b_count = v.value; break;
+      case 19:
+        var f = v.value;
+        d.boot = !!(f & (1 << 0));
+        d.machine_probe_tilt_alert_1 = !!(f & (1 << 1));
+        d.machine_probe_tilt_alert_2 = !!(f & (1 << 2));
+        d.hall_left_notify_act = !!(f & (1 << 3));
+        d.hall_left_notify_deact = !!(f & (1 << 4));
+        d.hall_left_is_active = !!(f & (1 << 5));
+        d.hall_right_notify_act = !!(f & (1 << 6));
+        d.hall_right_notify_deact = !!(f & (1 << 7));
+        d.hall_right_is_active = !!(f & (1 << 8));
+        d.input_a_notify_act = !!(f & (1 << 9));
+        d.input_a_notify_deact = !!(f & (1 << 10));
+        d.input_a_is_active = !!(f & (1 << 11));
+        d.input_b_notify_act = !!(f & (1 << 12));
+        d.input_b_notify_deact = !!(f & (1 << 13));
+        d.input_b_is_active = !!(f & (1 << 14));
+        break;
+      default: break; /* unknown field: ignore */
+    }
+  }
+  return d;
+}
+
 function decodeUplink(input) {
 
   // fPort 85: DownlinkResponse (Ack / Info / Error from command dispatcher).
   if (input.fPort === 85) {
     return {
       data: decodeDownlinkResponse(input.bytes),
+      warnings: [],
+      errors: []
+    };
+  }
+
+  // fPort 2: protobuf Telemetry (new format). fPort 1 stays the legacy bitmap.
+  if (input.fPort === 2) {
+    return {
+      data: decodeTelemetry(input.bytes),
       warnings: [],
       errors: []
     };

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -154,22 +154,25 @@ function decodeTelemetry(bytes) {
       case 17: d.input_a_count = v.value; break;
       case 18: d.input_b_count = v.value; break;
       case 19:
+        // Expose only the flags that are set, so the output mirrors the sparse
+        // payload (a missing flag means false). Avoids implying sensors that
+        // aren't connected exist.
         var f = v.value;
-        d.boot = !!(f & (1 << 0));
-        d.machine_probe_tilt_alert_1 = !!(f & (1 << 1));
-        d.machine_probe_tilt_alert_2 = !!(f & (1 << 2));
-        d.hall_left_notify_act = !!(f & (1 << 3));
-        d.hall_left_notify_deact = !!(f & (1 << 4));
-        d.hall_left_is_active = !!(f & (1 << 5));
-        d.hall_right_notify_act = !!(f & (1 << 6));
-        d.hall_right_notify_deact = !!(f & (1 << 7));
-        d.hall_right_is_active = !!(f & (1 << 8));
-        d.input_a_notify_act = !!(f & (1 << 9));
-        d.input_a_notify_deact = !!(f & (1 << 10));
-        d.input_a_is_active = !!(f & (1 << 11));
-        d.input_b_notify_act = !!(f & (1 << 12));
-        d.input_b_notify_deact = !!(f & (1 << 13));
-        d.input_b_is_active = !!(f & (1 << 14));
+        if (f & (1 << 0))  d.boot = true;
+        if (f & (1 << 1))  d.machine_probe_tilt_alert_1 = true;
+        if (f & (1 << 2))  d.machine_probe_tilt_alert_2 = true;
+        if (f & (1 << 3))  d.hall_left_notify_act = true;
+        if (f & (1 << 4))  d.hall_left_notify_deact = true;
+        if (f & (1 << 5))  d.hall_left_is_active = true;
+        if (f & (1 << 6))  d.hall_right_notify_act = true;
+        if (f & (1 << 7))  d.hall_right_notify_deact = true;
+        if (f & (1 << 8))  d.hall_right_is_active = true;
+        if (f & (1 << 9))  d.input_a_notify_act = true;
+        if (f & (1 << 10)) d.input_a_notify_deact = true;
+        if (f & (1 << 11)) d.input_a_is_active = true;
+        if (f & (1 << 12)) d.input_b_notify_act = true;
+        if (f & (1 << 13)) d.input_b_notify_deact = true;
+        if (f & (1 << 14)) d.input_b_is_active = true;
         break;
       default: break; /* unknown field: ignore */
     }

--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -27,48 +27,134 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 LOG_MODULE_REGISTER(app_compose, LOG_LEVEL_DBG);
 
-/* Telemetry.flags bit positions (see nfc_config.proto + ttn.js). */
-#define FLAG_BOOT               BIT(0)
-#define FLAG_MP1_TILT           BIT(1)
-#define FLAG_MP2_TILT           BIT(2)
-#define FLAG_HALL_L_NOTIFY_ACT  BIT(3)
-#define FLAG_HALL_L_NOTIFY_DEACT BIT(4)
-#define FLAG_HALL_L_ACTIVE      BIT(5)
-#define FLAG_HALL_R_NOTIFY_ACT  BIT(6)
-#define FLAG_HALL_R_NOTIFY_DEACT BIT(7)
-#define FLAG_HALL_R_ACTIVE      BIT(8)
-#define FLAG_INPUT_A_NOTIFY_ACT BIT(9)
-#define FLAG_INPUT_A_NOTIFY_DEACT BIT(10)
-#define FLAG_INPUT_A_ACTIVE     BIT(11)
-#define FLAG_INPUT_B_NOTIFY_ACT BIT(12)
-#define FLAG_INPUT_B_NOTIFY_DEACT BIT(13)
-#define FLAG_INPUT_B_ACTIVE     BIT(14)
+/* Per-group flag bit positions (mirrored in ttn.js). */
+#define SYSTEM_FLAG_BOOT      BIT(0)
+#define MP_FLAG_TILT          BIT(0)
+#define CNT_FLAG_NOTIFY_ACT   BIT(0)
+#define CNT_FLAG_NOTIFY_DEACT BIT(1)
+#define CNT_FLAG_ACTIVE       BIT(2)
 
-/*
- * Build a protobuf Telemetry message from the current sensor data and encode it
- * into `buf`, dropping low-priority fields until it fits the LoRaWAN payload
- * budget reported by the stack. Sent on fPort 2 (the legacy bitmap used fPort 1).
- *
- * Returns 0 on success (*len = encoded length), -EAGAIN when the budget is not
- * yet known (pre-join), or -EMSGSIZE if even the core fields don't fit / encode
- * fails.
- */
-int app_compose(uint8_t *buf, size_t size, size_t *len)
+/* Sensor groups, in priority order (packed into frames first → last). A group
+ * is the atomic unit: all its fields go into one frame, or none. */
+enum tlm_group {
+	G_INTERNAL = 0, /* temperature, humidity */
+	G_SYSTEM,       /* voltage, system_flags */
+	G_BAROMETER,    /* pressure, altitude */
+	G_LIGHT,        /* illuminance */
+	G_ACCEL,        /* orientation */
+	G_PIR,          /* motion_count */
+	G_EXT1,         /* ext1_temperature */
+	G_EXT2,         /* ext2_temperature */
+	G_MP1,          /* mp1_temperature, mp1_humidity, mp1_flags */
+	G_MP2,          /* mp2_temperature, mp2_humidity, mp2_flags */
+	G_HALL_L,       /* hall_left_count, hall_left_flags */
+	G_HALL_R,       /* hall_right_count, hall_right_flags */
+	G_INPUT_A,      /* input_a_count, input_a_flags */
+	G_INPUT_B,      /* input_b_count, input_b_flags */
+	G_COUNT,
+};
+
+/* Copy (on=true) or clear (on=false) a group's fields from src into dst. With a
+ * frozen snapshot src this both selects a group into a frame and reverts it. */
+static void apply_group(Telemetry *dst, const Telemetry *src, enum tlm_group g, bool on)
+{
+#define SEL(field)                                                                                 \
+	do {                                                                                       \
+		dst->has_##field = on && src->has_##field;                                         \
+		if (on) {                                                                          \
+			dst->field = src->field;                                                   \
+		}                                                                                  \
+	} while (0)
+
+	switch (g) {
+	case G_INTERNAL:
+		SEL(temperature);
+		SEL(humidity);
+		break;
+	case G_SYSTEM:
+		SEL(voltage);
+		SEL(system_flags);
+		break;
+	case G_BAROMETER:
+		SEL(pressure);
+		SEL(altitude);
+		break;
+	case G_LIGHT:
+		SEL(illuminance);
+		break;
+	case G_ACCEL:
+		SEL(orientation);
+		break;
+	case G_PIR:
+		SEL(motion_count);
+		break;
+	case G_EXT1:
+		SEL(ext1_temperature);
+		break;
+	case G_EXT2:
+		SEL(ext2_temperature);
+		break;
+	case G_MP1:
+		SEL(mp1_temperature);
+		SEL(mp1_humidity);
+		SEL(mp1_flags);
+		break;
+	case G_MP2:
+		SEL(mp2_temperature);
+		SEL(mp2_humidity);
+		SEL(mp2_flags);
+		break;
+	case G_HALL_L:
+		SEL(hall_left_count);
+		SEL(hall_left_flags);
+		break;
+	case G_HALL_R:
+		SEL(hall_right_count);
+		SEL(hall_right_flags);
+		break;
+	case G_INPUT_A:
+		SEL(input_a_count);
+		SEL(input_a_flags);
+		break;
+	case G_INPUT_B:
+		SEL(input_b_count);
+		SEL(input_b_flags);
+		break;
+	default:
+		break;
+	}
+#undef SEL
+}
+
+/* True if a group carries any data in the snapshot (any of its fields present). */
+static bool group_present(const Telemetry *s, enum tlm_group g)
+{
+	Telemetry probe = Telemetry_init_zero;
+
+	apply_group(&probe, s, g, true);
+
+	/* Re-encode the probe: empty (no has_ set) → 0 bytes. */
+	size_t sz = 0;
+	pb_get_encoded_size(&sz, Telemetry_fields, &probe);
+	return sz > 0;
+}
+
+/* Snapshot held across the frames of one report (consistency). */
+static Telemetry m_snapshot;
+static uint16_t m_pending;  /* bitmask of enum tlm_group still to send */
+static bool m_active;
+
+static void fill_snapshot(void)
 {
 	static bool boot = true;
 
-	uint8_t budget = app_lrw_get_max_payload();
-	if (budget == 0) {
-		return -EAGAIN;
-	}
-
 	Telemetry t = Telemetry_init_zero;
-	uint32_t flags = boot ? FLAG_BOOT : 0;
+	uint32_t system_flags = boot ? SYSTEM_FLAG_BOOT : 0;
 
-	/* Snapshot hall/input (clears notify edges) before taking the sensor lock. */
 	struct app_hall_data hall;
 	struct app_input_data input;
 	app_hall_get_data_and_clear_notify(&hall);
@@ -78,12 +164,18 @@ int app_compose(uint8_t *buf, size_t size, size_t *len)
 	struct app_sensor_data d = g_app_sensor_data;
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
-	/* --- always-present onboard channels --- */
+	/* system */
 	if (!isnan(d.voltage)) {
 		float v = CLAMP(d.voltage * 50.0f, 0.0f, 255.0f);
 		t.has_voltage = true;
 		t.voltage = (uint32_t)v;
 	}
+	if (system_flags) {
+		t.has_system_flags = true;
+		t.system_flags = system_flags;
+	}
+
+	/* internal */
 	if (!isnan(d.temperature)) {
 		t.has_temperature = true;
 		t.temperature = (int32_t)(d.temperature * 100.0f);
@@ -92,16 +184,8 @@ int app_compose(uint8_t *buf, size_t size, size_t *len)
 		t.has_humidity = true;
 		t.humidity = (uint32_t)(d.humidity * 2.0f);
 	}
-	if (d.orientation != INT_MAX) {
-		t.has_orientation = true;
-		t.orientation = (uint32_t)(d.orientation & 0xf);
-	}
 
-	/* --- capability-gated analog channels --- */
-	if (g_app_config.cap_light_sensor && !isnan(d.illuminance)) {
-		t.has_illuminance = true;
-		t.illuminance = (uint32_t)(d.illuminance / 2.0f);
-	}
+	/* barometer */
 	if (g_app_config.cap_barometer && !isnan(d.pressure)) {
 		t.has_pressure = true;
 		t.pressure = (uint32_t)(d.pressure * 1000.0f);
@@ -111,6 +195,26 @@ int app_compose(uint8_t *buf, size_t size, size_t *len)
 		t.has_altitude = true;
 		t.altitude = (int32_t)a;
 	}
+
+	/* light */
+	if (g_app_config.cap_light_sensor && !isnan(d.illuminance)) {
+		t.has_illuminance = true;
+		t.illuminance = (uint32_t)(d.illuminance / 2.0f);
+	}
+
+	/* accel */
+	if (d.orientation != INT_MAX) {
+		t.has_orientation = true;
+		t.orientation = (uint32_t)(d.orientation & 0xf);
+	}
+
+	/* pir */
+	if (g_app_config.cap_pir_detector && d.motion_count > 0) {
+		t.has_motion_count = true;
+		t.motion_count = d.motion_count;
+	}
+
+	/* 1-wire ext */
 	if (g_app_config.cap_1w_thermometer && !isnan(d.t1_temperature)) {
 		t.has_ext1_temperature = true;
 		t.ext1_temperature = (int32_t)(d.t1_temperature * 100.0f);
@@ -119,142 +223,198 @@ int app_compose(uint8_t *buf, size_t size, size_t *len)
 		t.has_ext2_temperature = true;
 		t.ext2_temperature = (int32_t)(d.t2_temperature * 100.0f);
 	}
-	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp1_temperature)) {
-		t.has_mp1_temperature = true;
-		t.mp1_temperature = (int32_t)(d.mp1_temperature * 100.0f);
-	}
-	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp2_temperature)) {
-		t.has_mp2_temperature = true;
-		t.mp2_temperature = (int32_t)(d.mp2_temperature * 100.0f);
-	}
-	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp1_humidity)) {
-		t.has_mp1_humidity = true;
-		t.mp1_humidity = (uint32_t)(d.mp1_humidity * 2.0f);
-	}
-	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp2_humidity)) {
-		t.has_mp2_humidity = true;
-		t.mp2_humidity = (uint32_t)(d.mp2_humidity * 2.0f);
-	}
 
-	/* --- counters (capability-gated, sent when non-zero) --- */
-	if (g_app_config.cap_pir_detector && d.motion_count > 0) {
-		t.has_motion_count = true;
-		t.motion_count = d.motion_count;
-	}
-	if (g_app_config.cap_hall_left && hall.left_count > 0) {
-		t.has_hall_left_count = true;
-		t.hall_left_count = hall.left_count;
-	}
-	if (g_app_config.cap_hall_right && hall.right_count > 0) {
-		t.has_hall_right_count = true;
-		t.hall_right_count = hall.right_count;
-	}
-	if (g_app_config.cap_input_a && input.input_a_count > 0) {
-		t.has_input_a_count = true;
-		t.input_a_count = input.input_a_count;
-	}
-	if (g_app_config.cap_input_b && input.input_b_count > 0) {
-		t.has_input_b_count = true;
-		t.input_b_count = input.input_b_count;
-	}
-
-	/* --- boolean state into the flags bitfield --- */
+	/* machine probe 1 / 2 */
 	if (g_app_config.cap_1w_machine_probe) {
+		if (!isnan(d.mp1_temperature)) {
+			t.has_mp1_temperature = true;
+			t.mp1_temperature = (int32_t)(d.mp1_temperature * 100.0f);
+		}
+		if (!isnan(d.mp1_humidity)) {
+			t.has_mp1_humidity = true;
+			t.mp1_humidity = (uint32_t)(d.mp1_humidity * 2.0f);
+		}
 		if (d.mp1_is_tilt_alert) {
-			flags |= FLAG_MP1_TILT;
+			t.has_mp1_flags = true;
+			t.mp1_flags = MP_FLAG_TILT;
+		}
+		if (!isnan(d.mp2_temperature)) {
+			t.has_mp2_temperature = true;
+			t.mp2_temperature = (int32_t)(d.mp2_temperature * 100.0f);
+		}
+		if (!isnan(d.mp2_humidity)) {
+			t.has_mp2_humidity = true;
+			t.mp2_humidity = (uint32_t)(d.mp2_humidity * 2.0f);
 		}
 		if (d.mp2_is_tilt_alert) {
-			flags |= FLAG_MP2_TILT;
+			t.has_mp2_flags = true;
+			t.mp2_flags = MP_FLAG_TILT;
 		}
 	}
+
+	/* hall left / right */
 	if (g_app_config.cap_hall_left) {
+		uint32_t f = 0;
 		if (hall.left_notify_act) {
-			flags |= FLAG_HALL_L_NOTIFY_ACT;
+			f |= CNT_FLAG_NOTIFY_ACT;
 		}
 		if (hall.left_notify_deact) {
-			flags |= FLAG_HALL_L_NOTIFY_DEACT;
+			f |= CNT_FLAG_NOTIFY_DEACT;
 		}
 		if (hall.left_is_active) {
-			flags |= FLAG_HALL_L_ACTIVE;
+			f |= CNT_FLAG_ACTIVE;
+		}
+		if (hall.left_count > 0) {
+			t.has_hall_left_count = true;
+			t.hall_left_count = hall.left_count;
+		}
+		if (f) {
+			t.has_hall_left_flags = true;
+			t.hall_left_flags = f;
 		}
 	}
 	if (g_app_config.cap_hall_right) {
+		uint32_t f = 0;
 		if (hall.right_notify_act) {
-			flags |= FLAG_HALL_R_NOTIFY_ACT;
+			f |= CNT_FLAG_NOTIFY_ACT;
 		}
 		if (hall.right_notify_deact) {
-			flags |= FLAG_HALL_R_NOTIFY_DEACT;
+			f |= CNT_FLAG_NOTIFY_DEACT;
 		}
 		if (hall.right_is_active) {
-			flags |= FLAG_HALL_R_ACTIVE;
+			f |= CNT_FLAG_ACTIVE;
+		}
+		if (hall.right_count > 0) {
+			t.has_hall_right_count = true;
+			t.hall_right_count = hall.right_count;
+		}
+		if (f) {
+			t.has_hall_right_flags = true;
+			t.hall_right_flags = f;
 		}
 	}
+
+	/* input A / B */
 	if (g_app_config.cap_input_a) {
+		uint32_t f = 0;
 		if (input.input_a_notify_act) {
-			flags |= FLAG_INPUT_A_NOTIFY_ACT;
+			f |= CNT_FLAG_NOTIFY_ACT;
 		}
 		if (input.input_a_notify_deact) {
-			flags |= FLAG_INPUT_A_NOTIFY_DEACT;
+			f |= CNT_FLAG_NOTIFY_DEACT;
 		}
 		if (input.input_a_is_active) {
-			flags |= FLAG_INPUT_A_ACTIVE;
+			f |= CNT_FLAG_ACTIVE;
+		}
+		if (input.input_a_count > 0) {
+			t.has_input_a_count = true;
+			t.input_a_count = input.input_a_count;
+		}
+		if (f) {
+			t.has_input_a_flags = true;
+			t.input_a_flags = f;
 		}
 	}
 	if (g_app_config.cap_input_b) {
+		uint32_t f = 0;
 		if (input.input_b_notify_act) {
-			flags |= FLAG_INPUT_B_NOTIFY_ACT;
+			f |= CNT_FLAG_NOTIFY_ACT;
 		}
 		if (input.input_b_notify_deact) {
-			flags |= FLAG_INPUT_B_NOTIFY_DEACT;
+			f |= CNT_FLAG_NOTIFY_DEACT;
 		}
 		if (input.input_b_is_active) {
-			flags |= FLAG_INPUT_B_ACTIVE;
+			f |= CNT_FLAG_ACTIVE;
+		}
+		if (input.input_b_count > 0) {
+			t.has_input_b_count = true;
+			t.input_b_count = input.input_b_count;
+		}
+		if (f) {
+			t.has_input_b_flags = true;
+			t.input_b_flags = f;
 		}
 	}
-	if (flags) {
-		t.has_flags = true;
-		t.flags = flags;
+
+	m_snapshot = t;
+	m_pending = 0;
+	for (enum tlm_group g = 0; g < G_COUNT; g++) {
+		if (group_present(&m_snapshot, g)) {
+			m_pending |= BIT(g);
+		}
+	}
+	m_active = true;
+	boot = false;
+}
+
+int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more)
+{
+	uint8_t budget = app_lrw_get_max_payload();
+	if (budget == 0) {
+		return -EAGAIN;
 	}
 
-	/* Priority-ordered drop list (lowest priority first). Core voltage/
-	 * temperature/humidity are never dropped. When the message exceeds the
-	 * budget, clear the lowest-priority set fields until it fits. */
-	bool *drop[] = {
-		&t.has_input_b_count, &t.has_input_a_count,
-		&t.has_hall_right_count, &t.has_hall_left_count,
-		&t.has_motion_count, &t.has_orientation,
-		&t.has_mp2_humidity, &t.has_mp2_temperature,
-		&t.has_mp1_humidity, &t.has_mp1_temperature,
-		&t.has_ext2_temperature, &t.has_ext1_temperature,
-		&t.has_illuminance, &t.has_altitude, &t.has_pressure,
-		&t.has_flags,
-	};
+	if (!m_active) {
+		fill_snapshot();
+		if (m_pending == 0) {
+			/* Nothing to report (e.g. all sensors NaN pre-sample). */
+			*len = 0;
+			*more = false;
+			m_active = false;
+			return 0;
+		}
+	}
 
 	size_t cap = MIN(size, (size_t)budget);
-	size_t needed = 0;
-	uint8_t dropped = 0;
 
-	pb_get_encoded_size(&needed, Telemetry_fields, &t);
-	for (size_t i = 0; needed > cap && i < ARRAY_SIZE(drop); i++) {
-		if (*drop[i]) {
-			*drop[i] = false;
-			dropped++;
-			pb_get_encoded_size(&needed, Telemetry_fields, &t);
+	/* Greedily pack whole pending groups, highest priority first, that fit. */
+	Telemetry frame = Telemetry_init_zero;
+	uint16_t frame_groups = 0;
+
+	for (enum tlm_group g = 0; g < G_COUNT; g++) {
+		if (!(m_pending & BIT(g))) {
+			continue;
+		}
+		apply_group(&frame, &m_snapshot, g, true); /* tentatively add */
+		size_t sz = 0;
+		pb_get_encoded_size(&sz, Telemetry_fields, &frame);
+		if (sz <= cap) {
+			frame_groups |= BIT(g);
+		} else {
+			apply_group(&frame, &m_snapshot, g, false); /* revert */
 		}
 	}
 
-	pb_ostream_t os = pb_ostream_from_buffer(buf, cap);
-	if (!pb_encode(&os, Telemetry_fields, &t)) {
+	/* A single group bigger than the budget would stall forever: force the
+	 * highest-priority pending group out alone and log it. */
+	if (frame_groups == 0) {
+		for (enum tlm_group g = 0; g < G_COUNT; g++) {
+			if (m_pending & BIT(g)) {
+				apply_group(&frame, &m_snapshot, g, true);
+				frame_groups = BIT(g);
+				LOG_WRN("Group %d exceeds budget %uB, sending alone", (int)g, budget);
+				break;
+			}
+		}
+	}
+
+	pb_ostream_t os = pb_ostream_from_buffer(buf, size);
+	if (!pb_encode(&os, Telemetry_fields, &frame)) {
 		LOG_ERR("pb_encode failed: %s", PB_GET_ERROR(&os));
+		m_active = false;
 		return -EMSGSIZE;
 	}
 
+	m_pending &= ~frame_groups;
 	*len = os.bytes_written;
-	boot = false;
+	*more = (m_pending != 0);
+	if (!*more) {
+		m_active = false;
+	}
 
-	LOG_INF("TX: DR budget=%uB (from system), payload=%zuB, %u field(s) dropped", budget,
-		*len, dropped);
-	LOG_HEXDUMP_DBG(buf, *len, "Telemetry:");
+	LOG_INF("TX: budget=%uB (from system), frame=%zuB, groups=0x%04x, more=%d", budget, *len,
+		frame_groups, (int)*more);
+	LOG_HEXDUMP_DBG(buf, *len, "Telemetry frame:");
 
 	return 0;
 }

--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -5,16 +5,23 @@
  */
 
 #include "app_compose.h"
+#include "app_config.h"
 #include "app_hall.h"
 #include "app_input.h"
+#include "app_lrw.h"
 #include "app_sensor.h"
+
+/* Nanopb includes */
+#include <pb_encode.h>
+#include "src/nfc_config.pb.h"
 
 /* Zephyr includes */
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
 
 /* Standard includes */
+#include <errno.h>
 #include <limits.h>
 #include <math.h>
 #include <stdbool.h>
@@ -23,294 +30,231 @@
 
 LOG_MODULE_REGISTER(app_compose, LOG_LEVEL_DBG);
 
+/* Telemetry.flags bit positions (see nfc_config.proto + ttn.js). */
+#define FLAG_BOOT               BIT(0)
+#define FLAG_MP1_TILT           BIT(1)
+#define FLAG_MP2_TILT           BIT(2)
+#define FLAG_HALL_L_NOTIFY_ACT  BIT(3)
+#define FLAG_HALL_L_NOTIFY_DEACT BIT(4)
+#define FLAG_HALL_L_ACTIVE      BIT(5)
+#define FLAG_HALL_R_NOTIFY_ACT  BIT(6)
+#define FLAG_HALL_R_NOTIFY_DEACT BIT(7)
+#define FLAG_HALL_R_ACTIVE      BIT(8)
+#define FLAG_INPUT_A_NOTIFY_ACT BIT(9)
+#define FLAG_INPUT_A_NOTIFY_DEACT BIT(10)
+#define FLAG_INPUT_A_ACTIVE     BIT(11)
+#define FLAG_INPUT_B_NOTIFY_ACT BIT(12)
+#define FLAG_INPUT_B_NOTIFY_DEACT BIT(13)
+#define FLAG_INPUT_B_ACTIVE     BIT(14)
+
+/*
+ * Build a protobuf Telemetry message from the current sensor data and encode it
+ * into `buf`, dropping low-priority fields until it fits the LoRaWAN payload
+ * budget reported by the stack. Sent on fPort 2 (the legacy bitmap used fPort 1).
+ *
+ * Returns 0 on success (*len = encoded length), -EAGAIN when the budget is not
+ * yet known (pre-join), or -EMSGSIZE if even the core fields don't fit / encode
+ * fails.
+ */
 int app_compose(uint8_t *buf, size_t size, size_t *len)
 {
 	static bool boot = true;
 
-	uint32_t header = boot ? BIT(31) : 0;
+	uint8_t budget = app_lrw_get_max_payload();
+	if (budget == 0) {
+		return -EAGAIN;
+	}
 
-	/* For compatibility reasons (indicates header extension from 16 bits to 32 bits) */
-	header |= BIT(20);
+	Telemetry t = Telemetry_init_zero;
+	uint32_t flags = boot ? FLAG_BOOT : 0;
 
-	uint8_t orientation = 0;
-	uint8_t voltage = 0xff;
-
-	int16_t temperature = 0x7fff;
-	uint8_t humidity = 0xff;
-	uint16_t illuminance = 0xffff;
-	int16_t altitude = 0x7fff;
-	uint32_t pressure = 0xffffffff;
-
-	struct app_hall_data hall_data;
-	uint32_t hall_left_count = 0;
-	uint32_t hall_right_count = 0;
-
-	struct app_input_data input_data;
-	uint32_t input_a_count = 0;
-	uint32_t input_b_count = 0;
-
-	uint32_t motion_count = 0xffffffff;
-	int16_t t1_temperature = 0x7fff;
-	int16_t t2_temperature = 0x7fff;
-
-	int16_t mp1_temperature = 0x7fff;
-	int16_t mp2_temperature = 0x7fff;
-	uint8_t mp1_humidity = 0xff;
-	uint8_t mp2_humidity = 0xff;
-
-	app_hall_get_data_and_clear_notify(&hall_data);
-	app_input_get_data_and_clear_notify(&input_data);
+	/* Snapshot hall/input (clears notify edges) before taking the sensor lock. */
+	struct app_hall_data hall;
+	struct app_input_data input;
+	app_hall_get_data_and_clear_notify(&hall);
+	app_input_get_data_and_clear_notify(&input);
 
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
-
-	if (g_app_sensor_data.orientation != INT_MAX) {
-		orientation = g_app_sensor_data.orientation & 0xf;
-		header |= BIT(30);
-	}
-
-	if (!isnan(g_app_sensor_data.voltage)) {
-		float v = g_app_sensor_data.voltage * 50;
-		if (v > 255.f) {
-			v = 255.f;
-		} else if (v < 0.f) {
-			v = 0.f;
-		}
-		voltage = (uint8_t)v;
-		header |= BIT(29);
-	}
-
-	if (!isnan(g_app_sensor_data.temperature)) {
-		temperature = (int16_t)(g_app_sensor_data.temperature * 100);
-		header |= BIT(28);
-	}
-
-	if (!isnan(g_app_sensor_data.humidity)) {
-		humidity = (uint8_t)(g_app_sensor_data.humidity * 2);
-		header |= BIT(27);
-	}
-
-	if (!isnan(g_app_sensor_data.illuminance)) {
-		illuminance = (uint16_t)(g_app_sensor_data.illuminance / 2);
-		header |= BIT(26);
-	}
-
-	if (!isnan(g_app_sensor_data.t1_temperature)) {
-		t1_temperature = (int16_t)(g_app_sensor_data.t1_temperature * 100);
-		header |= BIT(25);
-	}
-
-	if (!isnan(g_app_sensor_data.t2_temperature)) {
-		t2_temperature = (int16_t)(g_app_sensor_data.t2_temperature * 100);
-		header |= BIT(24);
-	}
-
-	motion_count = g_app_sensor_data.motion_count;
-	if (motion_count > 0) {
-		header |= BIT(23);
-	}
-
-	if (!isnan(g_app_sensor_data.altitude)) {
-		float alt_scaled = g_app_sensor_data.altitude * 10;
-
-		if (alt_scaled > INT16_MAX) {
-			alt_scaled = INT16_MAX;
-		} else if (alt_scaled < INT16_MIN) {
-			alt_scaled = INT16_MIN;
-		}
-
-		altitude = (int16_t)alt_scaled;
-		header |= BIT(22);
-	}
-
-	if (!isnan(g_app_sensor_data.pressure)) {
-		pressure = (uint32_t)(g_app_sensor_data.pressure * 1000.f);
-		header |= BIT(21);
-	}
-
-	if (!isnan(g_app_sensor_data.mp1_temperature)) {
-		mp1_temperature = (int16_t)(g_app_sensor_data.mp1_temperature * 100);
-		header |= BIT(19);
-	}
-
-	if (!isnan(g_app_sensor_data.mp2_temperature)) {
-		mp2_temperature = (int16_t)(g_app_sensor_data.mp2_temperature * 100);
-		header |= BIT(18);
-	}
-
-	if (!isnan(g_app_sensor_data.mp1_humidity)) {
-		mp1_humidity = (uint8_t)(g_app_sensor_data.mp1_humidity * 2);
-		header |= BIT(17);
-	}
-
-	if (!isnan(g_app_sensor_data.mp2_humidity)) {
-		mp2_humidity = (uint8_t)(g_app_sensor_data.mp2_humidity * 2);
-		header |= BIT(16);
-	}
-
-	if (g_app_sensor_data.mp1_is_tilt_alert) {
-		header |= BIT(15);
-	}
-
-	if (g_app_sensor_data.mp2_is_tilt_alert) {
-		header |= BIT(14);
-	}
-
-	hall_left_count = hall_data.left_count;
-	hall_right_count = hall_data.right_count;
-
-	if (hall_left_count > 0) {
-		header |= BIT(13);
-	}
-
-	if (hall_right_count > 0) {
-		header |= BIT(12);
-	}
-
-	input_a_count = input_data.input_a_count;
-	input_b_count = input_data.input_b_count;
-
-	if (input_a_count > 0 || input_data.input_a_notify_act || input_data.input_a_notify_deact) {
-		header |= BIT(5);
-	}
-
-	if (input_b_count > 0 || input_data.input_b_notify_act || input_data.input_b_notify_deact) {
-		header |= BIT(4);
-	}
-
+	struct app_sensor_data d = g_app_sensor_data;
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
-	/* Add hall notify events to header */
-	if (hall_data.left_notify_act) {
-		header |= BIT(11);
+	/* --- always-present onboard channels --- */
+	if (!isnan(d.voltage)) {
+		float v = CLAMP(d.voltage * 50.0f, 0.0f, 255.0f);
+		t.has_voltage = true;
+		t.voltage = (uint32_t)v;
 	}
-	if (hall_data.left_notify_deact) {
-		header |= BIT(10);
+	if (!isnan(d.temperature)) {
+		t.has_temperature = true;
+		t.temperature = (int32_t)(d.temperature * 100.0f);
 	}
-	if (hall_data.right_notify_act) {
-		header |= BIT(9);
+	if (!isnan(d.humidity)) {
+		t.has_humidity = true;
+		t.humidity = (uint32_t)(d.humidity * 2.0f);
 	}
-	if (hall_data.right_notify_deact) {
-		header |= BIT(8);
-	}
-
-	/* Add hall active states to header */
-	if (hall_data.left_is_active) {
-		header |= BIT(7);
-	}
-	if (hall_data.right_is_active) {
-		header |= BIT(6);
+	if (d.orientation != INT_MAX) {
+		t.has_orientation = true;
+		t.orientation = (uint32_t)(d.orientation & 0xf);
 	}
 
-	header |= orientation;
-
-	LOG_DBG("Header: 0x%08x", header);
-
-	struct net_buf_simple nbuf;
-
-	net_buf_simple_init_with_data(&nbuf, buf, size);
-	net_buf_simple_reset(&nbuf);
-
-	net_buf_simple_add_be32(&nbuf, header);
-
-	if (header & BIT(29)) {
-		net_buf_simple_add_u8(&nbuf, voltage);
+	/* --- capability-gated analog channels --- */
+	if (g_app_config.cap_light_sensor && !isnan(d.illuminance)) {
+		t.has_illuminance = true;
+		t.illuminance = (uint32_t)(d.illuminance / 2.0f);
+	}
+	if (g_app_config.cap_barometer && !isnan(d.pressure)) {
+		t.has_pressure = true;
+		t.pressure = (uint32_t)(d.pressure * 1000.0f);
+	}
+	if (g_app_config.cap_barometer && !isnan(d.altitude)) {
+		float a = CLAMP(d.altitude * 10.0f, (float)INT16_MIN, (float)INT16_MAX);
+		t.has_altitude = true;
+		t.altitude = (int32_t)a;
+	}
+	if (g_app_config.cap_1w_thermometer && !isnan(d.t1_temperature)) {
+		t.has_ext1_temperature = true;
+		t.ext1_temperature = (int32_t)(d.t1_temperature * 100.0f);
+	}
+	if (g_app_config.cap_1w_thermometer && !isnan(d.t2_temperature)) {
+		t.has_ext2_temperature = true;
+		t.ext2_temperature = (int32_t)(d.t2_temperature * 100.0f);
+	}
+	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp1_temperature)) {
+		t.has_mp1_temperature = true;
+		t.mp1_temperature = (int32_t)(d.mp1_temperature * 100.0f);
+	}
+	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp2_temperature)) {
+		t.has_mp2_temperature = true;
+		t.mp2_temperature = (int32_t)(d.mp2_temperature * 100.0f);
+	}
+	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp1_humidity)) {
+		t.has_mp1_humidity = true;
+		t.mp1_humidity = (uint32_t)(d.mp1_humidity * 2.0f);
+	}
+	if (g_app_config.cap_1w_machine_probe && !isnan(d.mp2_humidity)) {
+		t.has_mp2_humidity = true;
+		t.mp2_humidity = (uint32_t)(d.mp2_humidity * 2.0f);
 	}
 
-	if (header & BIT(28)) {
-		net_buf_simple_add_be16(&nbuf, (uint16_t)temperature);
+	/* --- counters (capability-gated, sent when non-zero) --- */
+	if (g_app_config.cap_pir_detector && d.motion_count > 0) {
+		t.has_motion_count = true;
+		t.motion_count = d.motion_count;
+	}
+	if (g_app_config.cap_hall_left && hall.left_count > 0) {
+		t.has_hall_left_count = true;
+		t.hall_left_count = hall.left_count;
+	}
+	if (g_app_config.cap_hall_right && hall.right_count > 0) {
+		t.has_hall_right_count = true;
+		t.hall_right_count = hall.right_count;
+	}
+	if (g_app_config.cap_input_a && input.input_a_count > 0) {
+		t.has_input_a_count = true;
+		t.input_a_count = input.input_a_count;
+	}
+	if (g_app_config.cap_input_b && input.input_b_count > 0) {
+		t.has_input_b_count = true;
+		t.input_b_count = input.input_b_count;
 	}
 
-	if (header & BIT(27)) {
-		net_buf_simple_add_u8(&nbuf, humidity);
-	}
-
-	if (header & BIT(26)) {
-		net_buf_simple_add_be16(&nbuf, illuminance);
-	}
-
-	if (header & BIT(25)) {
-		net_buf_simple_add_be16(&nbuf, (uint16_t)t1_temperature);
-	}
-
-	if (header & BIT(24)) {
-		net_buf_simple_add_be16(&nbuf, (uint16_t)t2_temperature);
-	}
-
-	if (header & BIT(23)) {
-		net_buf_simple_add_be32(&nbuf, motion_count);
-	}
-
-	if (header & BIT(22)) {
-		net_buf_simple_add_be16(&nbuf, (uint16_t)altitude);
-	}
-
-	if (header & BIT(21)) {
-		net_buf_simple_add_be32(&nbuf, pressure);
-	}
-
-	if (header & BIT(19)) {
-		net_buf_simple_add_be16(&nbuf, (uint16_t)mp1_temperature);
-	}
-
-	if (header & BIT(18)) {
-		net_buf_simple_add_be16(&nbuf, (uint16_t)mp2_temperature);
-	}
-
-	if (header & BIT(17)) {
-		net_buf_simple_add_u8(&nbuf, mp1_humidity);
-	}
-
-	if (header & BIT(16)) {
-		net_buf_simple_add_u8(&nbuf, mp2_humidity);
-	}
-
-	if (header & BIT(13)) {
-		net_buf_simple_add_be32(&nbuf, hall_left_count);
-	}
-
-	if (header & BIT(12)) {
-		net_buf_simple_add_be32(&nbuf, hall_right_count);
-	}
-
-	if (header & BIT(5)) {
-		net_buf_simple_add_be32(&nbuf, input_a_count);
-		/* Append status byte: bit 3=notify_act, bit 2=notify_deact, bit 1=reserved, bit
-		 * 0=is_active */
-		uint8_t status_a = 0;
-		if (input_data.input_a_notify_act) {
-			status_a |= BIT(3);
+	/* --- boolean state into the flags bitfield --- */
+	if (g_app_config.cap_1w_machine_probe) {
+		if (d.mp1_is_tilt_alert) {
+			flags |= FLAG_MP1_TILT;
 		}
-		if (input_data.input_a_notify_deact) {
-			status_a |= BIT(2);
+		if (d.mp2_is_tilt_alert) {
+			flags |= FLAG_MP2_TILT;
 		}
-		if (input_data.input_a_is_active) {
-			status_a |= BIT(0);
+	}
+	if (g_app_config.cap_hall_left) {
+		if (hall.left_notify_act) {
+			flags |= FLAG_HALL_L_NOTIFY_ACT;
 		}
-		net_buf_simple_add_u8(&nbuf, status_a);
+		if (hall.left_notify_deact) {
+			flags |= FLAG_HALL_L_NOTIFY_DEACT;
+		}
+		if (hall.left_is_active) {
+			flags |= FLAG_HALL_L_ACTIVE;
+		}
+	}
+	if (g_app_config.cap_hall_right) {
+		if (hall.right_notify_act) {
+			flags |= FLAG_HALL_R_NOTIFY_ACT;
+		}
+		if (hall.right_notify_deact) {
+			flags |= FLAG_HALL_R_NOTIFY_DEACT;
+		}
+		if (hall.right_is_active) {
+			flags |= FLAG_HALL_R_ACTIVE;
+		}
+	}
+	if (g_app_config.cap_input_a) {
+		if (input.input_a_notify_act) {
+			flags |= FLAG_INPUT_A_NOTIFY_ACT;
+		}
+		if (input.input_a_notify_deact) {
+			flags |= FLAG_INPUT_A_NOTIFY_DEACT;
+		}
+		if (input.input_a_is_active) {
+			flags |= FLAG_INPUT_A_ACTIVE;
+		}
+	}
+	if (g_app_config.cap_input_b) {
+		if (input.input_b_notify_act) {
+			flags |= FLAG_INPUT_B_NOTIFY_ACT;
+		}
+		if (input.input_b_notify_deact) {
+			flags |= FLAG_INPUT_B_NOTIFY_DEACT;
+		}
+		if (input.input_b_is_active) {
+			flags |= FLAG_INPUT_B_ACTIVE;
+		}
+	}
+	if (flags) {
+		t.has_flags = true;
+		t.flags = flags;
 	}
 
-	if (header & BIT(4)) {
-		net_buf_simple_add_be32(&nbuf, input_b_count);
-		/* Append status byte: bit 3=notify_act, bit 2=notify_deact, bit 1=reserved, bit
-		 * 0=is_active */
-		uint8_t status_b = 0;
-		if (input_data.input_b_notify_act) {
-			status_b |= BIT(3);
+	/* Priority-ordered drop list (lowest priority first). Core voltage/
+	 * temperature/humidity are never dropped. When the message exceeds the
+	 * budget, clear the lowest-priority set fields until it fits. */
+	bool *drop[] = {
+		&t.has_input_b_count, &t.has_input_a_count,
+		&t.has_hall_right_count, &t.has_hall_left_count,
+		&t.has_motion_count, &t.has_orientation,
+		&t.has_mp2_humidity, &t.has_mp2_temperature,
+		&t.has_mp1_humidity, &t.has_mp1_temperature,
+		&t.has_ext2_temperature, &t.has_ext1_temperature,
+		&t.has_illuminance, &t.has_altitude, &t.has_pressure,
+		&t.has_flags,
+	};
+
+	size_t cap = MIN(size, (size_t)budget);
+	size_t needed = 0;
+	uint8_t dropped = 0;
+
+	pb_get_encoded_size(&needed, Telemetry_fields, &t);
+	for (size_t i = 0; needed > cap && i < ARRAY_SIZE(drop); i++) {
+		if (*drop[i]) {
+			*drop[i] = false;
+			dropped++;
+			pb_get_encoded_size(&needed, Telemetry_fields, &t);
 		}
-		if (input_data.input_b_notify_deact) {
-			status_b |= BIT(2);
-		}
-		if (input_data.input_b_is_active) {
-			status_b |= BIT(0);
-		}
-		net_buf_simple_add_u8(&nbuf, status_b);
 	}
 
-	*len = nbuf.len;
+	pb_ostream_t os = pb_ostream_from_buffer(buf, cap);
+	if (!pb_encode(&os, Telemetry_fields, &t)) {
+		LOG_ERR("pb_encode failed: %s", PB_GET_ERROR(&os));
+		return -EMSGSIZE;
+	}
 
-	LOG_HEXDUMP_DBG(buf, *len, "Composed buffer:");
-
+	*len = os.bytes_written;
 	boot = false;
+
+	LOG_INF("TX: DR budget=%uB (from system), payload=%zuB, %u field(s) dropped", budget,
+		*len, dropped);
+	LOG_HEXDUMP_DBG(buf, *len, "Telemetry:");
 
 	return 0;
 }

--- a/app/src/app_compose.h
+++ b/app/src/app_compose.h
@@ -8,6 +8,7 @@
 #define APP_COMPOSE_H_
 
 /* Standard includes */
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -15,7 +16,15 @@
 extern "C" {
 #endif
 
-int app_compose(uint8_t *buf, size_t size, size_t *len);
+/* Compose one telemetry frame into `buf` (max `size`, also bounded by the
+ * LoRaWAN payload budget). On the first call of a report a consistent snapshot
+ * of all sensor groups is taken; each call emits the highest-priority pending
+ * groups that fit (whole groups only). *len = encoded length, *more = true when
+ * groups remain for a follow-up frame of the same snapshot (send ASAP).
+ *
+ * Returns 0 on success, -EAGAIN when the payload budget is unknown (pre-join),
+ * or -EMSGSIZE on encode failure. */
+int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -57,7 +57,23 @@ static K_THREAD_STACK_DEFINE(m_work_stack, 2048);
 static struct k_work_q m_work_q;
 static struct k_timer m_send_timer;
 static struct k_work m_send_work;
+static struct k_work_delayable m_frame_work; /* multi-frame snapshot continuation */
 static struct k_work m_join_work;
+
+/* Multi-frame telemetry: gap before the next frame of the same snapshot (covers
+ * RX1/RX2 windows) and backoff when a send is refused (duty cycle / MAC busy). */
+#define FRAME_GAP_SEC   3
+#define FRAME_RETRY_SEC 15
+
+/* Current telemetry frame, kept so a failed send can be retried verbatim
+ * (app_compose already consumed those groups from its snapshot). */
+static uint8_t m_frame_buf[64];
+static size_t  m_frame_len;
+static bool    m_frame_more;    /* more frames remain in this snapshot */
+static bool    m_frame_first;   /* this frame is the snapshot's first (for LC) */
+static bool    m_frame_resend;  /* last send failed; resend m_frame_buf as-is */
+
+static void tx_telemetry_frame(bool first_frame);
 
 static atomic_t m_state = ATOMIC_INIT(APP_LRW_STATE_IDLE);
 static struct k_timer m_link_check_timer;
@@ -602,7 +618,6 @@ static bool should_request_link_check(void)
 static void send_work_handler(struct k_work *work)
 {
 	int ret;
-	bool with_link_check;
 
 	/* Block normal transmissions during calibration mode */
 	if (g_app_config.calibration) {
@@ -641,67 +656,104 @@ static void send_work_handler(struct k_work *work)
 	}
 	k_mutex_unlock(&m_pending_response_lock);
 
-	int timeout = g_app_config.interval_report;
-
-#if defined(CONFIG_ENTROPY_GENERATOR)
-	timeout += (int32_t)sys_rand32_get() % (g_app_config.interval_report / 10);
-#endif /* defined(CONFIG_ENTROPY_GENERATOR) */
-
-	LOG_INF("Scheduling next timeout in %d seconds", timeout);
-
-	k_timer_start(&m_send_timer, K_SECONDS(timeout), K_FOREVER);
-
+	/* Sample fresh sensor values for a new report (the snapshot is taken inside
+	 * app_compose on the first frame). */
 	if (!g_app_config.interval_sample) {
 		app_sensor_sample();
 	}
 
-	uint8_t buf[64];
-	size_t len;
-	ret = app_compose(buf, sizeof(buf), &len);
-	if (ret == -EAGAIN) {
-		/* Budget unknown (not joined yet) — skip this TX. */
-		LOG_DBG("Telemetry budget unavailable, skipping TX");
-		return;
-	}
-	if (ret) {
-		LOG_ERR_CALL_FAILED_INT("app_compose", ret);
-		return;
+	m_frame_resend = false; /* start a new snapshot */
+	tx_telemetry_frame(true);
+}
+
+/* Compose+send one telemetry frame on fPort 2. With more==true the snapshot
+ * isn't drained yet, so the next frame is scheduled ASAP (after the RX windows
+ * / duty-cycle), not at the next interval_report. A failed send is retried with
+ * the same bytes so no group is lost (split is lossless). */
+static void tx_telemetry_frame(bool first_frame)
+{
+	int ret;
+
+	if (!m_frame_resend) {
+		ret = app_compose(m_frame_buf, sizeof(m_frame_buf), &m_frame_len, &m_frame_more);
+		if (ret == -EAGAIN) {
+			LOG_DBG("Telemetry budget unavailable, skipping TX");
+			return;
+		}
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("app_compose", ret);
+			return;
+		}
+		if (m_frame_len == 0) {
+			/* Nothing to report; resume the periodic timer. */
+			k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report),
+				      K_FOREVER);
+			return;
+		}
+		m_frame_first = first_frame;
 	}
 
-	/* Determine if this message should have link check.
-	 * Skip if LC is already pending (e.g. from send_with_lc path). */
-	with_link_check = !m_link_check_pending && should_request_link_check();
-
+	/* Link check only on the first frame of a snapshot. */
+	bool with_link_check =
+		m_frame_first && !m_link_check_pending && should_request_link_check();
 	if (with_link_check) {
 		ret = lorawan_request_link_check(false);
 		if (ret) {
 			LOG_ERR("Link check request failed: %d", ret);
+			with_link_check = false;
 		} else {
 			m_link_check_pending = true;
-			/* Start timeout timer for response */
-			k_timer_start(&m_link_check_timer,
-				      K_SECONDS(LINK_CHECK_TIMEOUT_SEC), K_FOREVER);
-			LOG_INF("Sending data with LC (msg #%u)...", m_message_count + 1);
+			k_timer_start(&m_link_check_timer, K_SECONDS(LINK_CHECK_TIMEOUT_SEC),
+				      K_FOREVER);
 		}
-	} else {
-		LOG_INF("Sending data (msg #%u)...", m_message_count + 1);
 	}
 
+	LOG_INF("Sending data (msg #%u, %s)...", m_message_count + 1,
+		m_frame_more ? "more pending" : "last frame");
+
 	/* Protobuf Telemetry on fPort 2 (legacy bitmap used fPort 1). */
-	ret = lorawan_send(2, buf, len, LORAWAN_MSG_UNCONFIRMED);
+	ret = lorawan_send(2, m_frame_buf, m_frame_len, LORAWAN_MSG_UNCONFIRMED);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("lorawan_send", ret);
 		if (with_link_check) {
 			m_link_check_pending = false;
 			k_timer_stop(&m_link_check_timer);
 		}
+		/* Likely duty-cycle / MAC busy — retry the same frame shortly. */
+		m_frame_resend = true;
+		k_work_schedule_for_queue(&m_work_q, &m_frame_work, K_SECONDS(FRAME_RETRY_SEC));
 		return;
 	}
 
-	/* Increment message counter after successful send */
+	m_frame_resend = false;
 	m_message_count++;
 
-	LOG_INF("Data sent");
+	if (m_frame_more) {
+		/* Same snapshot has more groups — send the next frame as soon as the
+		 * MAC allows; keep the periodic timer stopped until the snapshot drains. */
+		k_work_schedule_for_queue(&m_work_q, &m_frame_work, K_SECONDS(FRAME_GAP_SEC));
+	} else {
+		int timeout = g_app_config.interval_report;
+#if defined(CONFIG_ENTROPY_GENERATOR)
+		timeout += (int32_t)sys_rand32_get() % (g_app_config.interval_report / 10);
+#endif /* defined(CONFIG_ENTROPY_GENERATOR) */
+		LOG_INF("Snapshot complete; next report in %d s", timeout);
+		k_timer_start(&m_send_timer, K_SECONDS(timeout), K_FOREVER);
+	}
+}
+
+static void frame_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	enum app_lrw_state state = (enum app_lrw_state)atomic_get(&m_state);
+	if (state == APP_LRW_STATE_JOINING || state == APP_LRW_STATE_RECONNECT) {
+		/* Lost the link mid-snapshot; abandon the remaining frames. */
+		LOG_WRN("Frame continuation aborted: state=%d", (int)state);
+		return;
+	}
+
+	tx_telemetry_frame(false);
 }
 
 static void send_timer_handler(struct k_timer *timer)
@@ -828,6 +880,7 @@ int app_lrw_init(void)
 
 	k_work_init(&m_join_work, join_work_handler);
 	k_work_init(&m_send_work, send_work_handler);
+	k_work_init_delayable(&m_frame_work, frame_work_handler);
 	k_work_init(&m_link_check_work, link_check_work_handler);
 	k_work_init(&m_downlink_success_work, downlink_success_work_handler);
 	k_work_init(&m_lc_response_work, lc_response_work_handler);

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -78,6 +78,9 @@ static struct k_work_delayable m_join_complete_work;
 #define JOIN_BUSY_MAX_POLLS         30
 
 static int m_current_dr;
+/* Application-payload budget (bytes) for the next TX, sourced from the LoRaWAN
+ * stack (lorawan_get_payload_sizes); 0 until the first DR callback / join. */
+static uint8_t m_max_next_payload;
 static int16_t m_last_rssi;
 static int8_t m_last_snr;
 static uint8_t m_last_margin;
@@ -216,7 +219,13 @@ static void datarate_changed_callback(enum lorawan_datarate dr)
 
 	lorawan_get_payload_sizes(&max_next_payload_size, &max_payload_size);
 	m_current_dr = dr;
+	m_max_next_payload = max_next_payload_size;
 	LOG_INF("New data rate: DR%d, Maximum payload size: %d", dr, max_payload_size);
+}
+
+uint8_t app_lrw_get_max_payload(void)
+{
+	return m_max_next_payload;
 }
 
 static void join_complete_work_handler(struct k_work *work)
@@ -274,6 +283,14 @@ static void join_complete_work_handler(struct k_work *work)
 	LOG_INF("Join successful - transitioning to HEALTHY");
 	m_init_join = false;  /* Next join will be rejoin with MAC reset */
 	lorawan_enable_adr(g_app_config.lrw_adr);
+
+	/* Capture the initial DR's payload budget; the DR-changed callback may not
+	 * fire on join, so query it explicitly here. */
+	{
+		uint8_t max_next, max_now;
+		lorawan_get_payload_sizes(&max_next, &max_now);
+		m_max_next_payload = max_next;
+	}
 	atomic_set(&m_state, APP_LRW_STATE_HEALTHY);
 	m_rejoin_attempts = 0;
 
@@ -638,9 +655,14 @@ static void send_work_handler(struct k_work *work)
 		app_sensor_sample();
 	}
 
-	uint8_t buf[51];
+	uint8_t buf[64];
 	size_t len;
 	ret = app_compose(buf, sizeof(buf), &len);
+	if (ret == -EAGAIN) {
+		/* Budget unknown (not joined yet) — skip this TX. */
+		LOG_DBG("Telemetry budget unavailable, skipping TX");
+		return;
+	}
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("app_compose", ret);
 		return;
@@ -665,7 +687,8 @@ static void send_work_handler(struct k_work *work)
 		LOG_INF("Sending data (msg #%u)...", m_message_count + 1);
 	}
 
-	ret = lorawan_send(1, buf, len, LORAWAN_MSG_UNCONFIRMED);
+	/* Protobuf Telemetry on fPort 2 (legacy bitmap used fPort 1). */
+	ret = lorawan_send(2, buf, len, LORAWAN_MSG_UNCONFIRMED);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("lorawan_send", ret);
 		if (with_link_check) {

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -52,6 +52,12 @@ enum app_lrw_state app_lrw_get_state(void);
 int app_lrw_get_info(struct app_lrw_info *info);
 bool app_lrw_is_ready(void);
 
+/* Current application-payload budget (bytes) for the next uplink, taken from the
+ * LoRaWAN stack (lorawan_get_payload_sizes) and refreshed on every DR change and
+ * after join. 0 when unknown (before the first join). app_compose() uses this to
+ * decide how many telemetry fields fit. */
+uint8_t app_lrw_get_max_payload(void);
+
 /* Stage a serialized response (e.g. DownlinkResponse on port 85) for the next
  * uplink. send_work_handler() drains this slot before composing telemetry, so
  * the response leaves at the next jitter window. Single-slot, overwritten with

--- a/app/src/nfc_config.proto
+++ b/app/src/nfc_config.proto
@@ -200,37 +200,51 @@ message DownlinkResponse {
 }
 
 // Periodic / event-triggered telemetry uplink, sent on fPort 2 (legacy bitmap
-// stays on fPort 1). Flat schema: a field is present only when its sensor is
-// connected (capability on) and has valid data; the composer drops low-priority
-// fields to fit the LoRaWAN payload budget. Scalars are scaled integers
-// (varint) to stay compact; boolean state is packed into `flags`. The same
-// message is emitted for both periodic reports and event triggers.
+// stays on fPort 1). Fields are grouped per sensor; each group's boolean state
+// lives in its own `*_flags` field so a sensor's data stays together as an
+// atomic unit. A field is present only when its sensor is connected (capability
+// on) and has valid data. The composer packs whole groups by priority into one
+// or more frames to fit the LoRaWAN payload budget (split, never drop); all
+// frames of a report carry the same snapshot. Scalars are scaled-int varints.
+// The same message is emitted for periodic reports and event triggers.
 message Telemetry {
+    // system
     optional uint32 voltage          = 1;   // V    x50
-    optional sint32 temperature      = 2;   // degC x100  (SHT4x)
-    optional uint32 humidity         = 3;   // %RH  x2
-    optional uint32 illuminance      = 4;   // lux  /2     (cap_light_sensor)
-    optional uint32 pressure         = 5;   // hPa  x1000  (cap_barometer)
+    optional uint32 system_flags     = 2;   // bit0 boot
+    // internal (SHT4x)
+    optional sint32 temperature      = 3;   // degC x100
+    optional uint32 humidity         = 4;   // %RH  x2
+    // barometer (cap_barometer)
+    optional uint32 pressure         = 5;   // hPa  x1000
     optional sint32 altitude         = 6;   // m    x10
-    optional sint32 ext1_temperature = 7;   // degC x100   (cap_1w_thermometer)
-    optional sint32 ext2_temperature = 8;   // degC x100
-    optional sint32 mp1_temperature  = 9;   // degC x100   (cap_1w_machine_probe)
-    optional sint32 mp2_temperature  = 10;  // degC x100
-    optional uint32 mp1_humidity     = 11;  // %RH  x2
-    optional uint32 mp2_humidity     = 12;  // %RH  x2
-    optional uint32 orientation      = 13;  // 1..6
-    optional uint32 motion_count     = 14;
-    optional uint32 hall_left_count  = 15;  // cap_hall_left
-    optional uint32 hall_right_count = 16;  // cap_hall_right
-    optional uint32 input_a_count    = 17;  // cap_input_a
-    optional uint32 input_b_count    = 18;  // cap_input_b
-
-    // Boolean state bitfield (set only when any bit is true):
-    //   bit 0  boot                  bit 1  mp1_tilt          bit 2  mp2_tilt
-    //   bit 3  hall_left_notify_act   bit 4  hall_left_notify_deact   bit 5  hall_left_active
-    //   bit 6  hall_right_notify_act  bit 7  hall_right_notify_deact  bit 8  hall_right_active
-    //   bit 9  input_a_notify_act     bit 10 input_a_notify_deact     bit 11 input_a_active
-    //   bit 12 input_b_notify_act     bit 13 input_b_notify_deact     bit 14 input_b_active
-    optional uint32 flags            = 19;
-    // New sensors append at field >= 20; never renumber existing fields.
+    // light (cap_light_sensor)
+    optional uint32 illuminance      = 7;   // lux  /2
+    // accelerometer
+    optional uint32 orientation      = 8;   // 1..6
+    // pir (cap_pir_detector)
+    optional uint32 motion_count     = 9;
+    // 1-wire external thermometers (cap_1w_thermometer)
+    optional sint32 ext1_temperature = 10;  // degC x100
+    optional sint32 ext2_temperature = 11;  // degC x100
+    // machine probe 1 (cap_1w_machine_probe)
+    optional sint32 mp1_temperature  = 12;  // degC x100
+    optional uint32 mp1_humidity     = 13;  // %RH  x2
+    optional uint32 mp1_flags        = 14;  // bit0 tilt
+    // machine probe 2
+    optional sint32 mp2_temperature  = 15;  // degC x100
+    optional uint32 mp2_humidity     = 16;  // %RH  x2
+    optional uint32 mp2_flags        = 17;  // bit0 tilt
+    // hall left (cap_hall_left)
+    optional uint32 hall_left_count  = 18;
+    optional uint32 hall_left_flags  = 19;  // bit0 notify_act, bit1 notify_deact, bit2 active
+    // hall right (cap_hall_right)
+    optional uint32 hall_right_count = 20;
+    optional uint32 hall_right_flags = 21;
+    // input A (cap_input_a)
+    optional uint32 input_a_count    = 22;
+    optional uint32 input_a_flags    = 23;  // bit0 notify_act, bit1 notify_deact, bit2 active
+    // input B (cap_input_b)
+    optional uint32 input_b_count    = 24;
+    optional uint32 input_b_flags    = 25;
+    // New sensors append at field >= 26 as new groups; never renumber.
 }

--- a/app/src/nfc_config.proto
+++ b/app/src/nfc_config.proto
@@ -198,3 +198,39 @@ message DownlinkResponse {
         string detail       = 3;
     }
 }
+
+// Periodic / event-triggered telemetry uplink, sent on fPort 2 (legacy bitmap
+// stays on fPort 1). Flat schema: a field is present only when its sensor is
+// connected (capability on) and has valid data; the composer drops low-priority
+// fields to fit the LoRaWAN payload budget. Scalars are scaled integers
+// (varint) to stay compact; boolean state is packed into `flags`. The same
+// message is emitted for both periodic reports and event triggers.
+message Telemetry {
+    optional uint32 voltage          = 1;   // V    x50
+    optional sint32 temperature      = 2;   // degC x100  (SHT4x)
+    optional uint32 humidity         = 3;   // %RH  x2
+    optional uint32 illuminance      = 4;   // lux  /2     (cap_light_sensor)
+    optional uint32 pressure         = 5;   // hPa  x1000  (cap_barometer)
+    optional sint32 altitude         = 6;   // m    x10
+    optional sint32 ext1_temperature = 7;   // degC x100   (cap_1w_thermometer)
+    optional sint32 ext2_temperature = 8;   // degC x100
+    optional sint32 mp1_temperature  = 9;   // degC x100   (cap_1w_machine_probe)
+    optional sint32 mp2_temperature  = 10;  // degC x100
+    optional uint32 mp1_humidity     = 11;  // %RH  x2
+    optional uint32 mp2_humidity     = 12;  // %RH  x2
+    optional uint32 orientation      = 13;  // 1..6
+    optional uint32 motion_count     = 14;
+    optional uint32 hall_left_count  = 15;  // cap_hall_left
+    optional uint32 hall_right_count = 16;  // cap_hall_right
+    optional uint32 input_a_count    = 17;  // cap_input_a
+    optional uint32 input_b_count    = 18;  // cap_input_b
+
+    // Boolean state bitfield (set only when any bit is true):
+    //   bit 0  boot                  bit 1  mp1_tilt          bit 2  mp2_tilt
+    //   bit 3  hall_left_notify_act   bit 4  hall_left_notify_deact   bit 5  hall_left_active
+    //   bit 6  hall_right_notify_act  bit 7  hall_right_notify_deact  bit 8  hall_right_active
+    //   bit 9  input_a_notify_act     bit 10 input_a_notify_deact     bit 11 input_a_active
+    //   bit 12 input_b_notify_act     bit 13 input_b_notify_deact     bit 14 input_b_active
+    optional uint32 flags            = 19;
+    // New sensors append at field >= 20; never renumber existing fields.
+}


### PR DESCRIPTION
Implements #37: replace the 32-bit bitmap telemetry with a **protobuf (nanopb) `Telemetry`** message on **fPort 2**, capability-driven and dynamically sized to the LoRaWAN payload budget. The legacy bitmap stays on fPort 1 for already-deployed firmware (the decoder routes by port — no version byte, no discriminator).

## Why
The bitmap header is ~28/32 bits full, selects fields by `isnan()` only (capabilities ignored), and adding a sensor means hand-editing two synchronized places (`app_compose.c` + `ttn.js`). It's an evolutionary dead end and can't express "this sensor isn't connected".

## What
- **Protobuf `Telemetry`** (`nfc_config.proto`), fields grouped per sensor with **per-group flag fields** so a sensor's data (e.g. `input_a` count + its flags) is an atomic unit. Groups: system, internal (SHT4x), barometer, light, accel, pir, ext1/2 (1-Wire), mp1/2 (machine probe), hall L/R, input A/B. New sensors append at field ≥26; never renumber.
- **Capability-driven:** a field is sent only when its `g_app_config.cap_*` is on **and** it has valid data (non-NaN / count>0 / flag set) — sparse payload, no data for unconnected sensors.
- **Dynamic sizing from the stack:** `app_lrw_get_max_payload()` caches `max_next_payload` from `lorawan_get_payload_sizes()` (DR-changed callback + after join). `app_compose` packs whole groups by priority into the budget.
- **Lossless multi-frame split:** when a report exceeds the budget it is split across frames, not dropped. `app_compose` takes one frozen snapshot per report (`*more` out-param); `app_lrw` sends follow-up frames **ASAP** (after RX windows / duty-cycle, delayable work), holding the `interval_report` timer until the snapshot drains. A failed send retries the same bytes (no group lost). Link check only on the first frame.
- **Event-triggered send** (alarms, #8) reuses the same compose/snapshot path — same payload as a periodic report.
- **`ttn.js`** routes by fPort: 1 → legacy bitmap (kept), 2 → grouped `Telemetry` (per-group flags expanded to named booleans, sparse), 85 → command response. The server unions the frames of one snapshot. Unknown fields skipped (forward-compatible).

## Verification
- Builds clean: release FLASH 53.11% / RAM 64.78%, debug FLASH 89.83% / RAM 87.24%.
- HW (ABP, hm-test, via RTT): join → `TX: budget=51B (from system)`; real fPort-2 uplink decoded correctly through the TTS formatter (voltage/temperature/humidity/orientation/inputs).
- Multi-frame HW test (forced 12 B budget): one report split into atomic-group frames sent ~4 s apart from a single snapshot; full-budget reports stay single frame.
- Decoder round-trip verified offline (protobuf encode → `ttn.js`).

## Notes
- Size analysis informing the design: bitmap typical 8 B / full 48 B; flat protobuf ~9 B / ~56 B; TV/TLV rejected (TV = flat-protobuf size without unknown-field skip; TLV larger). Grouped sub-messages rejected for wrapper overhead — chose flat fields grouped logically with per-group flags.
- `ttn.js` on this branch does **not** yet include #43's `encodeDownlink` (command downlink JSON-encode); merge order with #43 should reconcile a combined codec. Command downlinks via raw hex still work.