### PR TITLE
v1.4.0: clang-format app/src + enforce in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,11 @@ jobs:
       - name: configen + proto tests
         run: pytest scripts/west_commands/tests
 
+      - name: clang-format check (app/src)
+        run: |
+          git ls-files 'app/src/*.c' 'app/src/*.h' \
+            | xargs clang-format --dry-run --Werror
+
   release:
     name: Create release
     if: startsWith(github.ref, 'refs/tags/v')

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -117,19 +117,17 @@ bool app_alarm_poll(void)
 				g_app_config.alarm_pressure_hi, g_app_config.alarm_pressure_hst,
 				"pressure", &should_send);
 
-	alarm |= eval_threshold(&alarm_t1_temperature, g_app_config.alarm_t1_temperature_enabled,
-				g_app_sensor_data.t1_temperature,
-				g_app_config.alarm_t1_temperature_lo,
-				g_app_config.alarm_t1_temperature_hi,
-				g_app_config.alarm_t1_temperature_hst, "external temperature 1",
-				&should_send);
+	alarm |= eval_threshold(
+		&alarm_t1_temperature, g_app_config.alarm_t1_temperature_enabled,
+		g_app_sensor_data.t1_temperature, g_app_config.alarm_t1_temperature_lo,
+		g_app_config.alarm_t1_temperature_hi, g_app_config.alarm_t1_temperature_hst,
+		"external temperature 1", &should_send);
 
-	alarm |= eval_threshold(&alarm_t2_temperature, g_app_config.alarm_t2_temperature_enabled,
-				g_app_sensor_data.t2_temperature,
-				g_app_config.alarm_t2_temperature_lo,
-				g_app_config.alarm_t2_temperature_hi,
-				g_app_config.alarm_t2_temperature_hst, "external temperature 2",
-				&should_send);
+	alarm |= eval_threshold(
+		&alarm_t2_temperature, g_app_config.alarm_t2_temperature_enabled,
+		g_app_sensor_data.t2_temperature, g_app_config.alarm_t2_temperature_lo,
+		g_app_config.alarm_t2_temperature_hi, g_app_config.alarm_t2_temperature_hst,
+		"external temperature 2", &should_send);
 
 	k_mutex_unlock(&g_app_sensor_data_lock);
 

--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -33,7 +33,7 @@
 
 LOG_MODULE_REGISTER(app_ats, LOG_LEVEL_DBG);
 
-#define SHELL_PFX "ats"
+#define SHELL_PFX                     "ats"
 #define SENSOR_CHECK_POLL_INTERVAL_MS 300 /* Poll interval for sensor check in milliseconds */
 
 static struct k_work_delayable g_led_cycle_work;
@@ -213,7 +213,8 @@ static int cmd_print_serial_numbers(const struct shell *shell, size_t argc, char
 		uint32_t sht_serial;
 		ret = app_machine_probe_read_hygrometer_serial(i, &serial_number, &sht_serial);
 		if (ret) {
-			shell_error(shell, "Failed to read Machine Probe SHT serial %d: %d", i, ret);
+			shell_error(shell, "Failed to read Machine Probe SHT serial %d: %d", i,
+				    ret);
 		} else {
 			shell_print(shell, "Machine Probe[%d] SHT serial: %u", i, sht_serial);
 		}
@@ -574,12 +575,11 @@ static int cmd_lrw_status(const struct shell *shell, size_t argc, char **argv)
 	shell_print(shell, "margin: %u dB", info.margin);
 	shell_print(shell, "gateways: %u", info.gw_count);
 	shell_print(shell, "messages: %d", info.message_count);
-	shell_print(shell, "healthy->warning: %d/%d",
-		    info.consecutive_lc_fail, info.thresh_warning);
-	shell_print(shell, "warning->healthy: %d/%d",
-		    info.consecutive_lc_ok, info.thresh_healthy);
-	shell_print(shell, "warning->reconnect: %d/%d",
-		    info.warning_lc_fail_total, info.thresh_reconnect);
+	shell_print(shell, "healthy->warning: %d/%d", info.consecutive_lc_fail,
+		    info.thresh_warning);
+	shell_print(shell, "warning->healthy: %d/%d", info.consecutive_lc_ok, info.thresh_healthy);
+	shell_print(shell, "warning->reconnect: %d/%d", info.warning_lc_fail_total,
+		    info.thresh_reconnect);
 
 	return 0;
 }
@@ -606,34 +606,35 @@ static int cmd_lrw_reset(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_lrw,
-	SHELL_CMD_ARG(status, NULL, "Print LoRaWAN status.", cmd_lrw_status, 1, 0),
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_lrw, SHELL_CMD_ARG(status, NULL, "Print LoRaWAN status.", cmd_lrw_status, 1, 0),
 	SHELL_CMD_ARG(check, NULL, "Send data with link check.", cmd_lrw_check, 1, 0),
 	SHELL_CMD_ARG(reset, NULL, "Reset LoRaWAN frame counters + DevNonce (reboots).",
 		      cmd_lrw_reset, 1, 0),
 	SHELL_SUBCMD_SET_END);
 #endif /* defined(CONFIG_LORAWAN) */
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensors,
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_sensors,
 	SHELL_CMD_ARG(sample, NULL, "Print all sensor values.", cmd_print_sample, 1, 0),
 	SHELL_CMD_ARG(reset, NULL, "Reset sensor counters.", cmd_reset_sample, 1, 0),
-	SHELL_CMD_ARG(serial, NULL, "Print sensor serial numbers.", cmd_print_serial_numbers, 1,
-		      0),
+	SHELL_CMD_ARG(serial, NULL, "Print sensor serial numbers.", cmd_print_serial_numbers, 1, 0),
 	SHELL_CMD_ARG(check, NULL, "Monitor sensor for changes. Usage: check <sensor> [timeout]",
 		      cmd_check_sensor, 2, 1),
 	SHELL_SUBCMD_SET_END);
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_led,
-	SHELL_CMD_ARG(cycle, NULL,
-		      "Cycle LED (R/Y/G/off). Usage: cycle [count] (default=1, 0=stop, 1-99=cycles)",
-		      cmd_cycle_led, 1, 1),
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_led,
+	SHELL_CMD_ARG(
+		cycle, NULL,
+		"Cycle LED (R/Y/G/off). Usage: cycle [count] (default=1, 0=stop, 1-99=cycles)",
+		cmd_cycle_led, 1, 1),
 	SHELL_CMD_ARG(switch, NULL, "Switch LED channel (format red|yellow|green on|off).",
 		      cmd_switch_led, 3, 0),
 	SHELL_SUBCMD_SET_END);
 
 #ifdef CONFIG_APP_CMD_DEBUG_SHELL
