### PR TITLE
v1.4.0: configen + proto round-trip pytest (#51 part 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,17 @@ jobs:
         working-directory: app/decoder
         run: node --test
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install configen test deps
+        run: pip install -r scripts/west_commands/requirements-dev.txt
+
+      - name: configen + proto tests
+        run: pytest scripts/west_commands/tests
+
   release:
     name: Create release
     if: startsWith(github.ref, 'refs/tags/v')

--- a/scripts/west_commands/requirements-dev.txt
+++ b/scripts/west_commands/requirements-dev.txt
@@ -1,0 +1,13 @@
+# Dev/test dependencies for the configen west command test suite (issue #51).
+# Enough to run `pytest scripts/west_commands/tests` standalone (e.g. in the CI
+# `test` job, which does not run the full Zephyr build setup).
+pytest>=8.0
+west>=1.2
+PyYAML>=6.0
+Jinja2>=3.1
+ruamel.yaml>=0.18
+protobuf>=5.26.1
+grpcio-tools>=1.68.0
+# Pinned so the generated-C-matches-committed test formats identically to the
+# committed files (configen runs clang-format on its C output).
+clang-format==22.1.5

--- a/scripts/west_commands/tests/conftest.py
+++ b/scripts/west_commands/tests/conftest.py
@@ -1,0 +1,11 @@
+"""pytest setup for the configen test suite.
+
+Puts the west_commands directory (where configen.py lives) on sys.path so the
+tests can `import configen` directly and exercise its functions.
+"""
+import sys
+from pathlib import Path
+
+WEST_COMMANDS_DIR = Path(__file__).resolve().parent.parent
+if str(WEST_COMMANDS_DIR) not in sys.path:
+    sys.path.insert(0, str(WEST_COMMANDS_DIR))

--- a/scripts/west_commands/tests/pytest.ini
+++ b/scripts/west_commands/tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# configen routes messages through the (deprecated) west.log API; silence that
+# noise so test output stays readable.
+filterwarnings =
+    ignore:The west.log API is deprecated:DeprecationWarning

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -1,0 +1,237 @@
+"""Tests for the configen west command (issue #51, part 2).
+
+Covers the proto/options generator added in #57: idempotence, the append-only
+proto_id allocator, the no-renumber guard, YAML validation, and a cross-check
+that the firmware proto schema and the ttn.js decoder agree on the wire.
+
+Run: `pytest scripts/west_commands/tests` (from the repo root, inside the venv).
+"""
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml as pyyaml
+
+import configen
+
+REPO = Path(__file__).resolve().parents[3]
+APP_SRC = REPO / "app" / "src"
+YAML = APP_SRC / "app_config.yml"
+PROTO = APP_SRC / "app_config.proto"
+OPTIONS = APP_SRC / "app_config.options.in"
+DECODER = REPO / "app" / "decoder" / "ttn.js"
+
+GEN_FILES = ["app_config.c", "app_config.h", "app_config.proto", "app_config.options.in"]
+
+
+def _load_config():
+    with open(YAML) as f:
+        return pyyaml.safe_load(f)
+
+
+def _run_configen(out_dir):
+    """Run the full configen command into out_dir (which must already hold copies
+    of the .yml/.proto/.options.in so the marker rewrite has something to edit)."""
+    args = argparse.Namespace(
+        yaml_file=out_dir / "app_config.yml",
+        output_dir=out_dir,
+        templates_dir=None,
+        proto=None,
+        options=None,
+        no_proto=False,
+        dry_run=False,
+    )
+    configen.Configen().do_run(args, [])
+
+
+@pytest.fixture
+def workdir(tmp_path):
+    for name in ["app_config.yml", "app_config.proto", "app_config.options.in"]:
+        shutil.copy(APP_SRC / name, tmp_path / name)
+    # Carry the project clang-format style so generated C matches the committed
+    # files (clang-format searches upward from the file for .clang-format).
+    if (REPO / ".clang-format").exists():
+        shutil.copy(REPO / ".clang-format", tmp_path / ".clang-format")
+    return tmp_path
+
+
+# --- pure helpers ---------------------------------------------------------
+
+def test_build_options_lines_matches_committed():
+    cfg = _load_config()
+    lines = configen.build_options_lines(cfg)
+    # Only the 7 hex Lorawan keys get max_length; secret_key is a callback.
+    assert lines == [
+        "AppConfigMessage.Lorawan.deveui max_length:16",
+        "AppConfigMessage.Lorawan.joineui max_length:16",
+        "AppConfigMessage.Lorawan.nwkkey max_length:32",
+        "AppConfigMessage.Lorawan.appkey max_length:32",
+        "AppConfigMessage.Lorawan.devaddr max_length:8",
+        "AppConfigMessage.Lorawan.nwkskey max_length:32",
+        "AppConfigMessage.Lorawan.appskey max_length:32",
+    ]
+    assert not any("secret_key" in ln for ln in lines)
+
+
+def test_build_proto_model_structure():
+    model = configen.build_proto_model(_load_config())
+    assert model["message"] == "AppConfigMessage"
+    root = {f["name"]: f["id"] for f in model["root_fields"]}
+    assert root["factory"] == 1
+    assert root["secret_key"] == 2
+    assert root["lorawan"] == 5 and root["application"] == 6
+    subs = {s["name"]: s for s in model["submessages"]}
+    assert subs["Lorawan"]["fields"][0]["name"] == "region"
+    app = subs["Application"]
+    assert 3 in app["reserved"]  # interval_aggreg
+    ids = {f["name"]: f["id"] for f in app["fields"]}
+    assert ids["history_enable"] == 49 and ids["history_sensors"] == 50
+    assert 3 not in ids.values()  # never reused
+
+
+# --- allocator + guard ----------------------------------------------------
+
+def test_allocator_appends_next_free():
+    cfg = _load_config()
+    # ruamel doc only needed for write-back; reuse the same yaml on disk.
+    from ruamel.yaml import YAML as RT
+    rt = RT()
+    with open(YAML) as f:
+        rt_doc = rt.load(f)
+
+    from ruamel.yaml.comments import CommentedMap
+    cfg["parameters"].append({"name": "telemetry_split", "type": "bool",
+                              "proto_group": "application"})
+    rt_new = CommentedMap()
+    rt_new["name"] = "telemetry_split"
+    rt_new["proto_group"] = "application"
+    rt_new["type"] = "bool"
+    rt_doc["parameters"].append(rt_new)
+
+    assigned = configen.allocate_proto_ids(cfg, rt_doc)
+    assert ("telemetry_split", 51) in assigned  # max(application)=50 -> 51
+    got = next(p for p in cfg["parameters"] if p["name"] == "telemetry_split")
+    assert got["proto_id"] == 51
+
+
+def test_guard_rejects_renumbering():
+    cfg = _load_config()
+    region = next(p for p in cfg["parameters"] if p["name"] == "lrw_region")
+    region["proto_id"] = 99  # differs from the locked 1 in the .proto
+    with pytest.raises(SystemExit):
+        configen.guard_no_renumber(cfg, PROTO)
+
+
+def test_guard_accepts_unchanged():
+    configen.guard_no_renumber(_load_config(), PROTO)  # must not raise
+
+
+def test_missing_proto_group_is_rejected():
+    cfg = _load_config()
+    cfg["parameters"].append({"name": "bad", "type": "bool"})
+    from ruamel.yaml import YAML as RT
+    rt = RT()
+    with open(YAML) as f:
+        rt_doc = rt.load(f)
+    with pytest.raises(SystemExit):
+        configen.allocate_proto_ids(cfg, rt_doc)
+
+
+def test_duplicate_proto_id_is_rejected():
+    cfg = _load_config()
+    # force a collision in the application namespace
+    next(p for p in cfg["parameters"] if p["name"] == "calibration")["proto_id"] = 2
+    from ruamel.yaml import YAML as RT
+    rt = RT()
+    with open(YAML) as f:
+        rt_doc = rt.load(f)
+    with pytest.raises(SystemExit):
+        configen.allocate_proto_ids(cfg, rt_doc)
+
+
+# --- full run -------------------------------------------------------------
+
+def test_generation_is_idempotent(workdir):
+    _run_configen(workdir)
+    first = {n: (workdir / n).read_text() for n in GEN_FILES}
+    _run_configen(workdir)
+    second = {n: (workdir / n).read_text() for n in GEN_FILES}
+    assert first == second
+
+
+def test_proto_region_preserves_all_field_numbers(workdir):
+    _run_configen(workdir)
+    committed = configen._parse_proto_field_ids(PROTO.read_text())
+    regenerated = configen._parse_proto_field_ids((workdir / "app_config.proto").read_text())
+    # every field present in the committed proto keeps its number
+    for name, num in committed.items():
+        assert regenerated.get(name) == num
+
+
+@pytest.mark.skipif(shutil.which("clang-format") is None,
+                    reason="clang-format not available")
+def test_generated_c_matches_committed(workdir):
+    _run_configen(workdir)
+    for name in ["app_config.c", "app_config.h"]:
+        assert (workdir / name).read_text() == (APP_SRC / name).read_text(), name
+
+
+# --- proto <-> decoder cross-check ---------------------------------------
+
+COMMAND_VECTORS = {
+    "set_param": "0801120d0a021801120720783d00004842",
+    "get_param": "08021a070a010312020407",
+    "reboot": "08083a00",
+}
+
+
+def _compile_proto(tmp_path):
+    from grpc_tools import protoc
+    rc = protoc.main([
+        "protoc", f"-I{APP_SRC}", f"--python_out={tmp_path}", str(PROTO),
+    ])
+    assert rc == 0, "protoc failed"
+    sys.path.insert(0, str(tmp_path))
+    import app_config_pb2
+    return app_config_pb2
+
+
+def _decode_with_node(hex_str):
+    js = (
+        "const fs=require('fs'),vm=require('vm');"
+        "const ctx={Buffer,console};vm.createContext(ctx);"
+        f"vm.runInContext(fs.readFileSync({str(DECODER)!r},'utf8'),ctx);"
+        f"process.stdout.write(JSON.stringify("
+        f"ctx.decodeDownlink({{bytes:Buffer.from('{hex_str}','hex'),fPort:85}}).data));"
+    )
+    out = subprocess.check_output(["node", "-e", js], text=True)
+    import json
+    return json.loads(out)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_proto_and_decoder_agree(tmp_path):
+    pb = _compile_proto(tmp_path)
+
+    # set_param: python protobuf and ttn.js must read the same fields
+    msg = pb.Command.FromString(bytes.fromhex(COMMAND_VECTORS["set_param"]))
+    assert msg.seq == 1
+    assert msg.set_param.lorawan.adr is True
+    assert msg.set_param.application.interval_report == 120
+    assert abs(msg.set_param.application.alarm_temperature_hi - 50.0) < 1e-6
+
+    js = _decode_with_node(COMMAND_VECTORS["set_param"])
+    assert js["seq"] == 1
+    assert js["set_param"]["application"]["interval_report"] == 120
+    assert abs(js["set_param"]["application"]["alarm_temperature_hi"] - 50.0) < 1e-6
+
+    # get_param field lists
+    msg = pb.Command.FromString(bytes.fromhex(COMMAND_VECTORS["get_param"]))
+    assert list(msg.get_param.lorawan_field) == [3]
+    assert list(msg.get_param.application_field) == [4, 7]
+    js = _decode_with_node(COMMAND_VECTORS["get_param"])
+    assert js["get_param"]["lorawan_field"] == [3]
+    assert js["get_param"]["application_field"] == [4, 7]


### PR DESCRIPTION
Part 2 of #51. Tests for the `west configen` generator (the single point of failure for the whole config/proto schema) — builds on the generator landed in #57.

## Tests — `pytest scripts/west_commands/tests`

`test_configen.py` imports `configen` directly:
- **Pure helpers** — `build_options_lines` (7 Lorawan keys, secret_key excluded), `build_proto_model` (root factory=1/secret_key=2/containers 5,6; Application `reserved 3`; history 49/50, never reuses 3).
- **Allocator** — a new param without `proto_id` gets `max(group)+1` (51), written back.
- **No-renumber guard** — flipping `lrw_region` 1→99 raises `SystemExit`; an unchanged config passes.
- **Validation** — missing `proto_group` and duplicate `proto_id` are rejected.
- **Full run** — idempotent; the proto region preserves **every** committed field number; generated `app_config.{c,h}` match the committed files (clang-format pinned to 22.1.5 so formatting is identical).
- **proto ↔ decoder cross-check** — compile `app_config.proto` with `grpc_tools.protoc`, decode the command vectors with **python protobuf** *and* **ttn.js** (node subprocess), assert they agree. Proves the proto field numbers, the firmware schema and the decoder can't silently diverge.

## CI

`test` job extended: `node --test` → install `requirements-dev.txt` → `pytest`. Still no Zephyr toolchain needed.

Verified locally: `pytest scripts/west_commands/tests` → 11 passed.