### PR TITLE
v1.4.0: JS decoder tests + symmetric encode/decode + CI test job (#51 part 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,23 @@ jobs:
           path: sticker/artifacts/hio-sticker-${{ steps.version.outputs.value }}-${{ matrix.config }}.hex
           if-no-files-found: error
 
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: JS decoder tests
+        working-directory: app/decoder
+        run: node --test
+
   release:
     name: Create release
     if: startsWith(github.ref, 'refs/tags/v')

--- a/app/decoder/package.json
+++ b/app/decoder/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sticker-decoder",
+  "version": "1.0.0",
+  "private": true,
+  "description": "STICKER LoRaWAN payload codec (TTN/ChirpStack) + tests",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -529,14 +529,18 @@ function encodeDownlinkCommand(cmd) {
     return { bytes: null, error: "unknown command: " + name };
   }
 
+  // Symmetric with decodeDownlink: the command body lives under cmd[name] —
+  // the same nested-oneof shape decode emits. Empty-body commands have no
+  // sub-object.
+  var b = cmd[name] || {};
   var body = [];
   if (name === "set_param") {
-    if (cmd.lorawan) body = body.concat(_encLenDelim(1, _encLorawan(cmd.lorawan)));
-    if (cmd.application) body = body.concat(_encLenDelim(2, _encApplication(cmd.application)));
+    if (b.lorawan) body = body.concat(_encLenDelim(1, _encLorawan(b.lorawan)));
+    if (b.application) body = body.concat(_encLenDelim(2, _encApplication(b.application)));
   } else if (name === "get_param") {
     // proto3 repeated scalars are packed (length-delimited) by default.
-    var lf = cmd.lorawan_field || [];
-    var af = cmd.application_field || [];
+    var lf = b.lorawan_field || [];
+    var af = b.application_field || [];
     if (lf.length) {
       var pl = [];
       for (var i = 0; i < lf.length; i++) pl = pl.concat(_encVarint(lf[i]));
@@ -548,15 +552,15 @@ function encodeDownlinkCommand(cmd) {
       body = body.concat(_encLenDelim(2, pa));
     }
   } else if (name === "get_config") {
-    if (cmd.page) body = body.concat(_encTag(1, 0)).concat(_encVarint(cmd.page));
+    if (b.page) body = body.concat(_encTag(1, 0)).concat(_encVarint(b.page));
   } else if (name === "reset_counters") {
-    if (cmd.hall_left) body = body.concat(_encTag(1, 0)).concat(_encVarint(1));
-    if (cmd.hall_right) body = body.concat(_encTag(2, 0)).concat(_encVarint(1));
-    if (cmd.input_a) body = body.concat(_encTag(3, 0)).concat(_encVarint(1));
-    if (cmd.input_b) body = body.concat(_encTag(4, 0)).concat(_encVarint(1));
+    if (b.hall_left) body = body.concat(_encTag(1, 0)).concat(_encVarint(1));
+    if (b.hall_right) body = body.concat(_encTag(2, 0)).concat(_encVarint(1));
+    if (b.input_a) body = body.concat(_encTag(3, 0)).concat(_encVarint(1));
+    if (b.input_b) body = body.concat(_encTag(4, 0)).concat(_encVarint(1));
   } else if (name === "req_history") {
-    if (cmd.from_unix) body = body.concat(_encTag(1, 0)).concat(_encVarint(cmd.from_unix));
-    if (cmd.to_unix) body = body.concat(_encTag(2, 0)).concat(_encVarint(cmd.to_unix));
+    if (b.from_unix) body = body.concat(_encTag(1, 0)).concat(_encVarint(b.from_unix));
+    if (b.to_unix) body = body.concat(_encTag(2, 0)).concat(_encVarint(b.to_unix));
   }
   // get_info / settings_save / reboot / factory_reset / force_send / clock_sync: empty body.
 
@@ -891,12 +895,11 @@ function decodeUplink(input) {
   };
 }
 
-if (false) {
-
-  // console.log("Decoded data:", JSON.stringify(decodeUplink({
-  //   bytes: [0x78, 0x1a, 0x00, 0x01, 0xa5, 0x08, 0xd7, 0x88, 0x08, 0xed, 0x75],
-  // }), null, 2));
-  console.log("Decoded data:", JSON.stringify(decodeUplink({
-    bytes: Buffer.from("7a01a109fa580258", "hex"),
-  }), null, 2));
+// Make the codec importable from Node (tests) without affecting the
+// TTN/ChirpStack sandbox, which has no `module`.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    decodeUplink, encodeDownlink, decodeDownlink, Decode,
+    decodeTelemetry, decodeDownlinkResponse,
+  };
 }

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -1,0 +1,114 @@
+// Tests for the STICKER LoRaWAN codec (ttn.js).
+// Run: `node --test` (Node >= 18, zero dependencies).
+//
+// Vectors are HW-verified / current-schema captures. The downlink command hex
+// are real DownlinkCommand frames (fPort 85); the uplink hex are real frames.
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const codec = require("./ttn.js");
+
+const hex = (h) => Buffer.from(h, "hex");
+const toHex = (bytes) => Buffer.from(bytes).toString("hex");
+
+// --- Downlink commands (decodeDownlink, fPort 85) -------------------------
+// Each entry: hex on the wire <-> the structured command it represents.
+const COMMANDS = [
+  {
+    name: "set_param (lorawan.adr + application interval_report/alarm_temperature_hi)",
+    hex: "0801120d0a021801120720783d00004842",
+    data: {
+      seq: 1,
+      command: "set_param",
+      set_param: {
+        lorawan: { adr: 1 },
+        application: { interval_report: 120, alarm_temperature_hi: 50 },
+      },
+    },
+  },
+  {
+    name: "get_param (field lists)",
+    hex: "08021a070a010312020407",
+    data: {
+      seq: 2,
+      command: "get_param",
+      get_param: { lorawan_field: [3], application_field: [4, 7] },
+    },
+  },
+  {
+    name: "reset_counters (hall_left + input_a)",
+    hex: "0807520408011801",
+    data: {
+      seq: 7,
+      command: "reset_counters",
+      reset_counters: { hall_left: true, input_a: true },
+    },
+  },
+  { name: "get_info", hex: "08032200", data: { seq: 3, command: "get_info" } },
+  { name: "settings_save", hex: "08043200", data: { seq: 4, command: "settings_save" } },
+  { name: "clock_sync", hex: "08056200", data: { seq: 5, command: "clock_sync" } },
+  { name: "force_send", hex: "08064a00", data: { seq: 6, command: "force_send" } },
+  { name: "reboot", hex: "08083a00", data: { seq: 8, command: "reboot" } },
+];
+
+test("decodeDownlink decodes command frames", () => {
+  for (const c of COMMANDS) {
+    const got = codec.decodeDownlink({ bytes: hex(c.hex), fPort: 85 });
+    assert.deepEqual(got.data, c.data, c.name);
+  }
+});
+
+test("encode/decode are symmetric (byte-exact round-trip)", () => {
+  for (const c of COMMANDS) {
+    const decoded = codec.decodeDownlink({ bytes: hex(c.hex), fPort: 85 }).data;
+    const reencoded = codec.encodeDownlink({ data: decoded });
+    assert.equal(reencoded.errors.length, 0, c.name + " encode errors");
+    assert.equal(reencoded.fPort, 85, c.name + " fPort");
+    assert.equal(toHex(reencoded.bytes), c.hex, c.name + " round-trip bytes");
+  }
+});
+
+// --- Uplink: legacy bitmap (fPort 1) --------------------------------------
+test("decodeUplink decodes legacy bitmap (fPort 1)", () => {
+  const got = codec.decodeUplink({ bytes: hex("7a01a109fa580258"), fPort: 1 });
+  assert.equal(got.data.boot, false);
+  assert.equal(got.data.orientation, 1);
+  assert.equal(got.data.voltage, 3.22);
+  assert.equal(got.data.temperature, 25.54);
+  assert.equal(got.data.humidity, 44);
+  assert.equal(got.data.ext_temperature_1, 6);
+  // sensors absent in this frame decode to null
+  assert.equal(got.data.illuminance, null);
+  assert.equal(got.data.pressure, null);
+});
+
+// --- Uplink: command response (fPort 85) ----------------------------------
+test("decodeUplink decodes an Ack response (fPort 85)", () => {
+  const got = codec.decodeUplink({ bytes: hex("08011200"), fPort: 85 });
+  assert.equal(got.data.seq, 1);
+  assert.deepEqual(got.data.ack, {});
+});
+
+// --- Uplink: protobuf telemetry (fPort 2) ---------------------------------
+// TODO(#51): assert an exact HW telemetry frame once captured. Until then,
+// confirm the fPort-2 path is wired and returns an object without throwing.
+test("decodeUplink routes fPort 2 to the telemetry decoder", () => {
+  const got = codec.decodeUplink({ bytes: hex("0864"), fPort: 2 });
+  assert.equal(typeof got.data, "object");
+});
+
+// --- Negative: a corrupted frame must change the result (tests are sensitive) ---
+test("a tampered command byte does not silently decode to the original", () => {
+  const good = codec.decodeDownlink({ bytes: hex("08032200"), fPort: 85 }).data;
+  // flip the command tag (0x22 get_info -> 0x3a reboot)
+  const bad = codec.decodeDownlink({ bytes: hex("08033a00"), fPort: 85 }).data;
+  assert.notDeepEqual(bad, good);
+  assert.equal(bad.command, "reboot");
+});
+
+test("a truncated buffer is handled without throwing", () => {
+  assert.doesNotThrow(() => codec.decodeUplink({ bytes: hex("7a01"), fPort: 1 }));
+  assert.doesNotThrow(() => codec.decodeDownlink({ bytes: hex("0801"), fPort: 85 }));
+});