-static int cmd_cmd_inject(const struct shell *sh, enum app_cmd_transport transport,
-			  const char *hex)
+static int cmd_cmd_inject(const struct shell *sh, enum app_cmd_transport transport, const char *hex)
 {
 	size_t hex_len = strlen(hex);
 
@@ -693,25 +694,23 @@ static int cmd_cmd_nfc(const struct shell *sh, size_t argc, char **argv)
 	return cmd_cmd_inject(sh, APP_CMD_TRANSPORT_NFC, argv[1]);
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd,
-	SHELL_CMD_ARG(lrw, NULL, "Inject over LoRaWAN transport. Usage: lrw <hex>",
-		      cmd_cmd_lrw, 2, 0),
-	SHELL_CMD_ARG(nfc, NULL, "Inject over NFC transport. Usage: nfc <hex>",
-		      cmd_cmd_nfc, 2, 0),
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_cmd,
+	SHELL_CMD_ARG(lrw, NULL, "Inject over LoRaWAN transport. Usage: lrw <hex>", cmd_cmd_lrw, 2,
+		      0),
+	SHELL_CMD_ARG(nfc, NULL, "Inject over NFC transport. Usage: nfc <hex>", cmd_cmd_nfc, 2, 0),
 	SHELL_SUBCMD_SET_END);
 #endif /* CONFIG_APP_CMD_DEBUG_SHELL */
 
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_ats,
-	SHELL_CMD(led, &sub_led, "LED commands.", NULL),
-	SHELL_CMD(sensors, &sub_sensors, "Sensor commands.", NULL),
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ats, SHELL_CMD(led, &sub_led, "LED commands.", NULL),
+			       SHELL_CMD(sensors, &sub_sensors, "Sensor commands.", NULL),
 #if defined(CONFIG_LORAWAN)
-	SHELL_CMD(lrw, &sub_lrw, "LoRaWAN commands.", NULL),
+			       SHELL_CMD(lrw, &sub_lrw, "LoRaWAN commands.", NULL),
 #endif /* defined(CONFIG_LORAWAN) */
 #ifdef CONFIG_APP_CMD_DEBUG_SHELL
-	SHELL_CMD(cmd, &sub_cmd, "Inject Command (protobuf hex).", NULL),
+			       SHELL_CMD(cmd, &sub_cmd, "Inject Command (protobuf hex).", NULL),
 #endif
-	SHELL_SUBCMD_SET_END);
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(ats, &sub_ats, "Automated test system commands.", NULL);
 

--- a/app/src/app_calibration.c
+++ b/app/src/app_calibration.c
@@ -31,14 +31,14 @@
 
 LOG_MODULE_REGISTER(app_calibration, LOG_LEVEL_DBG);
 
-#define SENTINEL          ((int16_t)0x7FFF)
-#define PAYLOAD_SIZE      24
-#define LOOP_INTERVAL_SEC 1
-#define SEND_INTERVAL_SEC 30
-#define SETTLE_DELAY_SEC  2
-#define ENTRY_BLINKS      5
-#define CALIBRATION_PORT        10
-#define MAGNET_PENDING_MAX      2
+#define SENTINEL           ((int16_t)0x7FFF)
+#define PAYLOAD_SIZE       24
+#define LOOP_INTERVAL_SEC  1
+#define SEND_INTERVAL_SEC  30
+#define SETTLE_DELAY_SEC   2
+#define ENTRY_BLINKS       5
+#define CALIBRATION_PORT   10
+#define MAGNET_PENDING_MAX 2
 
 /* Fixed ABP keys for calibration mode — all devices use the same credentials */
 static const uint8_t m_cal_deveui[] = {0x02, 0x40, 0x3b, 0x84, 0xfd, 0x45, 0x1f, 0x37};
@@ -298,11 +298,10 @@ int app_calibration_init(void)
 
 	/* One-time 5x fast yellow blink to indicate calibration entry */
 	{
-		struct app_led_blink_req req = {
-			.color = APP_LED_CHANNEL_Y,
-			.duration = 100,
-			.space = 100,
-			.repetitions = ENTRY_BLINKS};
+		struct app_led_blink_req req = {.color = APP_LED_CHANNEL_Y,
+						.duration = 100,
+						.space = 100,
+						.repetitions = ENTRY_BLINKS};
 		app_led_blink(&req);
 	}
 
