### PR TITLE
Device-driven multi-frame history replay (ReqHistory → N×HistoryFrame) #52

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -240,20 +240,29 @@ var _HIST_SENSORS = [
 var _HIST_TEMP_SENTINEL = 0x7fff;
 var _HIST_HUM_SENTINEL = 0xff;
 
-// HistoryFrame.samples: a sequence of records, each
-//   [delta_s u16 LE][present u16 LE][per present sensor: scaled value]
-// where the value is int16 LE ×100 (temp), uint8 ×2 (humidity) or uint32 LE
-// (counter). delta_s is seconds since the frame's t0_unix.
-function _decodeHistorySamples(bytes, t0) {
+// HistoryFrame carries a shared `present` mask + `interval_s` once; samples is a
+// sequence of fixed-size, values-only records (no per-record time or mask):
+//   [per present sensor: scaled value]   int16 LE ×100 (temp), uint8 ×2 (hum),
+//                                         uint32 LE (counter); sentinel = null.
+// Record j's time is t0_unix + j*interval_s (records are periodic). One
+// ReqHistory yields N such frames (frame_index 0..frame_count-1); the consumer
+// concatenates their records to reconstruct the requested window.
+function _decodeHistorySamples(bytes, t0, present, interval) {
   var out = [];
-  var p = 0;
-  while (p + 4 <= bytes.length) {
-    var delta = bytes[p] | (bytes[p + 1] << 8); p += 2;
-    var present = bytes[p] | (bytes[p + 1] << 8); p += 2;
-    var rec = { time: (t0 + delta) >>> 0 };
-    for (var s = 0; s < _HIST_SENSORS.length; s++) {
-      if (!(present & (1 << s))) continue;
-      var d = _HIST_SENSORS[s];
+  var recSize = 0;
+  for (var s = 0; s < _HIST_SENSORS.length; s++) {
+    if (!(present & (1 << s))) continue;
+    var e = _HIST_SENSORS[s].enc;
+    recSize += (e === "temp") ? 2 : (e === "hum") ? 1 : 4;
+  }
+  if (recSize === 0) return out;
+
+  var p = 0, j = 0;
+  while (p + recSize <= bytes.length) {
+    var rec = { time: (t0 + j * interval) >>> 0 };
+    for (var k = 0; k < _HIST_SENSORS.length; k++) {
+      if (!(present & (1 << k))) continue;
+      var d = _HIST_SENSORS[k];
       if (d.enc === "temp") {
         var raw = bytes[p] | (bytes[p + 1] << 8); p += 2;
         rec[d.name] = raw === _HIST_TEMP_SENTINEL ? null
@@ -267,13 +276,14 @@ function _decodeHistorySamples(bytes, t0) {
       }
     }
     out.push(rec);
+    j++;
   }
   return out;
 }
 
 function _decodeHistoryFrame(bytes, start, end) {
   var hf = { records: [] };
-  var t0 = 0;
+  var t0 = 0, present = 0, interval = 0;
   var samples = null;
   var pos = start;
   while (pos < end) {
@@ -284,6 +294,8 @@ function _decodeHistoryFrame(bytes, start, end) {
       if (f === 1) hf.frame_index = v.value;
       else if (f === 2) hf.frame_count = v.value;
       else if (f === 3) t0 = v.value;
+      else if (f === 5) present = v.value;
+      else if (f === 6) interval = v.value;
     } else if (w === 2) {
       var len = _pbReadVarint(bytes, pos); pos = len.next;
       if (f === 4) samples = bytes.slice(pos, pos + len.value);
@@ -291,7 +303,9 @@ function _decodeHistoryFrame(bytes, start, end) {
     } else { break; }
   }
   hf.t0_unix = t0;
-  if (samples) hf.records = _decodeHistorySamples(samples, t0);
+  hf.present = present;
+  hf.interval_s = interval;
+  if (samples) hf.records = _decodeHistorySamples(samples, t0, present, interval);
   return hf;
 }
 

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -282,7 +282,9 @@ function _decodeHistorySamples(bytes, t0, present, interval) {
 }
 
 function _decodeHistoryFrame(bytes, start, end) {
-  var hf = { records: [] };
+  // frame_index/frame_count default to 0 — proto3 omits a zero frame_index, so
+  // frame 0 of a replay carries no field 1; the consumer still needs index 0.
+  var hf = { frame_index: 0, frame_count: 0, records: [] };
   var t0 = 0, present = 0, interval = 0;
   var samples = null;
   var pos = start;

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -116,8 +116,10 @@ function histRec(tempC, humPct) {
   return [t & 0xff, (t >> 8) & 0xff, Math.round(humPct * 2)]; // int16 LE temp, u8 hum
 }
 function buildHistoryFrame(seq, idx, count, t0, present, interval, samples) {
-  const hf = []
-    .concat(pbTV(1, idx)).concat(pbTV(2, count)).concat(pbTV(3, t0))
+  // proto3 omits a zero field — mirror that for frame_index so the decoder's
+  // default-to-0 is exercised (the firmware sends frame 0 with no field 1).
+  let hf = idx ? pbTV(1, idx) : [];
+  hf = hf.concat(pbTV(2, count)).concat(pbTV(3, t0))
     .concat(pbLD(4, samples)).concat(pbTV(5, present)).concat(pbTV(6, interval));
   return [].concat(pbTV(1, seq)).concat(pbLD(5, hf)); // Response.history_frame = field 5
 }

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -99,6 +99,69 @@ test("decodeUplink routes fPort 2 to the telemetry decoder", () => {
   assert.equal(typeof got.data, "object");
 });
 
+// --- Uplink: history replay frames (fPort 85, device-driven multi-frame) ---
+// HistoryFrame carries a shared present mask + interval_s; samples are fixed-size
+// values-only records, time(j) = t0 + j*interval. Build frames with a tiny pb
+// encoder so the vectors are self-describing.
+function pbVarint(v) {
+  const o = [];
+  while (v > 127) { o.push((v & 0x7f) | 0x80); v = Math.floor(v / 128); }
+  o.push(v);
+  return o;
+}
+function pbTV(tag, varint) { return [(tag << 3) | 0].concat(pbVarint(varint)); }
+function pbLD(tag, payload) { return [(tag << 3) | 2, payload.length].concat(payload); }
+function histRec(tempC, humPct) {
+  const t = Math.round(tempC * 100);
+  return [t & 0xff, (t >> 8) & 0xff, Math.round(humPct * 2)]; // int16 LE temp, u8 hum
+}
+function buildHistoryFrame(seq, idx, count, t0, present, interval, samples) {
+  const hf = []
+    .concat(pbTV(1, idx)).concat(pbTV(2, count)).concat(pbTV(3, t0))
+    .concat(pbLD(4, samples)).concat(pbTV(5, present)).concat(pbTV(6, interval));
+  return [].concat(pbTV(1, seq)).concat(pbLD(5, hf)); // Response.history_frame = field 5
+}
+
+test("decodeUplink decodes + reassembles multi-frame history (fPort 85)", () => {
+  const present = 0x03; // temperature (bit0) + humidity (bit1)
+  const interval = 900;
+  const t0a = 1780000000;
+  const f0 = buildHistoryFrame(10, 0, 2, t0a, present, interval,
+    [].concat(histRec(21.5, 45)).concat(histRec(21.6, 46)));
+  const t0b = t0a + 2 * interval;
+  const f1 = buildHistoryFrame(10, 1, 2, t0b, present, interval, histRec(21.7, 47));
+
+  const d0 = codec.decodeUplink({ bytes: f0, fPort: 85 }).data;
+  const d1 = codec.decodeUplink({ bytes: f1, fPort: 85 }).data;
+
+  assert.equal(d0.seq, 10);
+  assert.equal(d0.history_frame.frame_index, 0);
+  assert.equal(d0.history_frame.frame_count, 2);
+  assert.equal(d0.history_frame.present, present);
+  assert.equal(d0.history_frame.interval_s, interval);
+  assert.equal(d0.history_frame.records.length, 2);
+  assert.equal(d0.history_frame.records[0].temperature, 21.5);
+  assert.equal(d0.history_frame.records[0].humidity, 45);
+  assert.equal(d0.history_frame.records[0].time, t0a);
+  assert.equal(d0.history_frame.records[1].time, t0a + interval); // implicit delta
+  assert.equal(d1.history_frame.frame_index, 1);
+  assert.equal(d1.history_frame.records[0].time, t0b);
+  assert.equal(d1.history_frame.records[0].temperature, 21.7);
+
+  // Consumer concatenates frames 0..count-1 into one window.
+  const all = d0.history_frame.records.concat(d1.history_frame.records);
+  assert.equal(all.length, 3);
+  assert.deepEqual(all.map((r) => r.time), [t0a, t0a + interval, t0b]);
+});
+
+test("history sentinel values decode to null", () => {
+  const present = 0x03;
+  const f = buildHistoryFrame(1, 0, 1, 1780000000, present, 900, [0xff, 0x7f, 0xff]);
+  const rec = codec.decodeUplink({ bytes: f, fPort: 85 }).data.history_frame.records[0];
+  assert.equal(rec.temperature, null); // 0x7fff sentinel
+  assert.equal(rec.humidity, null);    // 0xff sentinel
+});
+
 // --- Negative: a corrupted frame must change the result (tests are sensitive) ---
 test("a tampered command byte does not silently decode to the original", () => {
   const good = codec.decodeDownlink({ bytes: hex("08032200"), fPort: 85 }).data;

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -266,8 +266,7 @@ static void handle_reset_counters(const Command_ResetCounters *rc, Response *res
 	resp->which_body = Response_ack_tag;
 }
 
-static void handle_req_history(enum app_cmd_transport transport, const Command *cmd,
-			       Response *resp)
+static void handle_req_history(enum app_cmd_transport transport, const Command *cmd, Response *resp)
 {
 #if defined(APP_CMD_HAVE_HISTORY) && defined(CONFIG_LORAWAN)
 	if (transport != APP_CMD_TRANSPORT_LRW) {

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -233,11 +233,14 @@ static void handle_req_history(enum app_cmd_transport transport, const Command *
 	uint32_t from = rq->has_from_unix ? rq->from_unix : 0;
 	uint32_t to = rq->has_to_unix ? rq->to_unix : UINT32_MAX;
 
-	/* Device-driven replay: one request, the device streams all matching
-	 * records back as N HistoryFrame uplinks on port 85. This command just
-	 * acknowledges; the frames follow asynchronously. */
-	app_lrw_start_history_replay(from, to, cmd->seq);
-	resp->which_body = Response_ack_tag;
+	/* Device-driven replay: the device streams all matching records back as N
+	 * HistoryFrame uplinks on port 85. The first frame is the reply, so leave
+	 * the response body unset (which_body stays 0) to suppress a redundant Ack
+	 * uplink. Only when nothing replays (empty window / DR too low) do we send
+	 * an Error so the host still gets a definitive answer. */
+	if (!app_lrw_start_history_replay(from, to, cmd->seq)) {
+		make_error(resp, Response_Error_Code_HISTORY_UNAVAILABLE, "no records");
+	}
 #else
 	ARG_UNUSED(transport);
 	ARG_UNUSED(cmd);
@@ -335,6 +338,17 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 			   PB_GET_ERROR(&istream));
 	} else {
 		dispatch(transport, &cmd, &resp, &act);
+	}
+
+	/* A handler may opt out of an immediate response by leaving the oneof unset
+	 * (which_body == 0) — e.g. ReqHistory, whose HistoryFrame stream is the
+	 * reply. Emit nothing so no redundant uplink is queued. */
+	if (resp.which_body == 0) {
+		*out_len = 0;
+		if (action) {
+			*action = act;
+		}
+		return 0;
 	}
 
 	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -219,27 +219,28 @@ static void handle_reset_counters(const Command_ResetCounters *rc, Response *res
 	resp->which_body = Response_ack_tag;
 }
 
-static void handle_req_history(const Command_ReqHistory *rq, Response *resp)
+static void handle_req_history(enum app_cmd_transport transport, const Command *cmd,
+			       Response *resp)
 {
-#ifdef APP_CMD_HAVE_HISTORY
+#if defined(APP_CMD_HAVE_HISTORY) && defined(CONFIG_LORAWAN)
+	if (transport != APP_CMD_TRANSPORT_LRW) {
+		/* Replay is inherently a stream of LoRaWAN uplinks. */
+		make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
+		return;
+	}
+
+	const Command_ReqHistory *rq = &cmd->body.req_history;
 	uint32_t from = rq->has_from_unix ? rq->from_unix : 0;
 	uint32_t to = rq->has_to_unix ? rq->to_unix : UINT32_MAX;
-	uint32_t t0 = 0;
-	uint16_t n_written = 0;
-	uint16_t total = 0;
 
-	Response_HistoryFrame *hf = &resp->body.history_frame;
-	size_t len = app_history_export(from, to, hf->samples.bytes, sizeof(hf->samples.bytes),
-					&t0, &n_written, &total);
-
-	resp->which_body = Response_history_frame_tag;
-	hf->frame_index = 0;          /* this page starts at `from` */
-	hf->frame_count = total;      /* total records in the window; host pages by
-				       * narrowing from_unix to last returned time + 1 */
-	hf->t0_unix = t0;
-	hf->samples.size = len;
+	/* Device-driven replay: one request, the device streams all matching
+	 * records back as N HistoryFrame uplinks on port 85. This command just
+	 * acknowledges; the frames follow asynchronously. */
+	app_lrw_start_history_replay(from, to, cmd->seq);
+	resp->which_body = Response_ack_tag;
 #else
-	ARG_UNUSED(rq);
+	ARG_UNUSED(transport);
+	ARG_UNUSED(cmd);
 	make_error(resp, Response_Error_Code_HISTORY_UNAVAILABLE, "no history");
 #endif
 }
@@ -303,7 +304,7 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd,
 		break;
 
 	case Command_req_history_tag:
-		handle_req_history(&cmd->body.req_history, resp);
+		handle_req_history(transport, cmd, resp);
 		break;
 
 	default:
@@ -369,3 +370,40 @@ int app_cmd_build_info(uint8_t *out, size_t out_cap, size_t *out_len)
 	*out_len = ostream.bytes_written;
 	return 0;
 }
+
+#if defined(APP_CMD_HAVE_HISTORY)
+int app_cmd_build_history_frame(uint32_t seq, uint32_t frame_index, uint32_t frame_count,
+				uint32_t t0_unix, uint32_t present, uint32_t interval_s,
+				const uint8_t *samples, size_t samples_len, uint8_t *out,
+				size_t out_cap, size_t *out_len)
+{
+	Response resp = Response_init_zero;
+
+	if (!out || !out_len || (samples_len > 0 && !samples)) {
+		return -EINVAL;
+	}
+	if (samples_len > sizeof(resp.body.history_frame.samples.bytes)) {
+		return -EMSGSIZE;
+	}
+
+	resp.seq = seq;
+	resp.which_body = Response_history_frame_tag;
+	Response_HistoryFrame *hf = &resp.body.history_frame;
+	hf->frame_index = frame_index;
+	hf->frame_count = frame_count;
+	hf->t0_unix = t0_unix;
+	hf->present = present;
+	hf->interval_s = interval_s;
+	memcpy(hf->samples.bytes, samples, samples_len);
+	hf->samples.size = samples_len;
+
+	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
+	if (!pb_encode(&ostream, Response_fields, &resp)) {
+		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
+		return -EMSGSIZE;
+	}
+
+	*out_len = ostream.bytes_written;
+	return 0;
+}
+#endif /* APP_CMD_HAVE_HISTORY */

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -56,6 +56,16 @@ int app_cmd_handle(enum app_cmd_transport transport,
  * NULL argument, or -EMSGSIZE if `out_cap` is too small. */
 int app_cmd_build_info(uint8_t *out, size_t out_cap, size_t *out_len);
 
+/* Build one history-replay frame (Response{ seq, history_frame={...} }) into
+ * `out`. `samples` holds values-only records (the shared `present` mask +
+ * `interval_s` describe their layout/timing). Used by the app_lrw replay state
+ * machine to stream a ReqHistory window as N frames. Returns 0 with *out_len
+ * set, -EINVAL on a NULL/oversized argument, or -EMSGSIZE if it won't encode. */
+int app_cmd_build_history_frame(uint32_t seq, uint32_t frame_index, uint32_t frame_count,
+				uint32_t t0_unix, uint32_t present, uint32_t interval_s,
+				const uint8_t *samples, size_t samples_len, uint8_t *out,
+				size_t out_cap, size_t *out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -183,7 +183,9 @@ message Response {
         uint32 frame_index = 1;
         uint32 frame_count = 2;
         uint32 t0_unix     = 3;
-        bytes  samples     = 4;
+        bytes  samples     = 4;   // records, values only (no per-record time/mask)
+        uint32 present     = 5;   // sensor mask shared by every record in the frame
+        uint32 interval_s  = 6;   // seconds between records; time(j) = t0_unix + j*interval_s
     }
 
     message Error {

--- a/app/src/app_history.c
+++ b/app/src/app_history.c
@@ -90,7 +90,7 @@ static const struct hist_desc m_desc[APP_HISTORY_SENSOR_COUNT] = {
 
 #define TEMP_SENTINEL 0x7FFF
 #define HUM_SENTINEL  0xFF
-#define MAX_RECORD_SIZE (2 + 13 * 4) /* delta + worst case all channels */
+#define MAX_RECORD_SIZE (13 * 4) /* worst case all channels, values only */
 
 /* ---- Module state ------------------------------------------------------- */
 
@@ -102,8 +102,9 @@ static uint16_t m_capacity;
 static uint16_t m_start;      /* index of oldest record */
 static uint16_t m_count;
 static uint32_t m_base_time;  /* oldest record's time: uptime-s unsynced, unix synced */
-static uint32_t m_last_time;  /* newest record's time source */
 static bool m_base_synced;
+static uint32_t m_interval;   /* interval_report (s) the buffer was recorded at; records
+			       * are periodic so per-record time = base + ord*interval */
 
 static bool cap_on(size_t cap_off)
 {
@@ -143,11 +144,11 @@ struct hist_meta {
 	uint16_t start;
 	uint16_t count;
 	uint32_t base_time;
-	uint32_t last_time;
+	uint32_t interval;
 	uint8_t base_synced;
 };
 
-#define META_MAGIC 0x48495331 /* "HIS1" */
+#define META_MAGIC 0x48495332 /* "HIS2" — bumped: record layout dropped per-record delta */
 
 static int backend_init(void)
 {
@@ -185,7 +186,7 @@ static void backend_save_meta(void)
 		.start = m_start,
 		.count = m_count,
 		.base_time = m_base_time,
-		.last_time = m_last_time,
+		.interval = m_interval,
 		.base_synced = m_base_synced,
 	};
 	(void)nvs_write(&m_fs, NVS_ID_META, &meta, sizeof(meta));
@@ -208,7 +209,7 @@ static bool backend_load_meta(void)
 	m_start = meta.start;
 	m_count = meta.count;
 	m_base_time = meta.base_time;
-	m_last_time = meta.last_time;
+	m_interval = meta.interval;
 	m_base_synced = meta.base_synced;
 	return true;
 }
@@ -301,7 +302,7 @@ static void recompute_sizing(void)
 	uint16_t avail = app_history_available_mask();
 	m_mask &= avail; /* drop sensors whose capability went away */
 
-	uint16_t size = 2; /* delta_s */
+	uint16_t size = 0; /* values only; per-record time is implicit (base + ord*interval) */
 	for (int i = 0; i < APP_HISTORY_SENSOR_COUNT; i++) {
 		if (m_mask & BIT(i)) {
 			size += m_desc[i].size;
@@ -345,7 +346,7 @@ static size_t encode_value(uint8_t *p, int i)
 static void decode_record(const uint8_t *rec, struct app_history_record *out)
 {
 	out->present = 0;
-	const uint8_t *p = rec + 2; /* skip delta */
+	const uint8_t *p = rec; /* values only — no per-record delta prefix */
 	for (int i = 0; i < APP_HISTORY_SENSOR_COUNT; i++) {
 		if (!(m_mask & BIT(i))) {
 			out->value[i] = 0;
@@ -382,32 +383,33 @@ static void decode_record(const uint8_t *rec, struct app_history_record *out)
 	}
 }
 
-static uint16_t slot_delta(uint16_t slot)
-{
-	uint8_t rec[MAX_RECORD_SIZE];
-	if (backend_read_slot(slot, rec, m_sample_size) != 0) {
-		return 0;
-	}
-	return sys_get_le16(rec);
-}
-
 /* ---- Public API --------------------------------------------------------- */
 
 void app_history_capture(void)
 {
-	if (!m_enabled || m_sample_size <= 2 || m_capacity == 0) {
+	if (!m_enabled || m_sample_size == 0 || m_capacity == 0) {
 		return;
 	}
 
 	uint8_t rec[MAX_RECORD_SIZE];
-	bool synced;
-	uint32_t now;
 
 	k_mutex_lock(&m_lock, K_FOREVER);
 
-	/* Snapshot sensor values + timestamp atomically w.r.t. the sensor data. */
+	/* Records are periodic at interval_report, so per-record time is implicit
+	 * (base + ord*interval). If the interval changed, that timebase no longer
+	 * holds — drop the history and restart at the new rate. */
+	if (m_interval != (uint32_t)g_app_config.interval_report) {
+		backend_erase();
+		m_start = 0;
+		m_count = 0;
+		m_base_time = 0;
+		m_base_synced = false;
+		m_interval = (uint32_t)g_app_config.interval_report;
+	}
+
+	/* Snapshot sensor values atomically w.r.t. the sensor data. */
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
-	size_t pos = 2;
+	size_t pos = 0;
 	for (int i = 0; i < APP_HISTORY_SENSOR_COUNT; i++) {
 		if (m_mask & BIT(i)) {
 			pos += encode_value(&rec[pos], i);
@@ -415,32 +417,20 @@ void app_history_capture(void)
 	}
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
-	now = now_seconds(&synced);
-
-	uint16_t delta;
-	if (m_count == 0) {
-		m_base_time = now;
-		m_last_time = now;
-		m_base_synced = synced;
-		delta = 0;
-	} else {
-		uint32_t d = now - m_last_time;
-		delta = (d > 0xFFFF) ? 0xFFFF : (uint16_t)d;
-		m_last_time = now;
-	}
-	sys_put_le16(delta, rec);
-
 	uint16_t slot;
 	if (m_count < m_capacity) {
+		if (m_count == 0) {
+			bool synced;
+			m_base_time = now_seconds(&synced);
+			m_base_synced = synced;
+		}
 		slot = (m_start + m_count) % m_capacity;
 		m_count++;
 	} else {
-		/* Full: evict oldest, advance base past it. */
-		m_base_time += slot_delta(m_start);
+		/* Full: evict oldest; the oldest ordinal moves forward one interval. */
+		m_base_time += m_interval;
 		slot = m_start;
 		m_start = (m_start + 1) % m_capacity;
-		/* The new record's delta was measured from the previous newest,
-		 * which stays correct; the evicted slot is reused for it. */
 	}
 
 	(void)backend_write_slot(slot, rec, m_sample_size);
@@ -455,7 +445,6 @@ void app_history_on_clock_sync(uint32_t unix_now)
 	if (!m_base_synced && m_count > 0) {
 		uint32_t off = unix_now - (uint32_t)(k_uptime_get() / 1000);
 		m_base_time += off;
-		m_last_time += off;
 		m_base_synced = true;
 		backend_save_meta();
 	} else if (m_count == 0) {
@@ -481,7 +470,6 @@ void app_history_clear(void)
 	m_start = 0;
 	m_count = 0;
 	m_base_time = 0;
-	m_last_time = 0;
 	m_base_synced = false;
 	backend_save_meta();
 	k_mutex_unlock(&m_lock);
@@ -495,89 +483,60 @@ int app_history_get(size_t idx, struct app_history_record *out)
 		return -ENOENT;
 	}
 
-	/* Accumulate delta from base up to idx (records are oldest-first). */
-	uint32_t t = m_base_time;
+	/* Records are periodic: time = base + ord*interval (no per-record delta). */
 	uint8_t rec[MAX_RECORD_SIZE];
-	for (size_t k = 0; k <= idx; k++) {
-		uint16_t slot = (m_start + k) % m_capacity;
-		(void)backend_read_slot(slot, rec, m_sample_size);
-		if (k > 0) {
-			t += sys_get_le16(rec);
-		}
-	}
+	uint16_t slot = (m_start + idx) % m_capacity;
+	(void)backend_read_slot(slot, rec, m_sample_size);
 	decode_record(rec, out);
-	out->time_unix = t;
+	out->time_unix = m_base_time + (uint32_t)idx * m_interval;
 	out->time_synced = m_base_synced;
 
 	k_mutex_unlock(&m_lock);
 	return 0;
 }
 
-size_t app_history_export(uint32_t from_unix, uint32_t to_unix, uint8_t *buf, size_t cap,
-			  uint32_t *t0_out, uint16_t *n_written, uint16_t *total)
+uint32_t app_history_get_interval(void)
 {
-	size_t cnt = app_history_count();
+	return m_interval;
+}
+
+/* Records have a fixed size (m_sample_size, values only) and a shared present
+ * mask (m_mask) — so a wire frame carries the mask + interval once and each
+ * record is just the raw stored bytes (sentinels mark absent values). Time is
+ * implicit: ordinal `ord` is at base + ord*interval; records are time-ordered,
+ * so the window filter can break once past `to_unix`. */
+size_t app_history_export_page(uint32_t from_unix, uint32_t to_unix, size_t start_ord,
+			       uint8_t *buf, size_t cap, uint32_t *t0_out, uint16_t *n_written,
+			       size_t *next_ord)
+{
+	k_mutex_lock(&m_lock, K_FOREVER);
+
 	size_t pos = 0;
 	uint16_t written = 0;
-	uint16_t matched = 0;
 	uint32_t t0 = 0;
 	bool have_t0 = false;
-	bool full = false;
+	size_t ord = start_ord;
 
-	for (size_t ord = 0; ord < cnt; ord++) {
-		struct app_history_record rec;
-		if (app_history_get(ord, &rec) != 0) {
-			break;
-		}
-		/* The window filter only makes sense once we have absolute time. */
-		if (rec.time_synced && (rec.time_unix < from_unix || rec.time_unix > to_unix)) {
-			continue;
-		}
-		matched++;
-		if (full) {
-			continue; /* keep counting the window total, stop packing */
-		}
-
-		uint8_t tmp[MAX_RECORD_SIZE];
-		size_t rl = 0;
-		uint32_t delta = have_t0 ? (rec.time_unix - t0) : 0;
-		if (delta > 0xFFFF) {
-			delta = 0xFFFF;
-		}
-		sys_put_le16((uint16_t)delta, &tmp[rl]);
-		rl += 2;
-		sys_put_le16(rec.present, &tmp[rl]);
-		rl += 2;
-		for (int s = 0; s < APP_HISTORY_SENSOR_COUNT; s++) {
-			if (!(rec.present & BIT(s))) {
-				continue;
+	for (; ord < m_count; ord++) {
+		uint32_t t = m_base_time + (uint32_t)ord * m_interval;
+		if (m_base_synced) {
+			if (t > to_unix) {
+				break; /* monotonic time: no later record qualifies */
 			}
-			double v = rec.value[s];
-			switch (m_desc[s].enc) {
-			case ENC_TEMP:
-				sys_put_le16((uint16_t)(int16_t)llround(v * 100.0), &tmp[rl]);
-				rl += 2;
-				break;
-			case ENC_HUM:
-				tmp[rl++] = (uint8_t)llround(v * 2.0);
-				break;
-			case ENC_COUNT:
-				sys_put_le32((uint32_t)v, &tmp[rl]);
-				rl += 4;
-				break;
+			if (t < from_unix) {
+				continue; /* not yet in window */
 			}
 		}
-
-		if (pos + rl > cap) {
-			full = true; /* this record (and the rest) spill to a later page */
-			continue;
+		if (pos + m_sample_size > cap) {
+			break; /* this record spills to the next page */
 		}
+		uint16_t slot = (m_start + ord) % m_capacity;
+		(void)backend_read_slot(slot, buf + pos, m_sample_size);
 		if (!have_t0) {
-			t0 = rec.time_unix;
+			t0 = t;
 			have_t0 = true;
 		}
-		memcpy(buf + pos, tmp, rl);
-		pos += rl;
+		pos += m_sample_size;
 		written++;
 	}
 
@@ -587,10 +546,40 @@ size_t app_history_export(uint32_t from_unix, uint32_t to_unix, uint8_t *buf, si
 	if (n_written) {
 		*n_written = written;
 	}
-	if (total) {
-		*total = matched;
+	if (next_ord) {
+		*next_ord = ord;
 	}
+
+	k_mutex_unlock(&m_lock);
 	return pos;
+}
+
+/* Number of frames the [from,to] window needs at `cap` bytes/frame. Mirrors the
+ * packing in export_page (fixed record size → whole records per frame). */
+uint16_t app_history_count_frames(uint32_t from_unix, uint32_t to_unix, size_t cap)
+{
+	if (m_sample_size == 0 || cap < m_sample_size) {
+		return 0;
+	}
+	size_t per_frame = cap / m_sample_size;
+
+	k_mutex_lock(&m_lock, K_FOREVER);
+	size_t matched = 0;
+	for (size_t ord = 0; ord < m_count; ord++) {
+		uint32_t t = m_base_time + (uint32_t)ord * m_interval;
+		if (m_base_synced) {
+			if (t > to_unix) {
+				break;
+			}
+			if (t < from_unix) {
+				continue;
+			}
+		}
+		matched++;
+	}
+	k_mutex_unlock(&m_lock);
+
+	return (uint16_t)((matched + per_frame - 1) / per_frame);
 }
 
 bool app_history_is_enabled(void)
@@ -617,7 +606,6 @@ void app_history_set_mask(uint16_t mask)
 	m_start = 0;
 	m_count = 0;
 	m_base_time = 0;
-	m_last_time = 0;
 	m_base_synced = false;
 	recompute_sizing();
 	backend_save_meta();
@@ -670,13 +658,14 @@ int app_history_init(void)
 
 	recompute_sizing();
 
-	/* Restore prior buffer state if the layout matches; else start clean. */
+	/* Restore prior buffer state if the layout matches; else start clean.
+	 * m_interval = 0 forces the first capture to seed it from interval_report. */
 	if (!backend_load_meta()) {
 		m_start = 0;
 		m_count = 0;
 		m_base_time = 0;
-		m_last_time = 0;
 		m_base_synced = false;
+		m_interval = 0;
 	}
 
 	LOG_INF("history: enabled=%d, %u sensors, sample=%uB, capacity=%u, stored=%u",

--- a/app/src/app_history.c
+++ b/app/src/app_history.c
@@ -88,8 +88,8 @@ static const struct hist_desc m_desc[APP_HISTORY_SENSOR_COUNT] = {
 				4, offsetof(struct app_config, cap_pir_detector)},
 };
 
-#define TEMP_SENTINEL 0x7FFF
-#define HUM_SENTINEL  0xFF
+#define TEMP_SENTINEL   0x7FFF
+#define HUM_SENTINEL    0xFF
 #define MAX_RECORD_SIZE (13 * 4) /* worst case all channels, values only */
 
 /* ---- Module state ------------------------------------------------------- */
@@ -101,10 +101,10 @@ static uint16_t m_sample_size;
 static uint16_t m_capacity;
 static uint16_t m_start; /* index of oldest record */
 static uint16_t m_count;
-static uint32_t m_base_time;  /* oldest record's time: uptime-s unsynced, unix synced */
+static uint32_t m_base_time; /* oldest record's time: uptime-s unsynced, unix synced */
 static bool m_base_synced;
-static uint32_t m_interval;   /* interval_report (s) the buffer was recorded at; records
-			       * are periodic so per-record time = base + ord*interval */
+static uint32_t m_interval; /* interval_report (s) the buffer was recorded at; records
+			     * are periodic so per-record time = base + ord*interval */
 
 static bool cap_on(size_t cap_off)
 {
@@ -505,9 +505,8 @@ uint32_t app_history_get_interval(void)
  * record is just the raw stored bytes (sentinels mark absent values). Time is
  * implicit: ordinal `ord` is at base + ord*interval; records are time-ordered,
  * so the window filter can break once past `to_unix`. */
-size_t app_history_export_page(uint32_t from_unix, uint32_t to_unix, size_t start_ord,
-			       uint8_t *buf, size_t cap, uint32_t *t0_out, uint16_t *n_written,
-			       size_t *next_ord)
+size_t app_history_export_page(uint32_t from_unix, uint32_t to_unix, size_t start_ord, uint8_t *buf,
+			       size_t cap, uint32_t *t0_out, uint16_t *n_written, size_t *next_ord)
 {
 	k_mutex_lock(&m_lock, K_FOREVER);
 

--- a/app/src/app_history.h
+++ b/app/src/app_history.h
@@ -95,9 +95,8 @@ uint32_t app_history_get_interval(void);
  * bytes written; *t0_out = first packed record's absolute time, *n_written =
  * records packed, *next_ord = next ordinal to pass for the following page
  * (== app_history_count() when the scan is exhausted). */
-size_t app_history_export_page(uint32_t from_unix, uint32_t to_unix, size_t start_ord,
-			       uint8_t *buf, size_t cap, uint32_t *t0_out, uint16_t *n_written,
-			       size_t *next_ord);
+size_t app_history_export_page(uint32_t from_unix, uint32_t to_unix, size_t start_ord, uint8_t *buf,
+			       size_t cap, uint32_t *t0_out, uint16_t *n_written, size_t *next_ord);
 
 /* Number of frames the [from_unix, to_unix] window needs at `cap` bytes/frame
  * (whole records per frame). Mirrors export_page's packing so the replay can

--- a/app/src/app_history.h
+++ b/app/src/app_history.h
@@ -82,17 +82,27 @@ void app_history_set_enabled(bool enable);
 uint16_t app_history_get_mask(void);
 void app_history_set_mask(uint16_t mask);
 
-/* Serialize stored records in the window [from_unix, to_unix] into `buf` for a
- * LoRaWAN replay (ReqHistory -> HistoryFrame). Records are written oldest-first,
- * as many as fit in `cap`, each: delta_s (uint16 LE, from *t0_out) + present
- * (uint16 LE) + per present sensor a scaled value (int16 LE x100 temp / uint8 x2
- * humidity / uint32 LE counter), in enum order. When the buffer has no absolute
- * time yet (RTC not synced) the window filter is ignored. Returns bytes written;
- * *t0_out = first record's timestamp, *n_written = records packed, *total = total
- * records matching the window (so the host knows how many pages remain).
- * For the next page the host narrows from_unix to the last returned time + 1. */
-size_t app_history_export(uint32_t from_unix, uint32_t to_unix, uint8_t *buf, size_t cap,
-			  uint32_t *t0_out, uint16_t *n_written, uint16_t *total);
+/* interval_report (s) the buffer is currently recorded at; records are periodic
+ * so a wire frame carries this once and per-record time = t0 + ord*interval. */
+uint32_t app_history_get_interval(void);
+
+/* Pack one page of stored records into `buf` for a LoRaWAN replay (ReqHistory ->
+ * HistoryFrame), starting at ordinal `start_ord` (0 = oldest), oldest-first, as
+ * many whole records as fit in `cap`. Each record is the raw stored bytes (values
+ * only, fixed size = the sample size, sentinels mark absent values); the shared
+ * present mask + interval travel in the frame header, not per record. Records in
+ * [from_unix, to_unix] only (filter skipped until the clock is synced). Returns
+ * bytes written; *t0_out = first packed record's absolute time, *n_written =
+ * records packed, *next_ord = next ordinal to pass for the following page
+ * (== app_history_count() when the scan is exhausted). */
+size_t app_history_export_page(uint32_t from_unix, uint32_t to_unix, size_t start_ord,
+			       uint8_t *buf, size_t cap, uint32_t *t0_out, uint16_t *n_written,
+			       size_t *next_ord);
+
+/* Number of frames the [from_unix, to_unix] window needs at `cap` bytes/frame
+ * (whole records per frame). Mirrors export_page's packing so the replay can
+ * announce frame_count up front. */
+uint16_t app_history_count_frames(uint32_t from_unix, uint32_t to_unix, size_t cap);
 
 /* Descriptor helpers for the shell. */
 const char *app_history_sensor_name(enum app_history_sensor s);

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -81,20 +81,21 @@ static void tx_telemetry_frame(bool first_frame);
 /* History replay (#52): one ReqHistory streams all matching records back as N
  * HistoryFrame uplinks on the command port, ASAP. Independent state machine,
  * modeled on the telemetry frame machine above. */
-#define HISTORY_SAMPLES_MAX    48 /* nanopb Response.HistoryFrame.samples bound */
-#define HISTORY_FRAME_OVERHEAD 22 /* seq + history_frame wrapper + frame_index/count
-				   * + t0_unix(5B varint) + present + interval_s
-				   * + samples tag/len; conservative upper bound */
+#define HISTORY_SAMPLES_MAX 48 /* nanopb Response.HistoryFrame.samples bound */
+#define HISTORY_FRAME_OVERHEAD                                                                     \
+	22 /* seq + history_frame wrapper + frame_index/count                                      \
+	    * + t0_unix(5B varint) + present + interval_s                                          \
+	    * + samples tag/len; conservative upper bound */
 
 static struct k_work_delayable m_hist_work;
-static bool     m_hist_active;
+static bool m_hist_active;
 static uint32_t m_hist_from, m_hist_to, m_hist_seq;
 static uint32_t m_hist_count;    /* total frames (N) */
 static uint32_t m_hist_idx;      /* next frame_index to send */
-static size_t   m_hist_cursor;   /* next record ordinal */
+static size_t m_hist_cursor;     /* next record ordinal */
 static uint16_t m_hist_present;  /* shared sensor mask, snapshot at replay start */
 static uint32_t m_hist_interval; /* seconds between records, snapshot at start */
-static uint8_t  m_hist_tx_buf[64];
+static uint8_t m_hist_tx_buf[64];
 
 static void m_hist_work_handler(struct k_work *work);
 

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -78,6 +78,26 @@ static bool    m_frame_resend;  /* last send failed; resend m_frame_buf as-is */
 
 static void tx_telemetry_frame(bool first_frame);
 
+/* History replay (#52): one ReqHistory streams all matching records back as N
+ * HistoryFrame uplinks on the command port, ASAP. Independent state machine,
+ * modeled on the telemetry frame machine above. */
+#define HISTORY_SAMPLES_MAX    48 /* nanopb Response.HistoryFrame.samples bound */
+#define HISTORY_FRAME_OVERHEAD 22 /* seq + history_frame wrapper + frame_index/count
+				   * + t0_unix(5B varint) + present + interval_s
+				   * + samples tag/len; conservative upper bound */
+
+static struct k_work_delayable m_hist_work;
+static bool     m_hist_active;
+static uint32_t m_hist_from, m_hist_to, m_hist_seq;
+static uint32_t m_hist_count;    /* total frames (N) */
+static uint32_t m_hist_idx;      /* next frame_index to send */
+static size_t   m_hist_cursor;   /* next record ordinal */
+static uint16_t m_hist_present;  /* shared sensor mask, snapshot at replay start */
+static uint32_t m_hist_interval; /* seconds between records, snapshot at start */
+static uint8_t  m_hist_tx_buf[64];
+
+static void m_hist_work_handler(struct k_work *work);
+
 static atomic_t m_state = ATOMIC_INIT(APP_LRW_STATE_IDLE);
 static struct k_timer m_link_check_timer;
 static struct k_work m_link_check_work;
@@ -528,6 +548,7 @@ static void join_work_handler(struct k_work *work)
 	/* Stop send timer to prevent TX during join */
 	k_timer_stop(&m_send_timer);
 	atomic_set(&m_state, APP_LRW_STATE_JOINING);
+	m_hist_active = false; /* drop any in-flight history replay across (re)join */
 
 	if (m_init_join) {
 		LOG_INF("Initial join after boot");
@@ -810,6 +831,120 @@ static void frame_work_handler(struct k_work *work)
 	tx_telemetry_frame(false);
 }
 
+/* Bytes of `samples` that fit one HistoryFrame at the current DR (0 if the DR
+ * is too small even for the frame overhead). Bounded by the nanopb field size. */
+static size_t history_frame_cap(void)
+{
+	uint8_t budget = app_lrw_get_max_payload();
+
+	if (budget <= HISTORY_FRAME_OVERHEAD) {
+		return 0;
+	}
+	return MIN((size_t)(budget - HISTORY_FRAME_OVERHEAD), (size_t)HISTORY_SAMPLES_MAX);
+}
+
+static void history_replay_finish(void)
+{
+	m_hist_active = false;
+	/* Restore the periodic telemetry cadence the replay paused. */
+	k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report), K_FOREVER);
+}
+
+static void m_hist_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	if (!m_hist_active) {
+		return;
+	}
+
+	enum app_lrw_state state = (enum app_lrw_state)atomic_get(&m_state);
+	if (state == APP_LRW_STATE_JOINING || state == APP_LRW_STATE_RECONNECT) {
+		LOG_WRN("History replay aborted: state=%d", (int)state);
+		m_hist_active = false;
+		return; /* join path restarts the timer */
+	}
+
+	size_t cap = history_frame_cap();
+	uint8_t samples[HISTORY_SAMPLES_MAX];
+	uint32_t t0 = 0;
+	uint16_t n = 0;
+	size_t next = m_hist_cursor;
+	size_t slen = 0;
+
+	if (cap > 0) {
+		slen = app_history_export_page(m_hist_from, m_hist_to, m_hist_cursor, samples, cap,
+					       &t0, &n, &next);
+	}
+	if (n == 0) {
+		/* DR too low for even one record, or nothing left to send. */
+		LOG_WRN("History replay stop at frame %u/%u (cap=%uB)", (unsigned)m_hist_idx,
+			(unsigned)m_hist_count, (unsigned)cap);
+		history_replay_finish();
+		return;
+	}
+
+	size_t len;
+	int ret = app_cmd_build_history_frame(m_hist_seq, m_hist_idx, m_hist_count, t0,
+					      m_hist_present, m_hist_interval, samples, slen,
+					      m_hist_tx_buf, sizeof(m_hist_tx_buf), &len);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("app_cmd_build_history_frame", ret);
+		history_replay_finish();
+		return;
+	}
+
+	ret = lorawan_send(APP_LRW_DOWNLINK_CMD_PORT, m_hist_tx_buf, len, LORAWAN_MSG_UNCONFIRMED);
+	if (ret) {
+		/* Duty-cycle / MAC busy — retry the same frame, don't advance. */
+		LOG_ERR_CALL_FAILED_INT("lorawan_send(history)", ret);
+		k_work_schedule_for_queue(&m_work_q, &m_hist_work, K_SECONDS(FRAME_RETRY_SEC));
+		return;
+	}
+
+	LOG_INF("History frame %u/%u sent (%u rec, %zu B)", (unsigned)(m_hist_idx + 1),
+		(unsigned)m_hist_count, (unsigned)n, len);
+	m_hist_cursor = next;
+	m_hist_idx++;
+
+	if (m_hist_idx < m_hist_count && m_hist_cursor < app_history_count()) {
+		k_work_schedule_for_queue(&m_work_q, &m_hist_work, K_SECONDS(FRAME_GAP_SEC));
+	} else {
+		LOG_INF("History replay complete: %u frames", (unsigned)m_hist_idx);
+		history_replay_finish();
+	}
+}
+
+void app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t seq)
+{
+	if (!app_lrw_is_ready()) {
+		LOG_WRN("History replay requested but LRW not ready; ignoring");
+		return;
+	}
+
+	size_t cap = history_frame_cap();
+	uint32_t n = (cap > 0) ? app_history_count_frames(from_unix, to_unix, cap) : 0;
+	if (n == 0) {
+		LOG_INF("History replay: no records in window (or DR too low)");
+		return;
+	}
+
+	m_hist_from = from_unix;
+	m_hist_to = to_unix;
+	m_hist_seq = seq;
+	m_hist_count = n;
+	m_hist_idx = 0;
+	m_hist_cursor = 0;
+	m_hist_present = app_history_get_mask();
+	m_hist_interval = app_history_get_interval();
+	m_hist_active = true;
+
+	/* Pause periodic telemetry; the replay drives the work queue ASAP. */
+	k_timer_stop(&m_send_timer);
+	LOG_INF("History replay start: %u frames (window %u..%u)", (unsigned)n, from_unix, to_unix);
+	k_work_schedule_for_queue(&m_work_q, &m_hist_work, K_NO_WAIT);
+}
+
 static void send_timer_handler(struct k_timer *timer)
 {
 	k_work_submit_to_queue(&m_work_q, &m_send_work);
@@ -935,6 +1070,7 @@ int app_lrw_init(void)
 	k_work_init(&m_join_work, join_work_handler);
 	k_work_init(&m_send_work, send_work_handler);
 	k_work_init_delayable(&m_frame_work, frame_work_handler);
+	k_work_init_delayable(&m_hist_work, m_hist_work_handler);
 	k_work_init(&m_link_check_work, link_check_work_handler);
 	k_work_init(&m_downlink_success_work, downlink_success_work_handler);
 	k_work_init(&m_lc_response_work, lc_response_work_handler);

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -915,18 +915,18 @@ static void m_hist_work_handler(struct k_work *work)
 	}
 }
 
-void app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t seq)
+bool app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t seq)
 {
 	if (!app_lrw_is_ready()) {
 		LOG_WRN("History replay requested but LRW not ready; ignoring");
-		return;
+		return false;
 	}
 
 	size_t cap = history_frame_cap();
 	uint32_t n = (cap > 0) ? app_history_count_frames(from_unix, to_unix, cap) : 0;
 	if (n == 0) {
 		LOG_INF("History replay: no records in window (or DR too low)");
-		return;
+		return false;
 	}
 
 	m_hist_from = from_unix;
@@ -943,6 +943,7 @@ void app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t
 	k_timer_stop(&m_send_timer);
 	LOG_INF("History replay start: %u frames (window %u..%u)", (unsigned)n, from_unix, to_unix);
 	k_work_schedule_for_queue(&m_work_q, &m_hist_work, K_NO_WAIT);
+	return true;
 }
 
 static void send_timer_handler(struct k_timer *timer)

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -66,9 +66,10 @@ int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len);
 
 /* Start a device-driven history replay (issue #52): stream every stored record
  * in [from_unix, to_unix] back as N HistoryFrame uplinks on the command port,
- * back-to-back ASAP (duty-cycle permitting), echoing `seq`. No-op if the link
- * isn't ready or the window is empty. Triggered by the ReqHistory command. */
-void app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t seq);
+ * back-to-back ASAP (duty-cycle permitting), echoing `seq`. Returns true when a
+ * replay was armed (the first frame is the reply, so the caller should NOT also
+ * send an Ack), false if the link isn't ready or the window is empty. */
+bool app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t seq);
 
 /* Erase the persisted LoRaWAN NVM context (frame counters, DevNonce, session).
  * Used when re-provisioning credentials so a new ABP/OTAA identity starts from

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -64,6 +64,12 @@ uint8_t app_lrw_get_max_payload(void);
  * a warning if a prior response hasn't been transmitted yet. */
 int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len);
 
+/* Start a device-driven history replay (issue #52): stream every stored record
+ * in [from_unix, to_unix] back as N HistoryFrame uplinks on the command port,
+ * back-to-back ASAP (duty-cycle permitting), echoing `seq`. No-op if the link
+ * isn't ready or the window is empty. Triggered by the ReqHistory command. */
+void app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t seq);
+
 /* Erase the persisted LoRaWAN NVM context (frame counters, DevNonce, session).
  * Used when re-provisioning credentials so a new ABP/OTAA identity starts from
  * a clean state. The caller must reboot afterwards for the MAC to re-init from


### PR DESCRIPTION
Closes #52.

## What

Turns `ReqHistory` from **host-driven paging** (one request → one frame, host re-issues per page) into **device-driven multi-frame replay**: one `ReqHistory{from?,to?}` makes the device stream the whole matching window back as N `HistoryFrame` uplinks on fPort 85, back-to-back ASAP. **One downlink in, N uplinks out** — the motivation is to cap downlinks *to* the device.

## Compact encoding

A `HistoryFrame` now carries the `present` mask + `interval_s` **once**; records are **values-only** and periodic, so time = `t0 + j*interval_s`. This roughly doubles records/frame (T+RH ~3 B/record vs 7 B). The history storage was changed to match (dropped the per-record `delta_s`), so a changed `interval_report` clears the buffer to keep the period uniform.

## Changes

- **`app_cmd`**: `handle_req_history` (LRW transport) starts the replay via `app_lrw_start_history_replay` and returns `Ack`; non-LRW/no-history → `Error`. New `app_cmd_build_history_frame()` builds a standalone `Response{history_frame}`.
- **`app_lrw`**: `m_hist_work` replay state machine modeled on the telemetry multi-frame machine — one page per frame, `lorawan_send` on port 85, `FRAME_GAP_SEC`/`FRAME_RETRY_SEC` pacing, per-frame `cap` from `app_lrw_get_max_payload()` minus frame overhead, restores the interval timer when done, aborts on (re)join.
- **`app_history`**: storage record = values only (`m_sample_size` no longer includes delta); time = `base + ord*interval`; meta gains `interval_s` (magic `HIS1`→`HIS2`); changed `interval_report` clears the buffer. New `app_history_export_page` / `count_frames` / `get_interval`; `app_history_get` is now O(1).
- **proto**: `HistoryFrame += present (5), interval_s (6)`.
- **`ttn.js`**: decode `present`/`interval_s`, values-only records, time = `t0 + j*interval`; `ttn.test.js` multi-frame reassembly + sentinel tests.

## Known limitation

Implicit time assumes a capture every `interval_report` with no gaps. A reboot or skipped tick drifts later timestamps (accurate for the LoRaWAN-outage store-and-forward case; documented in code).

## Verification

- Builds clean: debug FLASH 91.17 % / RAM 89.20 %, release FLASH 56.15 %.
- `node --test app/decoder/ttn.test.js`: 9/9 pass (incl. new multi-frame reassembly + sentinel).
- Bench (RTT, unjoined): `history info` shows **sample = 7 B** (values-only, was 9 B); `ats cmd lrw 08015a00` (ReqHistory) → `Ack` + graceful `no records in window`.
- **Pending (needs a joined device + gateway):** over-the-air replay of N frames on port 85 with records present; reassembled set matches `history read`. To run on hardware via the user's rttt.

Branch off `v1.4.0`. (Note: `ats` rename #46 is already merged on v1.4.0, so the shell command is `ats cmd lrw`.)