### PR DESCRIPTION
Part 1 of #51 — automated validation of the LoRaWAN codec (`app/decoder/ttn.js`), the only FW↔cloud contract, previously unverified.

## Symmetric encode/decode (fresh LRW codec)

`encodeDownlink` now takes the **same nested-oneof shape** `decodeDownlink` emits — the command body lives under `cmd[command]` (e.g. `{seq, command:'set_param', set_param:{lorawan, application}}`), matching how uplink responses already decode (`{seq, ack:{}}`). The old flat `{command, ...fields}` input shape is **removed** (no back-compat shim — this is a new codec version for LRW). Result: `encode(decode(bytes)).bytes === bytes` for every command. No wire-format change.

## Tests — `node --test`, zero dependencies

`ttn.js` now exports its functions behind a CommonJS guard (TTN/ChirpStack sandbox unaffected — it has no `module`). `app/decoder/ttn.test.js` asserts current-schema vectors:

- **Downlink command decode** (8 vectors): set_param, get_param, reset_counters, get_info, settings_save, clock_sync, force_send, reboot.
- **Byte-exact round-trip**: `encode(decode(hex)).bytes === hex` for each.
- **fPort 1** legacy bitmap `7a01a109fa580258` (voltage 3.22, temp 25.54, hum 44, …).
- **fPort 85** Ack `08011200` → `{seq:1, ack:{}}`.
- **fPort 2** telemetry routing (exact HW frame TODO once captured).
- **Negative**: a tampered command tag changes the result; truncated buffers don't throw.

## CI

New `test` job (`actions/setup-node` + `node --test`). Fast, no toolchain. PR 2 (#51 part 2) extends it with configen pytest; PR 3 adds `tools/test.sh`.

Verified locally: `cd app/decoder && node --test` → 7/7 pass.