@@ -313,8 +312,7 @@ void app_calibration_run(void)
 {
 	k_sleep(K_SECONDS(SETTLE_DELAY_SEC));
 
-	int64_t deadline = k_uptime_get()
-			 + (int64_t)APP_CALIBRATION_DURATION_MIN * 60 * 1000;
+	int64_t deadline = k_uptime_get() + (int64_t)APP_CALIBRATION_DURATION_MIN * 60 * 1000;
 	int counter = SEND_INTERVAL_SEC;
 
 	for (;;) {
@@ -334,8 +332,7 @@ void app_calibration_run(void)
 
 #if defined(CONFIG_LORAWAN)
 			if (app_lrw_is_ready()) {
-				lorawan_send(CALIBRATION_PORT, buf,
-					     PAYLOAD_SIZE,
+				lorawan_send(CALIBRATION_PORT, buf, PAYLOAD_SIZE,
 					     LORAWAN_MSG_UNCONFIRMED);
 			}
 #endif /* defined(CONFIG_LORAWAN) */

--- a/app/src/app_clock.c
+++ b/app/src/app_clock.c
@@ -207,8 +207,8 @@ static int cmd_clock_sync(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_clock,
-	SHELL_CMD_ARG(get, NULL, "Read RTC time.", cmd_clock_get, 1, 0),
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_clock, SHELL_CMD_ARG(get, NULL, "Read RTC time.", cmd_clock_get, 1, 0),
 	SHELL_CMD_ARG(set, NULL, "Set RTC time. Usage: set <unix>", cmd_clock_set, 2, 0),
 	SHELL_CMD_ARG(sync, NULL, "Request network time (LoRaWAN DeviceTimeReq).", cmd_clock_sync,
 		      1, 0),

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -73,8 +73,7 @@ static void fill_info(Response_Info *info)
 #endif
 }
 
-static void make_error(Response *resp, Response_Error_Code code,
-		       const char *detail)
+static void make_error(Response *resp, Response_Error_Code code, const char *detail)
 {
 	resp->which_body = Response_error_tag;
 	resp->body.error.code = code;
@@ -144,14 +143,62 @@ static const struct {
 	uint8_t size;
 } DUMP_FIELDS[] = {
 	/* Lorawan (non-secret): varints 2 B, deveui/joineui 18 B, devaddr 10 B */
-	LRW(1, 2), LRW(2, 2), LRW(3, 2), LRW(4, 2), LRW(5, 18), LRW(6, 18), LRW(9, 10), LRW(12, 2),
+	LRW(1, 2),
+	LRW(2, 2),
+	LRW(3, 2),
+	LRW(4, 2),
+	LRW(5, 18),
+	LRW(6, 18),
+	LRW(9, 10),
+	LRW(12, 2),
 	/* Application (tag 3 interval_aggreg has no config field — skipped, like
 	 * fill_application). Floats 5 B, everything else 2 B. */
-	APP2(1), APP2(2), APP2(4), APP2(5), APP5(6), APP5(7), APP5(8), APP2(9), APP5(10), APP5(11),
-	APP5(12), APP2(13), APP5(14), APP5(15), APP5(16), APP2(17), APP5(18), APP5(19), APP5(20),
-	APP2(21), APP5(22), APP5(23), APP5(24), APP2(25), APP2(26), APP2(27), APP2(28), APP2(29),
-	APP2(30), APP2(31), APP2(32), APP2(33), APP2(34), APP2(35), APP2(36), APP5(37), APP5(38),
-	APP5(39), APP2(40), APP2(41), APP2(42), APP2(43), APP2(44), APP2(45), APP2(46), APP2(47),
+	APP2(1),
+	APP2(2),
+	APP2(4),
+	APP2(5),
+	APP5(6),
+	APP5(7),
+	APP5(8),
+	APP2(9),
+	APP5(10),
+	APP5(11),
+	APP5(12),
+	APP2(13),
+	APP5(14),
+	APP5(15),
+	APP5(16),
+	APP2(17),
+	APP5(18),
+	APP5(19),
+	APP5(20),
+	APP2(21),
+	APP5(22),
+	APP5(23),
+	APP5(24),
+	APP2(25),
+	APP2(26),
+	APP2(27),
+	APP2(28),
+	APP2(29),
+	APP2(30),
+	APP2(31),
+	APP2(32),
+	APP2(33),
+	APP2(34),
+	APP2(35),
+	APP2(36),
+	APP5(37),
+	APP5(38),
+	APP5(39),
+	APP2(40),
+	APP2(41),
+	APP2(42),
+	APP2(43),
+	APP2(44),
+	APP2(45),
+	APP2(46),
+	APP2(47),
 	APP2(48),
 };
 
@@ -229,13 +276,13 @@ static void handle_req_history(const Command_ReqHistory *rq, Response *resp)
 	uint16_t total = 0;
 
 	Response_HistoryFrame *hf = &resp->body.history_frame;
-	size_t len = app_history_export(from, to, hf->samples.bytes, sizeof(hf->samples.bytes),
-					&t0, &n_written, &total);
+	size_t len = app_history_export(from, to, hf->samples.bytes, sizeof(hf->samples.bytes), &t0,
+					&n_written, &total);
 
 	resp->which_body = Response_history_frame_tag;
-	hf->frame_index = 0;          /* this page starts at `from` */
-	hf->frame_count = total;      /* total records in the window; host pages by
-				       * narrowing from_unix to last returned time + 1 */
+	hf->frame_index = 0;     /* this page starts at `from` */
+	hf->frame_count = total; /* total records in the window; host pages by
+				  * narrowing from_unix to last returned time + 1 */
 	hf->t0_unix = t0;
 	hf->samples.size = len;
 #else
@@ -244,8 +291,8 @@ static void handle_req_history(const Command_ReqHistory *rq, Response *resp)
 #endif
 }
 
-static void dispatch(enum app_cmd_transport transport, const Command *cmd,
-		     Response *resp, enum app_cmd_action *action)
+static void dispatch(enum app_cmd_transport transport, const Command *cmd, Response *resp,
+		     enum app_cmd_action *action)
 {
 	ARG_UNUSED(transport);
 
@@ -313,8 +360,8 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd,
 	}
 }
 
-int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t in_len,
-		   uint8_t *out, size_t out_cap, size_t *out_len, enum app_cmd_action *action)
+int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t in_len, uint8_t *out,
+		   size_t out_cap, size_t *out_len, enum app_cmd_action *action)
 {
 	if (!in || !out || !out_len) {
 		return -EINVAL;
@@ -330,8 +377,7 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 	if (!pb_decode(&istream, Command_fields, &cmd)) {
 		LOG_ERR_CALL_FAILED_STR("pb_decode", PB_GET_ERROR(&istream));
 		resp.seq = 0;
-		make_error(&resp, Response_Error_Code_BAD_REQUEST,
-			   PB_GET_ERROR(&istream));
+		make_error(&resp, Response_Error_Code_BAD_REQUEST, PB_GET_ERROR(&istream));
 	} else {
 		dispatch(transport, &cmd, &resp, &act);
 	}

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -45,10 +45,8 @@ enum app_cmd_action {
  * transmitting the response (reboot/save/factory-reset). APP_CMD_ACTION_NONE
  * otherwise.
  */
-int app_cmd_handle(enum app_cmd_transport transport,
-		   const uint8_t *in, size_t in_len,
-		   uint8_t *out, size_t out_cap, size_t *out_len,
-		   enum app_cmd_action *action);
+int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t in_len, uint8_t *out,
+		   size_t out_cap, size_t *out_len, enum app_cmd_action *action);
 
 /* Build an unsolicited device Info frame (Response{ seq=0, info=... },
  * the same payload a GetInfo command returns) into `out`. Used to send an

--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -145,7 +145,7 @@ static bool group_present(const Telemetry *s, enum tlm_group g)
 
 /* Snapshot held across the frames of one report (consistency). */
 static Telemetry m_snapshot;
-static uint16_t m_pending;  /* bitmask of enum tlm_group still to send */
+static uint16_t m_pending; /* bitmask of enum tlm_group still to send */
 static bool m_active;
 
 static void fill_snapshot(void)
@@ -392,7 +392,8 @@ int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more)
 			if (m_pending & BIT(g)) {
 				apply_group(&frame, &m_snapshot, g, true);
 				frame_groups = BIT(g);
-				LOG_WRN("Group %d exceeds budget %uB, sending alone", (int)g, budget);
+				LOG_WRN("Group %d exceeds budget %uB, sending alone", (int)g,
+					budget);
 				break;
 			}
 		}

