### PR TITLE
v1.4.0: Rename app_tester module + tester shell → app_ats / ats (#46)

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories_ifdef(CONFIG_LORAWAN app PRIVATE
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/boards
 )
 target_sources_ifdef(CONFIG_OPT3001 app PRIVATE src/app_opt3001.c)
-target_sources_ifdef(CONFIG_SHELL app PRIVATE src/app_tester.c)
+target_sources_ifdef(CONFIG_SHELL app PRIVATE src/app_ats.c)
 target_sources_ifdef(CONFIG_SHT4X app PRIVATE src/app_sht4x.c)
 target_sources_ifdef(CONFIG_W1 app PRIVATE src/app_ds18b20.c)
 target_sources_ifdef(CONFIG_W1 app PRIVATE src/app_w1.c)

--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -31,9 +31,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-LOG_MODULE_REGISTER(app_tester, LOG_LEVEL_DBG);
+LOG_MODULE_REGISTER(app_ats, LOG_LEVEL_DBG);
 
-#define SHELL_PFX "tester"
+#define SHELL_PFX "ats"
 #define SENSOR_CHECK_POLL_INTERVAL_MS 300 /* Poll interval for sensor check in milliseconds */
 
 static struct k_work_delayable g_led_cycle_work;
@@ -702,7 +702,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd,
 #endif /* CONFIG_APP_CMD_DEBUG_SHELL */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_test,
+	sub_ats,
 	SHELL_CMD(led, &sub_led, "LED commands.", NULL),
 	SHELL_CMD(sensors, &sub_sensors, "Sensor commands.", NULL),
 #if defined(CONFIG_LORAWAN)
@@ -713,12 +713,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 #endif
 	SHELL_SUBCMD_SET_END);
 
-SHELL_CMD_REGISTER(tester, &sub_test, "Tester commands.", NULL);
+SHELL_CMD_REGISTER(ats, &sub_ats, "Automated test system commands.", NULL);
 
-static int app_tester_init(void)
+static int app_ats_init(void)
 {
 	k_work_init_delayable(&g_led_cycle_work, led_cycle_work_handler);
 	return 0;
 }
 
-SYS_INIT(app_tester_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(app_ats_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Closes #46.

Pure rename, no behavior change. Renames the debug/test module and its top-level shell command to match the bench/automation tooling ("Automated Test System").

## Changes
- `app/src/app_tester.c` → **`app/src/app_ats.c`** (module keeps the `app_` prefix like `app_lrw`/`app_cmd`; `LOG_MODULE_REGISTER` + init → `app_ats`).
- Top-level shell command **`tester` → `ats`** (`SHELL_PFX`, `sub_ats`, `SHELL_CMD_REGISTER`). Subcommands unchanged (`ats led/sensors/lrw/cmd …`).
- `CMakeLists.txt`: `src/app_tester.c` → `src/app_ats.c` (built only with `CONFIG_SHELL`).

## ⚠️ Breaking for bench scripts
Any automation typing `tester …` must switch to `ats …`. Update the tooling in lockstep.

## Verification
- Builds clean: debug + release (release unaffected — shell compiles out).
- `grep -rn "app_tester|SHELL_PFX \"tester\"|sub_test|REGISTER(tester" app/` → no hits.
- HW (RTT): `ats` → "Automated test system commands." + subcommands led/sensors/lrw/cmd; `tester` → `command not found`.