### PR TITLE
v1.4.0: tools/test.sh — run the full CI test set locally (#51 part 4)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,24 @@
+# tools
+
+## `test.sh` — run everything CI checks, locally
+
+```bash
+source ~/.venv/bin/activate     # west, pytest, node on PATH
+tools/test.sh                   # full run
+SKIP_BUILD=1 tools/test.sh      # skip the slow firmware builds
+```
+
+Steps (exits non-zero on the first hard failure):
+
+1. **Firmware builds** — release + debug (`west build -p always -b sticker .`).
+2. **Decoder tests** — `node --test` in `app/decoder/` (the LoRaWAN codec).
+3. **configen tests** — `pytest scripts/west_commands/tests` (generator + proto round-trip).
+4. **clang-format** — `--dry-run` over `app/src/*.{c,h}`, **advisory** (the repo has
+   pre-existing hand-written sources that aren't format-clean; reported, not failing).
+5. **configen in sync** — regenerate from `app_config.yml` and fail if the committed
+   `app_config.{c,h,proto,options.in}` would change.
+
+The CI `test` job (`.github/workflows/build.yml`) runs steps 2–3 (no Zephyr toolchain);
+this script is the fuller local superset that also builds and checks generated-file sync.
+
+Install the Python test deps once: `pip install -r scripts/west_commands/requirements-dev.txt`.

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Run everything CI checks, locally, with one command (issue #51, part 4).
+#
+#   tools/test.sh              # full run: builds + node + pytest + format + sync
+#   SKIP_BUILD=1 tools/test.sh # skip the slow firmware builds (quick iteration)
+#
+# Requires (same as CI): west + Zephyr SDK (for builds), node, python with
+# scripts/west_commands/requirements-dev.txt installed. Activate the venv first
+# (e.g. `source ~/.venv/bin/activate`). Exits non-zero on the first failure.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+PASS=0
+FAIL=0
+SKIP=0
+WARN=0
+
+banner() { printf '\n\033[1;36m=== %s ===\033[0m\n' "$1"; }
+ok()     { printf '\033[1;32mPASS\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
+bad()    { printf '\033[1;31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+skip()   { printf '\033[1;33mSKIP\033[0m %s\n' "$1"; SKIP=$((SKIP + 1)); }
+warn()   { printf '\033[1;33mWARN\033[0m %s\n' "$1"; WARN=$((WARN + 1)); }
+have()   { command -v "$1" >/dev/null 2>&1; }
+
+run() { # run <label> <cmd...>
+  local label="$1"; shift
+  banner "$label"
+  if "$@"; then ok "$label"; else bad "$label"; fi
+}
+
+# 1. Firmware builds (release + debug)
+if [ "${SKIP_BUILD:-0}" = "1" ]; then
+  skip "firmware builds (SKIP_BUILD=1)"
+elif ! have west; then
+  bad "firmware builds — 'west' not found (activate the venv / Zephyr env)"
+else
+  run "build release" bash -c "cd '$REPO/app' && west build -p always -b sticker ."
+  run "build debug"   bash -c "cd '$REPO/app' && west build -p always -b sticker . -- -DEXTRA_CONF_FILE=debug.conf"
+fi
+
+# 2. JS decoder tests
+if have node; then
+  run "decoder tests (node --test)" bash -c "cd '$REPO/app/decoder' && node --test"
+else
+  bad "decoder tests — 'node' not found"
+fi
+
+# 3. configen + proto pytest
+if have pytest; then
+  run "configen tests (pytest)" pytest "$REPO/scripts/west_commands/tests"
+else
+  bad "configen tests — 'pytest' not found (pip install -r scripts/west_commands/requirements-dev.txt)"
+fi
+
+# 4. C formatting — advisory only. The repo has pre-existing hand-written
+# sources that aren't clang-format-clean; surface drift without failing the run.
+if have clang-format && [ -f "$REPO/.clang-format" ]; then
+  banner "clang-format --dry-run (advisory)"
+  mapfile -t CFILES < <(git -C "$REPO" ls-files 'app/src/*.c' 'app/src/*.h')
+  if clang-format --dry-run --Werror "${CFILES[@]}" 2>/tmp/cf.$$; then
+    ok "clang-format"
+  else
+    warn "clang-format: $(grep -c 'clang-format-violations' /tmp/cf.$$) violation(s) in app/src (pre-existing; not failing)"
+  fi
+  rm -f /tmp/cf.$$
+else
+  skip "clang-format (not installed or no .clang-format)"
+fi
+
+# 5. Generated config in sync with app_config.yml
+if have west; then
+  banner "configen output in sync"
+  if west configen "$REPO/app/src/app_config.yml" -o "$REPO/app/src/" >/dev/null 2>&1 \
+     && git -C "$REPO" diff --quiet -- \
+        app/src/app_config.c app/src/app_config.h \
+        app/src/app_config.proto app/src/app_config.options.in; then
+    ok "configen output in sync"
+  else
+    bad "configen output in sync — regenerate and commit (git diff app/src/app_config.*)"
+  fi
+else
+  skip "configen sync — 'west' not found"
+fi
+
+banner "summary"
+printf 'pass=%d fail=%d warn=%d skip=%d\n' "$PASS" "$FAIL" "$WARN" "$SKIP"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Part 4 of #51 (final part of this round; part 3 native_sim/ztest deferred).

`tools/test.sh` runs everything CI checks, in one command, for developers:

1. **Builds** — release + debug (`west build -p always -b sticker .`).
2. **Decoder** — `node --test` (app/decoder).
3. **configen** — `pytest scripts/west_commands/tests` (generator + proto round-trip).
4. **clang-format** — `--dry-run` over `app/src/*.{c,h}`, **advisory** (the repo has ~214 pre-existing formatting violations in hand-written sources; reported, not failing).
5. **configen in sync** — regenerate from `app_config.yml` and fail if the committed `app_config.{c,h,proto,options.in}` would change.

`SKIP_BUILD=1` skips the slow builds. Non-zero exit on the first hard failure. `tools/README.md` documents it.

The CI `test` job stays the fast toolchain-free subset (node + pytest); this script is the local superset that also builds and checks generated-file sync.

Verified locally: full run → `pass=5 fail=0 warn=1 skip=0` (warn = advisory clang-format).