--- a/app/src/app_config_ingest.c
+++ b/app/src/app_config_ingest.c
@@ -41,7 +41,7 @@ LOG_MODULE_REGISTER(app_config_ingest, LOG_LEVEL_DBG);
 		if (src->field >= (lo) && src->field <= (hi)) {                                    \
 			config->field = src->field;                                                \
 		} else {                                                                           \
-			LOG_WRN("Invalid " #field);                                                 \
+			LOG_WRN("Invalid " #field);                                                \
 			FAULT(tag);                                                                \
 		}                                                                                  \
 	}
@@ -296,12 +296,12 @@ void app_config_fill_lorawan(AppConfigMessage_Lorawan *dst, const uint32_t *ids,
 
 #define FILL_BOOL(tag, field)                                                                      \
 	if (requested(ids, n, tag)) {                                                              \
-		dst->has_##field = true;                                                            \
+		dst->has_##field = true;                                                           \
 		dst->field = c->field;                                                             \
 	}
 #define FILL_NUM(tag, field)                                                                       \
 	if (requested(ids, n, tag)) {                                                              \
-		dst->has_##field = true;                                                            \
+		dst->has_##field = true;                                                           \
 		dst->field = c->field;                                                             \
 	}
 

--- a/app/src/app_history.c
+++ b/app/src/app_history.c
@@ -52,7 +52,7 @@ enum hist_enc {
 
 struct hist_desc {
 	const char *name;
-	size_t src_off;  /* offset in struct app_sensor_data */
+	size_t src_off; /* offset in struct app_sensor_data */
 	enum hist_enc enc;
 	uint8_t size;
 	size_t cap_off; /* offset of bool capability in struct app_config, or NO_CAP */
@@ -78,8 +78,8 @@ static const struct hist_desc m_desc[APP_HISTORY_SENSOR_COUNT] = {
 	[APP_HISTORY_HALL_LEFT] = {"hall-left", offsetof(struct app_sensor_data, hall_left_count),
 				   ENC_COUNT, 4, offsetof(struct app_config, cap_hall_left)},
 	[APP_HISTORY_HALL_RIGHT] = {"hall-right",
-				    offsetof(struct app_sensor_data, hall_right_count), ENC_COUNT, 4,
-				    offsetof(struct app_config, cap_hall_right)},
+				    offsetof(struct app_sensor_data, hall_right_count), ENC_COUNT,
+				    4, offsetof(struct app_config, cap_hall_right)},
 	[APP_HISTORY_INPUT_A] = {"input-a", offsetof(struct app_sensor_data, input_a_count),
 				 ENC_COUNT, 4, offsetof(struct app_config, cap_input_a)},
 	[APP_HISTORY_INPUT_B] = {"input-b", offsetof(struct app_sensor_data, input_b_count),
@@ -88,21 +88,21 @@ static const struct hist_desc m_desc[APP_HISTORY_SENSOR_COUNT] = {
 				4, offsetof(struct app_config, cap_pir_detector)},
 };
 
-#define TEMP_SENTINEL 0x7FFF
-#define HUM_SENTINEL  0xFF
+#define TEMP_SENTINEL   0x7FFF
+#define HUM_SENTINEL    0xFF
 #define MAX_RECORD_SIZE (2 + 13 * 4) /* delta + worst case all channels */
 
 /* ---- Module state ------------------------------------------------------- */
 
 static struct k_mutex m_lock;
 static bool m_enabled;
-static uint16_t m_mask;       /* selected & available sensors */
+static uint16_t m_mask; /* selected & available sensors */
 static uint16_t m_sample_size;
 static uint16_t m_capacity;
-static uint16_t m_start;      /* index of oldest record */
+static uint16_t m_start; /* index of oldest record */
 static uint16_t m_count;
-static uint32_t m_base_time;  /* oldest record's time: uptime-s unsynced, unix synced */
-static uint32_t m_last_time;  /* newest record's time source */
+static uint32_t m_base_time; /* oldest record's time: uptime-s unsynced, unix synced */
+static uint32_t m_last_time; /* newest record's time source */
 static bool m_base_synced;
 
 static bool cap_on(size_t cap_off)
@@ -130,7 +130,7 @@ static uint32_t now_seconds(bool *synced)
 
 #if defined(CONFIG_APP_HISTORY_FLASH)
 
-#define NVS_ID_META    1
+#define NVS_ID_META     1
 #define NVS_ID_REC_BASE 100
 
 static struct nvs_fs m_fs;
@@ -679,8 +679,8 @@ int app_history_init(void)
 		m_base_synced = false;
 	}
 
-	LOG_INF("history: enabled=%d, %u sensors, sample=%uB, capacity=%u, stored=%u",
-		m_enabled, (unsigned)POPCOUNT(m_mask), m_sample_size, m_capacity, m_count);
+	LOG_INF("history: enabled=%d, %u sensors, sample=%uB, capacity=%u, stored=%u", m_enabled,
+		(unsigned)POPCOUNT(m_mask), m_sample_size, m_capacity, m_count);
 	return 0;
 }
 
@@ -727,7 +727,8 @@ static int cmd_history_info(const struct shell *sh, size_t argc, char **argv)
 		    (unsigned)POPCOUNT(m_mask), m_sample_size);
 	shell_print(sh, "capacity:  %u records", m_capacity);
 	shell_print(sh, "stored:    %u / %u", m_count, m_capacity);
-	shell_print(sh, "base:      %u (%s)", m_base_time, m_base_synced ? "unix" : "uptime/no-rtc");
+	shell_print(sh, "base:      %u (%s)", m_base_time,
+		    m_base_synced ? "unix" : "uptime/no-rtc");
 	return 0;
 }
 
@@ -906,8 +907,7 @@ static int cmd_history_stats(const struct shell *sh, size_t argc, char **argv)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_history,
-	SHELL_CMD_ARG(info, NULL, "Buffer summary.", cmd_history_info, 1, 0),
+	sub_history, SHELL_CMD_ARG(info, NULL, "Buffer summary.", cmd_history_info, 1, 0),
 	SHELL_CMD_ARG(count, NULL, "Number of stored records.", cmd_history_count, 1, 0),
 	SHELL_CMD_ARG(read, NULL, "List records. Usage: read [N]", cmd_history_read, 1, 1),
 	SHELL_CMD_ARG(clear, NULL, "Erase the buffer.", cmd_history_clear, 1, 0),

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -43,18 +43,18 @@
 LOG_MODULE_REGISTER(app_lrw, LOG_LEVEL_DBG);
 
 /* Link check configuration constants */
