### PR TITLE
v1.4.0: Autonomous GetInfo uplink on join (+ piggybacked DeviceTimeReq) (#48)

### DIFF
--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -348,3 +348,24 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 	}
 	return 0;
 }
+
+int app_cmd_build_info(uint8_t *out, size_t out_cap, size_t *out_len)
+{
+	if (!out || !out_len) {
+		return -EINVAL;
+	}
+
+	DownlinkResponse resp = DownlinkResponse_init_zero;
+	resp.seq = 0;
+	resp.which_body = DownlinkResponse_info_tag;
+	fill_info(&resp.body.info);
+
+	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
+	if (!pb_encode(&ostream, DownlinkResponse_fields, &resp)) {
+		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
+		return -EMSGSIZE;
+	}
+
+	*out_len = ostream.bytes_written;
+	return 0;
+}

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -50,6 +50,12 @@ int app_cmd_handle(enum app_cmd_transport transport,
 		   uint8_t *out, size_t out_cap, size_t *out_len,
 		   enum app_cmd_action *action);
 
+/* Build an unsolicited device Info frame (DownlinkResponse{ seq=0, info=... },
+ * the same payload a GetInfo command returns) into `out`. Used to send an
+ * autonomous GetInfo uplink on join. Returns 0 with *out_len set, -EINVAL on a
+ * NULL argument, or -EMSGSIZE if `out_cap` is too small. */
+int app_cmd_build_info(uint8_t *out, size_t out_cap, size_t *out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -351,6 +351,18 @@ static void join_complete_work_handler(struct k_work *work)
 	 * in downlink_callback(). */
 	app_clock_request_sync();
 
+	/* Autonomous GetInfo on join: announce device identity/firmware on
+	 * fPort 85 before the first telemetry. send_work_handler drains this
+	 * queued response first, so it is the first uplink; the DeviceTimeReq
+	 * queued just above piggybacks on its FOpts. */
+	uint8_t info_buf[APP_LRW_RESPONSE_BUF_SIZE];
+	size_t info_len;
+	if (app_cmd_build_info(info_buf, sizeof(info_buf), &info_len) == 0) {
+		(void)app_lrw_queue_response(APP_LRW_DOWNLINK_CMD_PORT, info_buf, info_len);
+	} else {
+		LOG_WRN("app_cmd_build_info failed; skipping GetInfo-on-join");
+	}
+
 	restart_normal_operation();
 }
 


### PR DESCRIPTION
Closes #48.

On every successful (re)join the sticker now sends a device **Info** frame on **fPort 85** *before* the first periodic telemetry, so the backend learns the device identity + firmware as soon as it connects. The **DeviceTimeReq** queued just before it piggybacks on that frame's FOpts — one first uplink both announces the device and requests the network clock.

## Changes (2 files)
- **`app_cmd.{h,c}`** — expose `app_cmd_build_info()`: builds `DownlinkResponse{ seq=0, info=... }` via the existing `fill_info()` + `pb_encode` (same payload a GetInfo command returns).
- **`app_lrw.c`** — in the join-success path, after `app_clock_request_sync()` and before `restart_normal_operation()`, build the Info frame and queue it via `app_lrw_queue_response(85, …)`. `send_work_handler` drains the queued response first → Info is the first uplink; telemetry follows `interval_report` s later.

Fires on every (re)join; on a rejoin where the clock is already synced the Info still goes out and DeviceTimeReq simply isn't re-queued (the `m_time_synced` guard).

No decoder change — fPort 85 already decodes as `Info` in `ttn.js`.

## Verification
- Builds clean: debug FLASH 90.75% / RAM 89.00%, release 56.11% / 64.98%.
- HW (ABP/TTN, via RTT): join → `DeviceTimeReq queued` → `Response sent on port 85 (26 B)` as the **first** uplink.
- TTS: first uplink after join is fPort 85 → `Info{ fw_version "1.3.4", build_type_name "custom", serial_number, uptime_s=6, unix_time, debug }`; the DeviceTimeReq round-trip set the RTC (`unix_time` populated).