### PR TITLE
v1.4.0: Wire history_enable/history_sensors through the config command protocol (#58)

### DIFF
--- a/app/src/app_config_ingest.c
+++ b/app/src/app_config_ingest.c
@@ -220,6 +220,11 @@ int app_config_apply_application(const AppConfigMessage_Application *src, uint32
 	APPLY_BOOL(cap_1w_thermometer);
 	APPLY_BOOL(cap_1w_machine_probe);
 
+	APPLY_BOOL(history_enable);
+	if (src->has_history_sensors) {
+		config->history_sensors = src->history_sensors;
+	}
+
 	/* Cross-validate alarm lo/hi pairs — disable the alarm if lo >= hi */
 	if (config->alarm_temperature_lo >= config->alarm_temperature_hi) {
 		config->alarm_temperature_enabled = false;
@@ -351,6 +356,8 @@ void app_config_fill_application(AppConfigMessage_Application *dst, const uint32
 	FILL_BOOL(46, cap_pir_detector);
 	FILL_BOOL(47, cap_1w_thermometer);
 	FILL_BOOL(48, cap_1w_machine_probe);
+	FILL_BOOL(49, history_enable);
+	FILL_NUM(50, history_sensors);
 }
 
 bool app_config_ingest(const AppConfigMessage *message)


### PR DESCRIPTION
Closes #58. Follow-up to #57.

## What

#57 added `history_enable` (proto field 49) and `history_sensors` (50) to the generated config protobuf, but `app_config_ingest.c` did not read/write them — so `SetParam` (LoRaWAN / NFC) silently dropped them and `get_config` / `GetParam` never reported them. They were only reachable via the local `config` shell.

This wires both through the existing ingest pattern (mirrors `cap_*`):

- `app_config_apply_application()`: `APPLY_BOOL(history_enable)` + numeric apply for `history_sensors` (uint32, no range constraint).
- `app_config_fill_application()`: `FILL_BOOL(49, history_enable)` + `FILL_NUM(50, history_sensors)`.

Pure C wiring — no proto/YAML change.

## Verification

- Debug (FLASH 90.77%) + release (FLASH 56.14%) builds clean.
- `SetParam{history_enable=true}` is now applied; `get_config` / `GetParam` reports tags 49/50.