-#define LINK_CHECK_INTERVAL    5   /* Every N-th message has LC (0 = disabled) */
-#define LINK_CHECK_TIMEOUT_SEC 10  /* Timeout for response */
+#define LINK_CHECK_INTERVAL    5  /* Every N-th message has LC (0 = disabled) */
+#define LINK_CHECK_TIMEOUT_SEC 10 /* Timeout for response */
 
 /* State machine thresholds  */
-#define FAIL_THRESHOLD_WARNING   3  /* LC failures to enter WARNING */
-#define FAIL_THRESHOLD_RECONNECT 5  /* LC failures in WARNING to enter RECONNECT */
-#define OK_THRESHOLD_HEALTHY     1  /* LC successes in WARNING to return to HEALTHY */
+#define FAIL_THRESHOLD_WARNING   3 /* LC failures to enter WARNING */
+#define FAIL_THRESHOLD_RECONNECT 5 /* LC failures in WARNING to enter RECONNECT */
+#define OK_THRESHOLD_HEALTHY     1 /* LC successes in WARNING to return to HEALTHY */
 
 /* Join/Rejoin backoff configuration - easily adjustable */
-#define REJOIN_BACKOFF_BASE_SEC  60   /* Base backoff time in seconds */
-#define REJOIN_BACKOFF_MAX_SEC   3600 /* Maximum backoff time (1 hour) */
-#define REJOIN_BACKOFF_MULTIPLIER 2   /* Exponential multiplier per attempt */
+#define REJOIN_BACKOFF_BASE_SEC   60   /* Base backoff time in seconds */
+#define REJOIN_BACKOFF_MAX_SEC    3600 /* Maximum backoff time (1 hour) */
+#define REJOIN_BACKOFF_MULTIPLIER 2    /* Exponential multiplier per attempt */
 
 static K_THREAD_STACK_DEFINE(m_work_stack, 2048);
 static struct k_work_q m_work_q;
@@ -71,30 +71,30 @@ static struct k_work m_join_work;
 /* Current telemetry frame, kept so a failed send can be retried verbatim
  * (app_compose already consumed those groups from its snapshot). */
 static uint8_t m_frame_buf[64];
-static size_t  m_frame_len;
-static bool    m_frame_more;    /* more frames remain in this snapshot */
-static bool    m_frame_first;   /* this frame is the snapshot's first (for LC) */
-static bool    m_frame_resend;  /* last send failed; resend m_frame_buf as-is */
+static size_t m_frame_len;
+static bool m_frame_more;   /* more frames remain in this snapshot */
+static bool m_frame_first;  /* this frame is the snapshot's first (for LC) */
+static bool m_frame_resend; /* last send failed; resend m_frame_buf as-is */
 
 static void tx_telemetry_frame(bool first_frame);
 
 static atomic_t m_state = ATOMIC_INIT(APP_LRW_STATE_IDLE);
 static struct k_timer m_link_check_timer;
 static struct k_work m_link_check_work;
-static int m_consecutive_lc_fail;          /* LC failures in a row (HEALTHY) */
-static int m_consecutive_lc_ok;            /* LC successes in a row (WARNING) */
-static int m_warning_lc_fail_total;        /* Total LC failures in WARNING */
-static int m_force_lc_remaining;           /* Remaining forced LC messages */
-static bool m_link_check_pending;          /* Waiting for LC response */
-static int m_message_count;                /* Message counter for N-th LC */
-static int m_rejoin_attempts;              /* Rejoin attempt counter for backoff */
-static int m_join_busy_polls;              /* Counter for MAC busy polling */
-static bool m_init_join;                   /* True for first join after boot */
+static int m_consecutive_lc_fail;   /* LC failures in a row (HEALTHY) */
+static int m_consecutive_lc_ok;     /* LC successes in a row (WARNING) */
+static int m_warning_lc_fail_total; /* Total LC failures in WARNING */
+static int m_force_lc_remaining;    /* Remaining forced LC messages */
+static bool m_link_check_pending;   /* Waiting for LC response */
+static int m_message_count;         /* Message counter for N-th LC */
+static int m_rejoin_attempts;       /* Rejoin attempt counter for backoff */
+static int m_join_busy_polls;       /* Counter for MAC busy polling */
+static bool m_init_join;            /* True for first join after boot */
 
 static struct k_work_delayable m_join_complete_work;
 
-#define JOIN_BUSY_POLL_INTERVAL_MS  500
-#define JOIN_BUSY_MAX_POLLS         30
+#define JOIN_BUSY_POLL_INTERVAL_MS 500
+#define JOIN_BUSY_MAX_POLLS        30
 
 static int m_current_dr;
 /* Application-payload budget (bytes) for the next TX, sourced from the LoRaWAN
@@ -121,23 +121,22 @@ static uint8_t m_lc_response_gw_count;
  * response leaves overwrites with a warning. */
 #define APP_LRW_RESPONSE_BUF_SIZE 64
 static uint8_t m_pending_response_buf[APP_LRW_RESPONSE_BUF_SIZE];
-static size_t  m_pending_response_len;
+static size_t m_pending_response_len;
 static uint8_t m_pending_response_port;
 static K_MUTEX_DEFINE(m_pending_response_lock);
 
 /* Inbound downlink request on port 85 captured from downlink_callback().
  * The callback runs on the LoRaMac stack (restricted), so it only copies the
  * payload and defers parsing to m_dl_request_work on m_work_q. */
-#define APP_LRW_REQUEST_BUF_SIZE 64
+#define APP_LRW_REQUEST_BUF_SIZE  64
 #define APP_LRW_DOWNLINK_CMD_PORT 85
 static uint8_t m_dl_request_buf[APP_LRW_REQUEST_BUF_SIZE];
-static size_t  m_dl_request_len;
+static size_t m_dl_request_len;
 static struct k_work m_dl_request_work;
 
 /* Deferred reboot/save requested by a command handler; runs after the Ack TX. */
 static struct k_work_delayable m_post_cmd_work;
 static enum app_cmd_action m_post_cmd_action;
