### PR TITLE
v1.4.0: configen generates config .proto + options from app_config.yml (#44 PR B)

### DIFF
--- a/app/src/app_config.options.in
+++ b/app/src/app_config.options.in
@@ -1,3 +1,4 @@
+# BEGIN GENERATED CONFIG
 AppConfigMessage.Lorawan.deveui max_length:16
 AppConfigMessage.Lorawan.joineui max_length:16
 AppConfigMessage.Lorawan.nwkkey max_length:32
@@ -5,6 +6,7 @@ AppConfigMessage.Lorawan.appkey max_length:32
 AppConfigMessage.Lorawan.devaddr max_length:8
 AppConfigMessage.Lorawan.nwkskey max_length:32
 AppConfigMessage.Lorawan.appskey max_length:32
+# END GENERATED CONFIG
 
 Response.Error.detail       max_size:32
 Response.HistoryFrame.samples max_size:48

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -1,12 +1,11 @@
 syntax = "proto3";
 
+// BEGIN GENERATED CONFIG
 message AppConfigMessage {
     optional bool factory = 1;
-
     optional string secret_key = 2;
     optional uint32 serial_number = 3;
     optional uint32 nonce_counter = 4;
-
     optional Lorawan lorawan = 5;
     optional Application application = 6;
 
@@ -17,14 +16,14 @@ message AppConfigMessage {
             AU915 = 2;
         }
 
-        enum Activation {
-            OTAA = 0;
-            ABP = 1;
-        }
-
         enum Network {
             PUBLIC = 0;
             PRIVATE = 1;
+        }
+
+        enum Activation {
+            OTAA = 0;
+            ABP = 1;
         }
 
         optional Region region = 1;
@@ -42,9 +41,9 @@ message AppConfigMessage {
     }
 
     message Application {
+        reserved 3;
         optional bool calibration = 1;
         optional uint32 interval_sample = 2;
-        optional uint32 interval_aggreg = 3;
         optional uint32 interval_report = 4;
         optional bool alarm_temperature_enabled = 5;
         optional float alarm_temperature_lo = 6;
@@ -90,8 +89,11 @@ message AppConfigMessage {
         optional bool cap_pir_detector = 46;
         optional bool cap_1w_thermometer = 47;
         optional bool cap_1w_machine_probe = 48;
+        optional bool history_enable = 49;
+        optional uint32 history_sensors = 50;
     }
 }
+// END GENERATED CONFIG
 
 message Command {
     uint32 seq = 1;

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -35,13 +35,26 @@ enums:
       value: 1
       shell: abp
 
+proto:
+  message: AppConfigMessage
+  extra_fields:
+    - {name: factory, type: bool, proto_id: 1, proto_group: root}
+  groups:
+    - {key: root}
+    - {key: lorawan, message: Lorawan, field: lorawan, proto_id: 5, strip_prefix: lrw_}
+    - {key: application, message: Application, field: application, proto_id: 6, reserved: [3]}
 parameters:
   - name: secret_key
+    proto_group: root
+    proto_id: 2
+    proto_callback: true
     type: bytes
     size: 16
     help: "Get/Set device secret key (32 hexadecimal digits)."
 
   - name: serial_number
+    proto_group: root
+    proto_id: 3
     type: uint32
     format: "%010u"
     help: "Get/Set device serial number (10 decimal digits)."
@@ -49,14 +62,20 @@ parameters:
       digits: 10
 
   - name: nonce_counter
+    proto_group: root
+    proto_id: 4
     type: uint32
     help: "Get/Set nonce counter (unsigned integer)."
 
   - name: calibration
+    proto_group: application
+    proto_id: 1
     type: bool
     help: "Get/Set calibration mode (true/false)."
 
   - name: interval_sample
+    proto_group: application
+    proto_id: 2
     type: int
     min: 5
     max: 3600
@@ -65,6 +84,8 @@ parameters:
       zero_allowed: true
 
   - name: interval_report
+    proto_group: application
+    proto_id: 4
     type: int
     default: 900
     min: 60
@@ -72,11 +93,15 @@ parameters:
     help: "Get/Set report interval (range 60 to 86400 seconds)."
 
   - name: lrw_region
+    proto_group: lorawan
+    proto_id: 1
     type: enum
     enum: lrw_region
     help: "Get/Set LoRaWAN region (eu868/us915/au915)."
 
   - name: lrw_sub_band
+    proto_group: lorawan
+    proto_id: 12
     type: int
     default: 2
     min: 0
@@ -84,59 +109,83 @@ parameters:
     help: "Get/Set US915/AU915 sub-band (1-8, 0 = all channels). Default 2 matches TTN/Helium/ChirpStack."
 
   - name: lrw_network
+    proto_group: lorawan
+    proto_id: 2
     type: enum
     enum: lrw_network
     help: "Get/Set LoRaWAN network (public/private)."
 
   - name: lrw_adr
+    proto_group: lorawan
+    proto_id: 3
     type: bool
     help: "Get/Set LoRaWAN ADR (true/false)."
 
   - name: lrw_activation
+    proto_group: lorawan
+    proto_id: 4
     type: enum
     enum: lrw_activation
     help: "Get/Set LoRaWAN activation (otaa/abp)."
 
   - name: lrw_deveui
+    proto_group: lorawan
+    proto_id: 5
     type: bytes
     size: 8
     help: "Get/Set LoRaWAN DevEUI (16 hex digits)."
 
   - name: lrw_joineui
+    proto_group: lorawan
+    proto_id: 6
     type: bytes
     size: 8
     help: "Get/Set LoRaWAN JoinEUI (16 hex digits)."
 
   - name: lrw_nwkkey
+    proto_group: lorawan
+    proto_id: 7
     type: bytes
     size: 16
     help: "Get/Set LoRaWAN NwkKey (32 hex digits)."
 
   - name: lrw_appkey
+    proto_group: lorawan
+    proto_id: 8
     type: bytes
     size: 16
     help: "Get/Set LoRaWAN AppKey (32 hex digits)."
 
   - name: lrw_devaddr
+    proto_group: lorawan
+    proto_id: 9
     type: bytes
     size: 4
     help: "Get/Set LoRaWAN DevAddr (8 hex digits)."
 
   - name: lrw_nwkskey
+    proto_group: lorawan
+    proto_id: 10
     type: bytes
     size: 16
     help: "Get/Set LoRaWAN NwkSKey (32 hexadecimal digits)."
 
   - name: lrw_appskey
+    proto_group: lorawan
+    proto_id: 11
     type: bytes
     size: 16
     help: "Get/Set LoRaWAN AppSKey (32 hexadecimal digits)."
 
   - name: alarm_temperature_enabled
+    proto_group: application
+    proto_id: 5
     type: bool
     help: "Get/Set temperature alarm enabled (true/false)."
 
   - name: alarm_temperature_lo
+    proto_group: application
+    proto_id: 6
     type: float
     default: 15.0
     min: -30.0
@@ -144,6 +193,8 @@ parameters:
     help: "Get/Set temperature low threshold (-30 to 70 deg. C)."
 
   - name: alarm_temperature_hi
+    proto_group: application
+    proto_id: 7
     type: float
     default: 25.0
     min: -30.0
@@ -151,6 +202,8 @@ parameters:
     help: "Get/Set temperature high threshold (-30 to 70 deg. C)."
 
   - name: alarm_temperature_hst
+    proto_group: application
+    proto_id: 8
     type: float
     default: 0.5
     min: 0.0
@@ -158,10 +211,14 @@ parameters:
     help: "Get/Set T1 temperature hysteresis (0 to 5 deg. C)."
 
   - name: alarm_humidity_enabled
+    proto_group: application
+    proto_id: 9
     type: bool
     help: "Get/Set humidity alarm enabled (true/false)."
 
   - name: alarm_humidity_lo
+    proto_group: application
+    proto_id: 10
     type: float
     default: 30.0
     min: 0.0
@@ -169,6 +226,8 @@ parameters:
     help: "Get/Set humidity low threshold (0 to 100 %)."
 
   - name: alarm_humidity_hi
+    proto_group: application
+    proto_id: 11
     type: float
     default: 75.0
     min: 0.0
@@ -176,6 +235,8 @@ parameters:
     help: "Get/Set humidity high threshold (0 to 100 %)."
 
   - name: alarm_humidity_hst
+    proto_group: application
+    proto_id: 12
     type: float
     default: 5.0
     min: 0.0
@@ -183,10 +244,14 @@ parameters:
     help: "Get/Set humidity hysteresis (0 to 20 %)."
 
   - name: alarm_pressure_enabled
+    proto_group: application
+    proto_id: 13
     type: bool
     help: "Get/Set pressure alarm enabled (true/false)."
 
   - name: alarm_pressure_lo
+    proto_group: application
+    proto_id: 14
     type: float
     default: 700.0
     min: 500.0
@@ -194,6 +259,8 @@ parameters:
     help: "Get/Set pressure low threshold (500 to 1200 hPa)."
 
   - name: alarm_pressure_hi
+    proto_group: application
+    proto_id: 15
     type: float
     default: 1060.0
     min: 500.0
@@ -201,6 +268,8 @@ parameters:
     help: "Get/Set pressure high threshold (500 to 1200 hPa)."
 
   - name: alarm_pressure_hst
+    proto_group: application
+    proto_id: 16
     type: float
     default: 10.0
     min: 0.0
@@ -208,10 +277,14 @@ parameters:
     help: "Get/Set pressure hysteresis (0 to 50 hPa)."
 
   - name: alarm_t1_temperature_enabled
+    proto_group: application
+    proto_id: 17
     type: bool
     help: "Get/Set T1 temperature alarm enabled (true/false)."
 
   - name: alarm_t1_temperature_lo
+    proto_group: application
+    proto_id: 18
     type: float
     default: 15.0
     min: -30.0
@@ -219,6 +292,8 @@ parameters:
     help: "Get/Set T1 temperature low threshold (-30 to 70 deg. C)."
 
   - name: alarm_t1_temperature_hi
+    proto_group: application
+    proto_id: 19
     type: float
     default: 25.0
     min: -30.0
@@ -226,6 +301,8 @@ parameters:
     help: "Get/Set T1 temperature high threshold (-30 to 70 deg. C)."
 
   - name: alarm_t1_temperature_hst
+    proto_group: application
+    proto_id: 20
     type: float
     default: 0.5
     min: 0.0
@@ -233,10 +310,14 @@ parameters:
     help: "Get/Set T1 temperature hysteresis (0 to 5 deg. C)."
 
   - name: alarm_t2_temperature_enabled
+    proto_group: application
+    proto_id: 21
     type: bool
     help: "Get/Set T2 temperature alarm enabled (true/false)."
 
   - name: alarm_t2_temperature_lo
+    proto_group: application
+    proto_id: 22
     type: float
     default: 15.0
     min: -30.0
@@ -244,6 +325,8 @@ parameters:
     help: "Get/Set T2 temperature low threshold (-30 to 70 deg. C)."
 
   - name: alarm_t2_temperature_hi
+    proto_group: application
+    proto_id: 23
     type: float
     default: 25.0
     min: -30.0
@@ -251,6 +334,8 @@ parameters:
     help: "Get/Set T2 temperature high threshold (-30 to 70 deg. C)."
 
   - name: alarm_t2_temperature_hst
+    proto_group: application
+    proto_id: 24
     type: float
     default: 0.5
     min: 0.0
@@ -258,113 +343,165 @@ parameters:
     help: "Get/Set T2 temperature hysteresis (0 to 5 deg. C)."
 
   - name: hall_left_counter
+    proto_group: application
+    proto_id: 25
     type: bool
     help: "Get/Set hall left switch counter enabled (true/false)."
 
   - name: hall_left_notify_act
+    proto_group: application
+    proto_id: 26
     type: bool
     help: "Get/Set hall left switch notify on activation (true/false)."
 
   - name: hall_left_notify_deact
+    proto_group: application
+    proto_id: 27
     type: bool
     help: "Get/Set hall left switch notify on deactivation (true/false)."
 
   - name: hall_right_counter
+    proto_group: application
+    proto_id: 28
     type: bool
     help: "Get/Set hall right switch counter enabled (true/false)."
 
   - name: hall_right_notify_act
+    proto_group: application
+    proto_id: 29
     type: bool
     help: "Get/Set hall right switch notify on activation (true/false)."
 
   - name: hall_right_notify_deact
+    proto_group: application
+    proto_id: 30
     type: bool
     help: "Get/Set hall right switch notify on deactivation (true/false)."
 
   - name: input_a_counter
+    proto_group: application
+    proto_id: 31
     type: bool
     help: "Get/Set input A counter enabled (true/false)."
 
   - name: input_a_notify_act
+    proto_group: application
+    proto_id: 32
     type: bool
     help: "Get/Set input A notify on activation (true/false)."
 
   - name: input_a_notify_deact
+    proto_group: application
+    proto_id: 33
     type: bool
     help: "Get/Set input A notify on deactivation (true/false)."
 
   - name: input_b_counter
+    proto_group: application
+    proto_id: 34
     type: bool
     help: "Get/Set input B counter enabled (true/false)."
 
   - name: input_b_notify_act
+    proto_group: application
+    proto_id: 35
     type: bool
     help: "Get/Set input B notify on activation (true/false)."
 
   - name: input_b_notify_deact
+    proto_group: application
+    proto_id: 36
     type: bool
     help: "Get/Set input B notify on deactivation (true/false)."
 
   - name: corr_temperature
+    proto_group: application
+    proto_id: 37
     type: float
     min: -5.0
     max: 5.0
     help: "Get/Set temperature correction (range -5.0 to +5.0 deg. C)."
 
   - name: corr_t1_temperature
+    proto_group: application
+    proto_id: 38
     type: float
     min: -5.0
     max: 5.0
     help: "Get/Set T1 temperature correction (range -5.0 to +5.0 deg. C)."
 
   - name: corr_t2_temperature
+    proto_group: application
+    proto_id: 39
     type: float
     min: -5.0
     max: 5.0
     help: "Get/Set T2 temperature correction (range -5.0 to +5.0 deg. C)."
 
   - name: cap_hall_left
+    proto_group: application
+    proto_id: 40
     type: bool
     help: "Get/Set hall left capability (true/false)."
 
   - name: cap_hall_right
+    proto_group: application
+    proto_id: 41
     type: bool
     help: "Get/Set hall right capability (true/false)."
 
   - name: cap_input_a
+    proto_group: application
+    proto_id: 42
     type: bool
     help: "Get/Set input A capability (true/false)."
 
   - name: cap_input_b
+    proto_group: application
+    proto_id: 43
     type: bool
     help: "Get/Set input B capability (true/false)."
 
   - name: cap_light_sensor
+    proto_group: application
+    proto_id: 44
     type: bool
     help: "Get/Set light sensor capability (true/false)."
 
   - name: cap_barometer
+    proto_group: application
+    proto_id: 45
     type: bool
     help: "Get/Set barometer capability (true/false)."
 
   - name: cap_pir_detector
+    proto_group: application
+    proto_id: 46
     type: bool
     help: "Get/Set PIR detector capability (true/false)."
 
   - name: cap_1w_thermometer
+    proto_group: application
+    proto_id: 47
     type: bool
     help: "Get/Set 1-wire thermometer capability (true/false)."
 
   - name: cap_1w_machine_probe
+    proto_group: application
+    proto_id: 48
     type: bool
     help: "Get/Set 1-wire machine probe capability (true/false)."
 
   - name: history_enable
+    proto_group: application
+    proto_id: 49
     type: bool
     default: false
     help: "Get/Set sensor history store-and-forward (true/false)."
 
   - name: history_sensors
+    proto_group: application
+    proto_id: 50
     type: uint32
     default: 0
     help: "Get/Set history sensor selection bitmask (0 = all capability-available)."

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -34,6 +34,7 @@ Parameter options:
 """
 
 import argparse
+import re
 from pathlib import Path
 
 import yaml
@@ -320,6 +321,245 @@ def filter_printf_cast(param):
     return casts.get(ptype, "")
 
 
+# ---------------------------------------------------------------------------
+# Protobuf config generation (issue #44)
+#
+# configen also emits the config section of the .proto (and the nanopb
+# max_length options for hex-key fields) from the same YAML, so app_config.yml
+# is the single source of truth for both the C struct and the wire schema.
+# Existing field numbers are locked via per-parameter `proto_id`; the allocator
+# only appends new ones (never renumbers) and writes them back into the YAML.
+# ---------------------------------------------------------------------------
+
+# Marker pair delimiting the generated region in the .proto / .options files.
+PROTO_BEGIN = "BEGIN GENERATED CONFIG"
+PROTO_END = "END GENERATED CONFIG"
+
+# YAML type -> proto3 scalar type (mirrors the hand-written proto: every integer
+# maps to uint32, byte arrays / strings become `string` with a nanopb option).
+PROTO_SCALAR = {
+    "bool": "bool",
+    "float": "float",
+    "double": "double",
+    "bytes": "string",
+    "string": "string",
+}
+
+
+def _pascal(name):
+    """snake_case -> PascalCase (lrw_region -> Region after prefix strip)."""
+    return "".join(w.capitalize() for w in name.split("_") if w)
+
+
+def _proto_field_name(param, group):
+    """Proto field name = YAML name with the group's strip_prefix removed."""
+    name = param["name"]
+    prefix = group.get("strip_prefix", "")
+    if prefix and name.startswith(prefix):
+        name = name[len(prefix):]
+    return param.get("proto_name", name)
+
+
+def _proto_type(param, enum_proto_name):
+    ptype = param.get("type")
+    if ptype == "enum":
+        return enum_proto_name[param["enum"]]
+    return PROTO_SCALAR.get(ptype, "uint32")
+
+
+def _proto_groups(config):
+    """Return (proto_block, {group_key: group_cfg}) or (None, None)."""
+    proto = config.get("proto")
+    if not proto:
+        return None, None
+    return proto, {g["key"]: g for g in proto["groups"]}
+
+
+def allocate_proto_ids(config, rt_doc):
+    """Assign a proto_id to every parameter missing one (append-only) and mirror
+    the assignment back into `rt_doc` (a ruamel round-trip doc) for write-back.
+
+    Returns the list of (name, id) newly assigned. Mutates `config` parameters
+    in place so the proto model sees the final numbers.
+    """
+    proto, gmap = _proto_groups(config)
+
+    # Collect the used field numbers per message namespace. The root message
+    # namespace holds extra_fields(root), the root-group params and the
+    # submessage container fields; each submessage namespace holds its own
+    # params plus any `reserved` numbers.
+    used = {g["key"]: set() for g in proto["groups"]}
+    for ef in proto.get("extra_fields", []):
+        used[ef.get("proto_group", "root")].add(ef["proto_id"])
+    for g in proto["groups"]:
+        if g["key"] != "root":
+            used.setdefault("root", set()).add(g["proto_id"])
+        for r in g.get("reserved", []):
+            used[g["key"]].add(r)
+
+    # Lock existing ids + detect duplicates within a namespace.
+    for p in config["parameters"]:
+        group = p.get("proto_group")
+        if group is None:
+            log.die(f"parameter '{p['name']}' is missing 'proto_group'")
+        if group not in used:
+            log.die(f"parameter '{p['name']}' has unknown proto_group '{group}'")
+        pid = p.get("proto_id")
+        if pid is not None:
+            if pid in used[group]:
+                log.die(f"duplicate proto_id {pid} in group '{group}' "
+                        f"(parameter '{p['name']}')")
+            used[group].add(pid)
+
+    # Append-only allocation for parameters without an id, in YAML order.
+    assigned = []
+    for p in config["parameters"]:
+        if p.get("proto_id") is None:
+            group = p["proto_group"]
+            nid = (max(used[group]) + 1) if used[group] else 1
+            used[group].add(nid)
+            p["proto_id"] = nid
+            assigned.append((p["name"], nid))
+
+    # Write the new ids back into the round-trip doc (after proto_group).
+    if assigned:
+        new_ids = dict(assigned)
+        for p in rt_doc["parameters"]:
+            if p["name"] in new_ids and "proto_id" not in p:
+                idx = list(p.keys()).index("proto_group") + 1
+                p.insert(idx, "proto_id", new_ids[p["name"]])
+
+    return assigned
+
+
+def _parse_proto_field_ids(text):
+    """Extract {field_name: number} from `optional <type> <name> = <n>;` lines in
+    the existing generated region (used by the no-renumber guard)."""
+    ids = {}
+    region = text
+    if PROTO_BEGIN in text and PROTO_END in text:
+        region = text.split(PROTO_BEGIN, 1)[1].split(PROTO_END, 1)[0]
+    for m in re.finditer(r"optional\s+\S+\s+(\w+)\s*=\s*(\d+)\s*;", region):
+        ids[m.group(1)] = int(m.group(2))
+    return ids
+
+
+def guard_no_renumber(config, proto_path):
+    """Fail the run if a parameter's locked proto field number differs from the
+    one already in the target .proto (someone edited a YAML proto_id)."""
+    if not proto_path.exists():
+        return
+    old_ids = _parse_proto_field_ids(proto_path.read_text())
+    if not old_ids:
+        return
+    _, gmap = _proto_groups(config)
+    for p in config["parameters"]:
+        fname = _proto_field_name(p, gmap[p["proto_group"]])
+        if fname in old_ids and old_ids[fname] != p["proto_id"]:
+            log.die(f"proto_id for '{fname}' changed {old_ids[fname]} -> "
+                    f"{p['proto_id']} — renumbering is forbidden (NFC tags / "
+                    f"downlinks already deployed)")
+
+
+def build_proto_model(config):
+    """Build the jinja2 context for config.proto.j2 from the YAML config."""
+    proto, gmap = _proto_groups(config)
+    enums = config.get("enums", {})
+
+    by_group = {g["key"]: [] for g in proto["groups"]}
+    for p in config["parameters"]:
+        by_group[p["proto_group"]].append(p)
+
+    # Map each YAML enum to its proto type name, derived in the group that uses
+    # it (strip that group's prefix, PascalCase the remainder).
+    enum_proto_name = {}
+    for gkey, plist in by_group.items():
+        for p in plist:
+            if p.get("type") == "enum" and p["enum"] not in enum_proto_name:
+                base = p["enum"]
+                prefix = gmap[gkey].get("strip_prefix", "")
+                if prefix and base.startswith(prefix):
+                    base = base[len(prefix):]
+                enum_proto_name[p["enum"]] = _pascal(base)
+
+    def field(name, ptype, fid):
+        return {"name": name, "ptype": ptype, "id": fid}
+
+    # Root message: extra_fields(root) + root-group params + submessage
+    # containers, all in the root namespace, ordered by field number.
+    root_fields = []
+    for ef in proto.get("extra_fields", []):
+        if ef.get("proto_group", "root") == "root":
+            root_fields.append(field(ef["name"], ef["type"], ef["proto_id"]))
+    for p in by_group.get("root", []):
+        root_fields.append(field(_proto_field_name(p, gmap["root"]),
+                                  _proto_type(p, enum_proto_name), p["proto_id"]))
+    for g in proto["groups"]:
+        if g["key"] != "root":
+            root_fields.append(field(g["field"], g["message"], g["proto_id"]))
+    root_fields.sort(key=lambda f: f["id"])
+
+    submessages = []
+    for g in proto["groups"]:
+        if g["key"] == "root":
+            continue
+        plist = sorted(by_group.get(g["key"], []), key=lambda p: p["proto_id"])
+        genums, seen = [], set()
+        for p in plist:
+            if p.get("type") == "enum" and p["enum"] not in seen:
+                seen.add(p["enum"])
+                genums.append({
+                    "name": enum_proto_name[p["enum"]],
+                    "members": [{"name": v["name"], "value": v["value"]}
+                                for v in enums[p["enum"]]],
+                })
+        fields = [field(_proto_field_name(p, g), _proto_type(p, enum_proto_name),
+                        p["proto_id"]) for p in plist]
+        submessages.append({
+            "name": g["message"],
+            "enums": genums,
+            "reserved": list(g.get("reserved", [])),
+            "fields": fields,
+        })
+
+    return {"message": proto["message"], "root_fields": root_fields,
+            "submessages": submessages}
+
+
+def build_options_lines(config):
+    """nanopb max_length options for hex-key (bytes) fields. Fields flagged
+    `proto_callback: true` are left as nanopb callbacks (no option emitted)."""
+    proto, gmap = _proto_groups(config)
+    msg = proto["message"]
+    lines = []
+    for p in config["parameters"]:
+        if p.get("type") != "bytes" or p.get("proto_callback"):
+            continue
+        g = gmap[p["proto_group"]]
+        fname = _proto_field_name(p, g)
+        path = (f"{msg}.{fname}" if g["key"] == "root"
+                else f"{msg}.{g['message']}.{fname}")
+        lines.append(f"{path} max_length:{p['size'] * 2}")
+    return lines
+
+
+def rewrite_marked_region(path, body, comment):
+    """Replace the text between the BEGIN/END markers in `path` with `body`,
+    keeping everything outside (hand-written messages / options)."""
+    if not path.exists():
+        log.die(f"target {path} not found — seed it with the "
+                f"'{comment} {PROTO_BEGIN}' / '{comment} {PROTO_END}' markers first")
+    text = path.read_text()
+    begin = f"{comment} {PROTO_BEGIN}"
+    end = f"{comment} {PROTO_END}"
+    if begin not in text or end not in text:
+        log.die(f"{path} is missing the generated-region markers "
+                f"({begin} / {end})")
+    head, rest = text.split(begin, 1)
+    _, tail = rest.split(end, 1)
+    return f"{head}{begin}\n{body}\n{end}{tail}"
+
+
 class Configen(WestCommand):
     def __init__(self):
         super().__init__(
@@ -354,6 +594,27 @@ class Configen(WestCommand):
             type=Path,
             default=None,
             help="custom templates directory (default: built-in templates)",
+        )
+        parser.add_argument(
+            "--proto",
+            type=Path,
+            default=None,
+            help="path to the .proto whose generated region is rewritten "
+            "(default: <output-dir>/<module>.proto). Only used when the YAML "
+            "has a 'proto:' block.",
+        )
+        parser.add_argument(
+            "--options",
+            type=Path,
+            default=None,
+            help="path to the nanopb .options.in whose generated region is "
+            "rewritten (default: <output-dir>/<module>.options.in)",
+        )
+        parser.add_argument(
+            "--no-proto",
+            action="store_true",
+            help="skip proto/options generation even if the YAML has a "
+            "'proto:' block",
         )
         parser.add_argument(
             "--dry-run",
@@ -481,6 +742,59 @@ class Configen(WestCommand):
             log.inf(f"Generated: {source_path}")
 
             self._clang_format([header_path, source_path])
+
+        # Proto + nanopb options generation (issue #44).
+        if config.get("proto") and not args.no_proto:
+            proto_path = args.proto or (output_dir / f"{module_name}.proto")
+            options_path = args.options or (output_dir / f"{module_name}.options.in")
+            self._generate_proto(env, config, yaml_path, proto_path.resolve(),
+                                 options_path.resolve(), args.dry_run)
+
+    def _generate_proto(self, env, config, yaml_path, proto_path, options_path,
+                        dry_run):
+        """Generate the .proto config region + nanopb options from the YAML,
+        with an append-only proto_id allocator that writes new ids back."""
+        from ruamel.yaml import YAML
+
+        ryaml = YAML()
+        ryaml.preserve_quotes = True
+        ryaml.width = 4096
+        ryaml.indent(mapping=2, sequence=4, offset=2)
+        with open(yaml_path) as f:
+            rt_doc = ryaml.load(f)
+
+        # Allocate ids for new params, guard against renumbering existing ones.
+        assigned = allocate_proto_ids(config, rt_doc)
+        guard_no_renumber(config, proto_path)
+
+        model = build_proto_model(config)
+        body = env.get_template("config.proto.j2").render(proto=model).rstrip("\n")
+        proto_text = rewrite_marked_region(proto_path, body, "//")
+
+        options_body = "\n".join(build_options_lines(config))
+        options_text = rewrite_marked_region(options_path, options_body, "#")
+
+        if dry_run:
+            for name, fid in assigned:
+                log.inf(f"Would assign proto_id {fid} to '{name}'")
+            log.inf(f"Would generate: {proto_path}")
+            log.inf("--- Proto generated region ---")
+            print(body)
+            log.inf(f"\nWould generate: {options_path}")
+            print(options_body)
+            return
+
+        for name, fid in assigned:
+            log.inf(f"Assigned proto_id {fid} to new parameter '{name}'")
+        if assigned:
+            with open(yaml_path, "w") as f:
+                ryaml.dump(rt_doc, f)
+            log.inf(f"Wrote new proto_id(s) back into: {yaml_path}")
+
+        proto_path.write_text(proto_text)
+        log.inf(f"Generated: {proto_path}")
+        options_path.write_text(options_text)
+        log.inf(f"Generated: {options_path}")
 
     def _clang_format(self, paths):
         """Run clang-format on generated files if available."""

--- a/scripts/west_commands/templates/config.proto.j2
+++ b/scripts/west_commands/templates/config.proto.j2
@@ -1,0 +1,24 @@
+message {{ proto.message }} {
+{% for f in proto.root_fields %}
+    optional {{ f.ptype }} {{ f.name }} = {{ f.id }};
+{% endfor %}
+{% for sub in proto.submessages %}
+
+    message {{ sub.name }} {
+{% for e in sub.enums %}
+        enum {{ e.name }} {
+{% for v in e.members %}
+            {{ v.name }} = {{ v.value }};
+{% endfor %}
+        }
+
+{% endfor %}
+{% for r in sub.reserved %}
+        reserved {{ r }};
+{% endfor %}
+{% for f in sub.fields %}
+        optional {{ f.ptype }} {{ f.name }} = {{ f.id }};
+{% endfor %}
+    }
+{% endfor %}
+}


### PR DESCRIPTION
Closes #44 — **PR B of 2** (the generator). Builds on the rename in #56.

## What

`west configen` now generates the **config section of the protobuf** (and its nanopb `max_length` options) from the same `app_config.yml` that already drives the C struct/Settings/shell. The YAML is now the single source of truth for both the C struct and the wire schema, eliminating the hand-maintained parallel proto that was silently drifting.

### How
- Each parameter gains `proto_group` (root / lorawan / application) + `proto_id`. A module-level `proto:` block declares the message skeleton (`factory`, container fields, submessage names, `reserved` numbers).
- configen rewrites only the `// BEGIN GENERATED CONFIG` … `// END GENERATED CONFIG` region of `app_config.proto` and the keys region of `app_config.options.in`. The hand-written `Command` / `Response` / `Telemetry` messages outside the markers are untouched.
- New template `templates/config.proto.j2` renders nested enums, `reserved` lines and fields in `proto_id` order. `bytes`→`string` with `max_length = size*2`; `secret_key` stays a nanopb callback (`proto_callback: true`).

### Safety — never renumber
- **Append-only allocator**: existing `proto_id`s are reused verbatim; a new parameter gets `max(group)+1`, written back into the YAML (ruamel — comments/order preserved).
- **Hard guard**: the run aborts if an existing field's `proto_id` changed vs the current `.proto` (deployed NFC tags / LoRaWAN downlinks depend on stable numbers). Verified: editing `region` 1→99 fails with `renumbering is forbidden`.

## Drift fixed
`history_enable` / `history_sensors` (added to the YAML by #47, **absent from the proto**) are now allocated **application 49 / 50** and emitted. `interval_aggreg` (proto-only) becomes `reserved 3`. **All other field numbers unchanged** → wire schema for deployed fields identical.

## Verification
- `west configen app/src/app_config.yml -o app/src/`: regenerated config region preserves every existing number; only adds the two history fields + `reserved 3`; enum block cosmetically reordered (Region/Network/Activation — values unchanged). Second run is idempotent.
- No-renumber guard fires on a changed id (tested).
- `app_config.{c,h}` regenerate **byte-identically** (new YAML keys don't affect C output).
- Pristine **debug** (FLASH 90.74% / RAM 89.00%) and **release** (FLASH 56.11% / RAM 64.98%) builds clean; generated `app_config.pb.h` shows `history_*` tags 49/50 and no `interval_aggreg`.

> Note: the new `history_enable`/`history_sensors` proto fields are now part of the wire schema; wiring them through `app_config_ingest` (SetParam) is left for a follow-up — out of scope for this generation change.