-
 
 static uint32_t calculate_rejoin_backoff(int attempt)
 {
@@ -198,8 +197,8 @@ static void dl_request_work_handler(struct k_work *work)
 	size_t resp_len = 0;
 	enum app_cmd_action action = APP_CMD_ACTION_NONE;
 
-	int ret = app_cmd_handle(APP_CMD_TRANSPORT_LRW, m_dl_request_buf, m_dl_request_len,
-				 resp, sizeof(resp), &resp_len, &action);
+	int ret = app_cmd_handle(APP_CMD_TRANSPORT_LRW, m_dl_request_buf, m_dl_request_len, resp,
+				 sizeof(resp), &resp_len, &action);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("app_cmd_handle", ret);
 		return;
@@ -251,8 +250,8 @@ static void downlink_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t 
 			m_dl_request_len = len;
 			k_work_submit_to_queue(&m_work_q, &m_dl_request_work);
 		} else {
-			LOG_WRN("Port %u payload too large: %u B (max %zu)",
-				port, len, sizeof(m_dl_request_buf));
+			LOG_WRN("Port %u payload too large: %u B (max %zu)", port, len,
+				sizeof(m_dl_request_buf));
 		}
 	}
 
@@ -303,15 +302,15 @@ static void join_complete_work_handler(struct k_work *work)
 				JOIN_BUSY_MAX_POLLS * JOIN_BUSY_POLL_INTERVAL_MS);
 			atomic_set(&m_state, APP_LRW_STATE_RECONNECT);
 			m_rejoin_attempts = 0;
-			k_timer_start(&m_link_check_timer,
-				      K_SECONDS(REJOIN_BACKOFF_BASE_SEC), K_FOREVER);
+			k_timer_start(&m_link_check_timer, K_SECONDS(REJOIN_BACKOFF_BASE_SEC),
+				      K_FOREVER);
 			return;
 		}
 
 		/* Log only every 10th poll (5 seconds) to reduce noise */
 		if ((m_join_busy_polls % 10) == 0) {
-			LOG_INF("MAC still busy (%d/%d)...",
-				m_join_busy_polls, JOIN_BUSY_MAX_POLLS);
+			LOG_INF("MAC still busy (%d/%d)...", m_join_busy_polls,
+				JOIN_BUSY_MAX_POLLS);
 		}
 		k_work_schedule_for_queue(&m_work_q, &m_join_complete_work,
 					  K_MSEC(JOIN_BUSY_POLL_INTERVAL_MS));
@@ -334,7 +333,7 @@ static void join_complete_work_handler(struct k_work *work)
 
 	/* Join succeeded - transition to HEALTHY */
 	LOG_INF("Join successful - transitioning to HEALTHY");
-	m_init_join = false;  /* Next join will be rejoin with MAC reset */
+	m_init_join = false; /* Next join will be rejoin with MAC reset */
 	lorawan_enable_adr(g_app_config.lrw_adr);
 
 	/* Capture the initial DR's payload budget; the DR-changed callback may not
@@ -376,8 +375,8 @@ static void handle_link_check_failure(void)
 	switch (state) {
 	case APP_LRW_STATE_HEALTHY:
 		m_consecutive_lc_fail++;
-		LOG_WRN("LC FAIL in HEALTHY (streak: %d/%d)",
-			m_consecutive_lc_fail, FAIL_THRESHOLD_WARNING);
+		LOG_WRN("LC FAIL in HEALTHY (streak: %d/%d)", m_consecutive_lc_fail,
+			FAIL_THRESHOLD_WARNING);
 
 		if (m_consecutive_lc_fail >= FAIL_THRESHOLD_WARNING) {
 			LOG_WRN("Entering WARNING state");
@@ -391,8 +390,8 @@ static void handle_link_check_failure(void)
 
 	case APP_LRW_STATE_WARNING:
 		m_warning_lc_fail_total++;
-		LOG_WRN("LC FAIL in WARNING (total: %d/%d)",
-			m_warning_lc_fail_total, FAIL_THRESHOLD_RECONNECT);
+		LOG_WRN("LC FAIL in WARNING (total: %d/%d)", m_warning_lc_fail_total,
+			FAIL_THRESHOLD_RECONNECT);
 
 		if (m_warning_lc_fail_total >= FAIL_THRESHOLD_RECONNECT) {
 			/* Only OTAA can reconnect */
@@ -448,8 +447,8 @@ static void handle_link_check_success(void)
 
 	case APP_LRW_STATE_WARNING:
 		m_consecutive_lc_ok++;
-		LOG_INF("LC OK in WARNING (streak: %d/%d)",
-			m_consecutive_lc_ok, OK_THRESHOLD_HEALTHY);
+		LOG_INF("LC OK in WARNING (streak: %d/%d)", m_consecutive_lc_ok,
+			OK_THRESHOLD_HEALTHY);
 
 		if (m_consecutive_lc_ok >= OK_THRESHOLD_HEALTHY) {
 			LOG_INF("Returning to HEALTHY state");
@@ -596,8 +595,8 @@ static void join_work_handler(struct k_work *work)
 	if (ret && ret != -ETIMEDOUT) {
 		/* Hard error (not ETIMEDOUT) - retry with backoff */
 		uint32_t backoff = calculate_rejoin_backoff(m_rejoin_attempts);
-		LOG_ERR("Join failed: %d, will retry in %u seconds (attempt %d)",
-			ret, backoff, m_rejoin_attempts + 1);
+		LOG_ERR("Join failed: %d, will retry in %u seconds (attempt %d)", ret, backoff,
+			m_rejoin_attempts + 1);
 		m_rejoin_attempts++;
 		atomic_set(&m_state, APP_LRW_STATE_RECONNECT);
 		k_timer_start(&m_link_check_timer, K_SECONDS(backoff), K_FOREVER);
@@ -687,7 +686,7 @@ static void send_work_handler(struct k_work *work)
 	k_mutex_lock(&m_pending_response_lock, K_FOREVER);
 	if (m_pending_response_len) {
 		uint8_t buf[APP_LRW_RESPONSE_BUF_SIZE];
-		size_t  len  = m_pending_response_len;
+		size_t len = m_pending_response_len;
 		uint8_t port = m_pending_response_port;
 		memcpy(buf, m_pending_response_buf, len);
 		m_pending_response_len = 0;
@@ -699,8 +698,7 @@ static void send_work_handler(struct k_work *work)
 		} else {
 			LOG_INF("Response sent on port %u (%zu B)", port, len);
 		}
-		k_timer_start(&m_send_timer,
-			      K_SECONDS(g_app_config.interval_report), K_FOREVER);
+		k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report), K_FOREVER);
 		return;
 	}
 	k_mutex_unlock(&m_pending_response_lock);
@@ -948,7 +946,7 @@ int app_lrw_init(void)
 	/* Don't start send timer here - wait for join completion via DR callback */
 
 	atomic_set(&m_state, APP_LRW_STATE_IDLE);
-	m_init_join = true;  /* First join after boot */
+	m_init_join = true; /* First join after boot */
 
 	return 0;
 }
@@ -1052,15 +1050,14 @@ int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len)
 		return -EINVAL;
 	}
 	if (len > sizeof(m_pending_response_buf)) {
-		LOG_ERR("Response too large: %zu B (max %zu)", len,
-			sizeof(m_pending_response_buf));
+		LOG_ERR("Response too large: %zu B (max %zu)", len, sizeof(m_pending_response_buf));
 		return -EMSGSIZE;
 	}
 
 	k_mutex_lock(&m_pending_response_lock, K_FOREVER);
 	if (m_pending_response_len) {
-		LOG_WRN("Overwriting unsent response on port %u (%zu B)",
-			m_pending_response_port, m_pending_response_len);
+		LOG_WRN("Overwriting unsent response on port %u (%zu B)", m_pending_response_port,
+			m_pending_response_len);
 	}
 	memcpy(m_pending_response_buf, buf, len);
 	m_pending_response_len = len;
@@ -1080,9 +1077,8 @@ int app_lrw_reset_nvm(void)
 	 * frame counters (FCntUp/Down), DevNonce and the cached session; a reboot
 	 * then makes the MAC re-init from a clean NVM. */
 	static const char *const keys[] = {
-		"lorawan/nvm/Crypto",       "lorawan/nvm/MacGroup1",
-		"lorawan/nvm/MacGroup2",    "lorawan/nvm/SecureElement",
-		"lorawan/nvm/RegionGroup1", "lorawan/nvm/RegionGroup2",
+		"lorawan/nvm/Crypto",        "lorawan/nvm/MacGroup1",    "lorawan/nvm/MacGroup2",
+		"lorawan/nvm/SecureElement", "lorawan/nvm/RegionGroup1", "lorawan/nvm/RegionGroup2",
 		"lorawan/nvm/ClassB",
 	};
 	int ret = 0;

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -25,23 +25,23 @@ enum app_lrw_state {
 
 struct app_lrw_info {
 	enum app_lrw_state state;
-	uint32_t dev_addr;             /* Device address (from OTAA or ABP) */
-	uint32_t fcnt_up;              /* Uplink frame counter */
+	uint32_t dev_addr; /* Device address (from OTAA or ABP) */
+	uint32_t fcnt_up;  /* Uplink frame counter */
 	int datarate;
 	int16_t rssi;
 	int8_t snr;
 	uint8_t margin;
 	uint8_t gw_count;
 	/* State machine counters */
-	int consecutive_lc_fail;       /* LC failures in a row (HEALTHY) */
-	int consecutive_lc_ok;         /* LC successes in a row (WARNING) */
-	int warning_lc_fail_total;     /* Total LC failures in WARNING */
-	int message_count;             /* Messages sent since boot/rejoin */
+	int consecutive_lc_fail;   /* LC failures in a row (HEALTHY) */
+	int consecutive_lc_ok;     /* LC successes in a row (WARNING) */
+	int warning_lc_fail_total; /* Total LC failures in WARNING */
+	int message_count;         /* Messages sent since boot/rejoin */
 	/* Thresholds for display */
-	int thresh_warning;            /* FAIL_THRESHOLD_WARNING */
-	int thresh_healthy;            /* OK_THRESHOLD_HEALTHY */
-	int thresh_reconnect;          /* FAIL_THRESHOLD_RECONNECT */
-	int link_check_interval;       /* Every N-th message has LC */
+	int thresh_warning;      /* FAIL_THRESHOLD_WARNING */
+	int thresh_healthy;      /* OK_THRESHOLD_HEALTHY */
+	int thresh_reconnect;    /* FAIL_THRESHOLD_RECONNECT */
+	int link_check_interval; /* Every N-th message has LC */
 };
 
 int app_lrw_init(void);

--- a/app/src/app_machine_probe.c
+++ b/app/src/app_machine_probe.c
@@ -223,8 +223,7 @@ static int sht30_read(const struct device *dev, float *temperature, float *humid
 		return ret;
 	}
 
-	if (sht_crc8(&read_buf[0], 2) != read_buf[2] ||
-	    sht_crc8(&read_buf[3], 2) != read_buf[5]) {
+	if (sht_crc8(&read_buf[0], 2) != read_buf[2] || sht_crc8(&read_buf[3], 2) != read_buf[5]) {
 		LOG_ERR("CRC mismatch");
 		return -EIO;
 	}
@@ -288,8 +287,7 @@ static int sht43_read(const struct device *dev, float *temperature, float *humid
 		return ret;
 	}
 
-	if (sht_crc8(&read_buf[0], 2) != read_buf[2] ||
-	    sht_crc8(&read_buf[3], 2) != read_buf[5]) {
+	if (sht_crc8(&read_buf[0], 2) != read_buf[2] || sht_crc8(&read_buf[3], 2) != read_buf[5]) {
 		LOG_ERR("CRC mismatch");
 		return -EIO;
 	}
@@ -880,8 +878,7 @@ int app_machine_probe_read_hygrometer(int index, uint64_t *serial_number, float 
 	COMM_PROLOGUE
 
 	if (!res && m_sensors[index].sht_type == SHT_TYPE_UNKNOWN) {
-		ret = sht_read_serial(m_sensors[index].dev, NULL,
-				      &m_sensors[index].sht_type);
+		ret = sht_read_serial(m_sensors[index].dev, NULL, &m_sensors[index].sht_type);
 		if (ret) {
 			LOG_ERR_CALL_FAILED_INT("sht_read_serial", ret);
 			res = ret;

--- a/app/src/app_sht4x.c
+++ b/app/src/app_sht4x.c
@@ -122,8 +122,7 @@ int app_sht4x_read_serial(uint32_t *serial_number)
 		return ret;
 	}
 
-	if (sht_crc8(&data[0], 2) != data[2] ||
-	    sht_crc8(&data[3], 2) != data[5]) {
+	if (sht_crc8(&data[0], 2) != data[2] || sht_crc8(&data[3], 2) != data[5]) {
 		LOG_ERR("CRC mismatch");
 		return -EIO;
 	}

--- a/app/src/app_version.h
+++ b/app/src/app_version.h
@@ -32,8 +32,8 @@ extern "C" {
 
 /* Source of the build (orthogonal to the debug/release config). */
 enum app_build_type {
-	APP_BUILD_TYPE_MAIN   = 0, /* tagged build from main */
-	APP_BUILD_TYPE_DEV    = 1, /* CI build from a branch / PR */
+	APP_BUILD_TYPE_MAIN = 0,   /* tagged build from main */
+	APP_BUILD_TYPE_DEV = 1,    /* CI build from a branch / PR */
 	APP_BUILD_TYPE_CUSTOM = 2, /* local / modified firmware */
 };
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,8 +13,7 @@ Steps (exits non-zero on the first hard failure):
 1. **Firmware builds** — release + debug (`west build -p always -b sticker .`).
 2. **Decoder tests** — `node --test` in `app/decoder/` (the LoRaWAN codec).
 3. **configen tests** — `pytest scripts/west_commands/tests` (generator + proto round-trip).
-4. **clang-format** — `--dry-run` over `app/src/*.{c,h}`, **advisory** (the repo has
-   pre-existing hand-written sources that aren't format-clean; reported, not failing).
+4. **clang-format** — `--dry-run --Werror` over `app/src/*.{c,h}`; fails on any drift.
 5. **configen in sync** — regenerate from `app_config.yml` and fail if the committed
    `app_config.{c,h,proto,options.in}` would change.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,7 +17,16 @@ Steps (exits non-zero on the first hard failure):
 5. **configen in sync** — regenerate from `app_config.yml` and fail if the committed
    `app_config.{c,h,proto,options.in}` would change.
 
-The CI `test` job (`.github/workflows/build.yml`) runs steps 2–3 (no Zephyr toolchain);
+The CI `test` job (`.github/workflows/build.yml`) runs steps 2–4 (no Zephyr toolchain);
 this script is the fuller local superset that also builds and checks generated-file sync.
 
 Install the Python test deps once: `pip install -r scripts/west_commands/requirements-dev.txt`.
+
+## clang-format pre-commit hook
+
+`tools/hooks/pre-commit` auto-runs `clang-format -i` on staged `app/src/*.{c,h}` before
+each commit (CI then verifies the same with `--dry-run --Werror`). Enable once per clone:
+
+```bash
+git config core.hooksPath tools/hooks
+```

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Auto-apply clang-format to staged app/src C sources before each commit, so the
+# repo stays clang-format-clean (the CI `test` job verifies the same with
+# --dry-run --Werror). Enable once with:
+#
+#   git config core.hooksPath tools/hooks
+#
+# Skips silently if clang-format isn't installed.
+
+set -euo pipefail
+
+command -v clang-format >/dev/null 2>&1 || exit 0
+
+mapfile -t FILES < <(git diff --cached --name-only --diff-filter=ACM -- \
+  'app/src/*.c' 'app/src/*.h')
+[ "${#FILES[@]}" -eq 0 ] && exit 0
+
+clang-format -i "${FILES[@]}"
+git add -- "${FILES[@]}"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -17,13 +17,11 @@ cd "$REPO"
 PASS=0
 FAIL=0
 SKIP=0
-WARN=0
 
 banner() { printf '\n\033[1;36m=== %s ===\033[0m\n' "$1"; }
 ok()     { printf '\033[1;32mPASS\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
 bad()    { printf '\033[1;31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
 skip()   { printf '\033[1;33mSKIP\033[0m %s\n' "$1"; SKIP=$((SKIP + 1)); }
-warn()   { printf '\033[1;33mWARN\033[0m %s\n' "$1"; WARN=$((WARN + 1)); }
 have()   { command -v "$1" >/dev/null 2>&1; }
 
 run() { # run <label> <cmd...>
@@ -56,17 +54,10 @@ else
   bad "configen tests — 'pytest' not found (pip install -r scripts/west_commands/requirements-dev.txt)"
 fi
 
-# 4. C formatting — advisory only. The repo has pre-existing hand-written
-# sources that aren't clang-format-clean; surface drift without failing the run.
+# 4. C formatting — app/src must be clang-format-clean.
 if have clang-format && [ -f "$REPO/.clang-format" ]; then
-  banner "clang-format --dry-run (advisory)"
   mapfile -t CFILES < <(git -C "$REPO" ls-files 'app/src/*.c' 'app/src/*.h')
-  if clang-format --dry-run --Werror "${CFILES[@]}" 2>/tmp/cf.$$; then
-    ok "clang-format"
-  else
-    warn "clang-format: $(grep -c 'clang-format-violations' /tmp/cf.$$) violation(s) in app/src (pre-existing; not failing)"
-  fi
-  rm -f /tmp/cf.$$
+  run "clang-format --dry-run --Werror" clang-format --dry-run --Werror "${CFILES[@]}"
 else
   skip "clang-format (not installed or no .clang-format)"
 fi
@@ -87,5 +78,5 @@ else
 fi
 
 banner "summary"
-printf 'pass=%d fail=%d warn=%d skip=%d\n' "$PASS" "$FAIL" "$WARN" "$SKIP"
+printf 'pass=%d fail=%d skip=%d\n' "$PASS" "$FAIL" "$SKIP"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Cleans the repo so `app/src` is clang-format-clean, and enforces it so it can't drift again.

## What

- **Reformatted** the 14 hand-written `app/src` sources that weren't clang-format-clean (per the project `.clang-format`, clang-format 22.1.5). **Pure formatting — 0 semantic changes**; builds are byte-for-byte equivalent (release RAM 64.98%, debug 89.00%, unchanged).
- Generated `app_config.{c,h}` were already clean (configen formats them) — untouched.

## Enforcement (so it stays clean)

- New CI step **clang-format check (app/src)** in the `test` job — `clang-format --dry-run --Werror` over `app/src/*.{c,h}` (clang-format 22.1.5 from `requirements-dev.txt`).
- `tools/test.sh` step 4 is now a hard `--Werror` check (was advisory, since the repo had ~214 pre-existing violations — now zero).

## Verification

- `clang-format --dry-run --Werror` over all `app/src` C → 0 violations.
- Pristine release + debug builds clean, sizes unchanged.
- `tools/test.sh` (SKIP_BUILD) → `pass=4 fail=0`.