### PR TITLE
Global alarm LRW rate-limit + configurable notif-time + PIR unblock (#28)

### DIFF
--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -201,8 +201,7 @@ void app_alarm_event(enum app_alarm_source source, bool active)
 	/* Both bools set, or a pulse source (PIR is activation-only): the latch has
 	 * no clearing edge, so hold it for alarm_notif_time and let app_alarm_poll()
 	 * auto-clear it. Otherwise the latch tracks the configured edge. */
-	if ((notify_act && notify_deact) ||
-	    (source == APP_ALARM_SOURCE_PIR_MOTION && notify_act)) {
+	if ((notify_act && notify_deact) || (source == APP_ALARM_SOURCE_PIR_MOTION && notify_act)) {
 		m_alarm_active[source] = true;
 		m_both_bool_expiry_ms[source] = k_uptime_get() + notif_hold_ms();
 	} else if (notify_act) {

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -22,14 +22,40 @@
 
 LOG_MODULE_REGISTER(app_alarm, LOG_LEVEL_DBG);
 
-#define APP_ALARM_BOTH_BOOL_RED_HOLD_MS 10000
-
 static bool m_alarm_active[APP_ALARM_SOURCE_COUNT];
 static int64_t m_both_bool_expiry_ms[APP_ALARM_SOURCE_COUNT];
+static int64_t m_last_alarm_send_ms;
 static app_alarm_event_cb m_event_cb;
 static void *m_event_cb_user_data;
 
 K_MUTEX_DEFINE(m_lock);
+
+/* Red-LED hold for both-mode and pulse sources, in ms (config alarm_notif_time). */
+static inline int64_t notif_hold_ms(void)
+{
+	return (int64_t)g_app_config.alarm_notif_time * 1000;
+}
+
+/* Send an alarm uplink, rate-limited by the global alarm_limit (seconds). The
+ * first alarm goes out immediately; further alarms within the window are
+ * suppressed (the source latch, LED and counters still update elsewhere — only
+ * the LoRaWAN message is throttled). alarm_limit == 0 disables the limit. */
+static void alarm_lrw_send(void)
+{
+#if defined(CONFIG_LORAWAN)
+	int limit = g_app_config.alarm_limit;
+	int64_t now = k_uptime_get();
+
+	if (limit > 0 && m_last_alarm_send_ms != 0 &&
+	    (now - m_last_alarm_send_ms) < (int64_t)limit * 1000) {
+		LOG_INF("Alarm uplink rate-limited (limit %d s)", limit);
+		return;
+	}
+
+	m_last_alarm_send_ms = now;
+	app_lrw_send();
+#endif /* defined(CONFIG_LORAWAN) */
+}
 
 static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deact)
 {
@@ -51,7 +77,7 @@ static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deac
 		*deact = g_app_config.input_b_notify_deact;
 		return 0;
 	case APP_ALARM_SOURCE_PIR_MOTION:
-		*act = false;
+		*act = g_app_config.pir_notify_act && g_app_config.cap_pir_detector;
 		*deact = false;
 		return 0;
 	default:
@@ -150,9 +176,7 @@ bool app_alarm_poll(void)
 	k_mutex_unlock(&m_lock);
 
 	if (should_send) {
-#if defined(CONFIG_LORAWAN)
-		app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+		alarm_lrw_send();
 	}
 
 	return alarm;
@@ -174,10 +198,13 @@ void app_alarm_event(enum app_alarm_source source, bool active)
 
 	k_mutex_lock(&m_lock, K_FOREVER);
 
-	/* Both bools set: every edge (act or deact) extends the red-LED hold 10 s further. */
-	if (notify_act && notify_deact) {
+	/* Both bools set, or a pulse source (PIR is activation-only): the latch has
+	 * no clearing edge, so hold it for alarm_notif_time and let app_alarm_poll()
+	 * auto-clear it. Otherwise the latch tracks the configured edge. */
+	if ((notify_act && notify_deact) ||
+	    (source == APP_ALARM_SOURCE_PIR_MOTION && notify_act)) {
 		m_alarm_active[source] = true;
-		m_both_bool_expiry_ms[source] = k_uptime_get() + APP_ALARM_BOTH_BOOL_RED_HOLD_MS;
+		m_both_bool_expiry_ms[source] = k_uptime_get() + notif_hold_ms();
 	} else if (notify_act) {
 		m_alarm_active[source] = active;
 		m_both_bool_expiry_ms[source] = 0;
@@ -194,10 +221,8 @@ void app_alarm_event(enum app_alarm_source source, bool active)
 
 	k_mutex_unlock(&m_lock);
 
-	if (send && source != APP_ALARM_SOURCE_PIR_MOTION) {
-#if defined(CONFIG_LORAWAN)
-		app_lrw_send();
-#endif /* defined(CONFIG_LORAWAN) */
+	if (send) {
+		alarm_lrw_send();
 	}
 
 	if (cb) {

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -53,6 +53,9 @@ static const struct app_config m_app_config_defaults = {
 	.alarm_t2_temperature_hst = 0.5f,
 	.history_enable = false,
 	.history_sensors = 0,
+	.alarm_limit = 0,
+	.alarm_notif_time = 10,
+	.pir_notify_act = false,
 };
 
 static struct app_config m_app_config = {
@@ -76,6 +79,9 @@ static struct app_config m_app_config = {
 	.alarm_t2_temperature_hst = 0.5f,
 	.history_enable = false,
 	.history_sensors = 0,
+	.alarm_limit = 0,
+	.alarm_notif_time = 10,
+	.pir_notify_act = false,
 };
 
 static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb_arg)
@@ -216,6 +222,11 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.history_enable));
 	SETTINGS_SET("history-sensors", &m_app_config.history_sensors,
 		     sizeof(m_app_config.history_sensors));
+	SETTINGS_SET("alarm-limit", &m_app_config.alarm_limit, sizeof(m_app_config.alarm_limit));
+	SETTINGS_SET("alarm-notif-time", &m_app_config.alarm_notif_time,
+		     sizeof(m_app_config.alarm_notif_time));
+	SETTINGS_SET("pir-notify-act", &m_app_config.pir_notify_act,
+		     sizeof(m_app_config.pir_notify_act));
 
 #undef SETTINGS_SET
 
@@ -358,6 +369,11 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.history_enable));
 	EXPORT_FUNC("history-sensors", &m_app_config.history_sensors,
 		    sizeof(m_app_config.history_sensors));
+	EXPORT_FUNC("alarm-limit", &m_app_config.alarm_limit, sizeof(m_app_config.alarm_limit));
+	EXPORT_FUNC("alarm-notif-time", &m_app_config.alarm_notif_time,
+		    sizeof(m_app_config.alarm_notif_time));
+	EXPORT_FUNC("pir-notify-act", &m_app_config.pir_notify_act,
+		    sizeof(m_app_config.pir_notify_act));
 
 #undef EXPORT_FUNC
 
@@ -944,6 +960,22 @@ static void print_history_sensors(const struct shell *shell)
 	shell_print(shell, SETTINGS_PFX " history-sensors %u", m_app_config.history_sensors);
 }
 
+static void print_alarm_limit(const struct shell *shell)
+{
+	shell_print(shell, SETTINGS_PFX " alarm-limit %d", m_app_config.alarm_limit);
+}
+
+static void print_alarm_notif_time(const struct shell *shell)
+{
+	shell_print(shell, SETTINGS_PFX " alarm-notif-time %d", m_app_config.alarm_notif_time);
+}
+
+static void print_pir_notify_act(const struct shell *shell)
+{
+	shell_print(shell, SETTINGS_PFX " pir-notify-act %s",
+		    m_app_config.pir_notify_act ? "true" : "false");
+}
+
 static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 {
 	print_secret_key(shell);
@@ -1010,6 +1042,9 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_cap_1w_machine_probe(shell);
 	print_history_enable(shell);
 	print_history_sensors(shell);
+	print_alarm_limit(shell);
+	print_alarm_notif_time(shell);
+	print_pir_notify_act(shell);
 
 	return 0;
 }
@@ -1748,6 +1783,22 @@ static int cmd_history_sensors(const struct shell *shell, size_t argc, char **ar
 	return 0;
 }
 
+static int cmd_alarm_limit(const struct shell *shell, size_t argc, char **argv)
+{
+	return cmd_int(shell, argc, argv, &m_app_config.alarm_limit, 0, 3600, print_alarm_limit);
+}
+
+static int cmd_alarm_notif_time(const struct shell *shell, size_t argc, char **argv)
+{
+	return cmd_int(shell, argc, argv, &m_app_config.alarm_notif_time, 1, 60,
+		       print_alarm_notif_time);
+}
+
+static int cmd_pir_notify_act(const struct shell *shell, size_t argc, char **argv)
+{
+	return cmd_bool(shell, argc, argv, &m_app_config.pir_notify_act, print_pir_notify_act);
+}
+
 static int print_help(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc > 1) {
@@ -2025,6 +2076,18 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(history-sensors, NULL,
 	              "Get/Set history sensor selection bitmask (0 = all capability-available).",
 	              cmd_history_sensors, 1, 1),
+
+	SHELL_CMD_ARG(alarm-limit, NULL,
+	              "Get/Set minimum interval between alarm uplinks in seconds (0 = disabled).",
+	              cmd_alarm_limit, 1, 1),
+
+	SHELL_CMD_ARG(alarm-notif-time, NULL,
+	              "Get/Set alarm red-LED hold time in seconds (both-mode and pulse sources).",
+	              cmd_alarm_notif_time, 1, 1),
+
+	SHELL_CMD_ARG(pir-notify-act, NULL,
+	              "Get/Set PIR motion alarm notify on activation (true/false).",
+	              cmd_pir_notify_act, 1, 1),
 
 	SHELL_SUBCMD_SET_END
 );

--- a/app/src/app_config.h
+++ b/app/src/app_config.h
@@ -101,6 +101,9 @@ struct app_config {
 	bool cap_1w_machine_probe;
 	bool history_enable;
 	uint32_t history_sensors;
+	int alarm_limit;
+	int alarm_notif_time;
+	bool pir_notify_act;
 };
 
 extern struct app_config g_app_config;

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -91,6 +91,9 @@ message AppConfigMessage {
         optional bool cap_1w_machine_probe = 48;
         optional bool history_enable = 49;
         optional uint32 history_sensors = 50;
+        optional uint32 alarm_limit = 51;
+        optional uint32 alarm_notif_time = 52;
+        optional bool pir_notify_act = 53;
     }
 }
 // END GENERATED CONFIG

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -505,3 +505,28 @@ parameters:
     type: uint32
     default: 0
     help: "Get/Set history sensor selection bitmask (0 = all capability-available)."
+
+  - name: alarm_limit
+    proto_group: application
+    proto_id: 51
+    type: int
+    default: 0
+    min: 0
+    max: 3600
+    help: "Get/Set minimum interval between alarm uplinks in seconds (0 = disabled)."
+
+  - name: alarm_notif_time
+    proto_group: application
+    proto_id: 52
+    type: int
+    default: 10
+    min: 1
+    max: 60
+    help: "Get/Set alarm red-LED hold time in seconds (both-mode and pulse sources)."
+
+  - name: pir_notify_act
+    proto_group: application
+    proto_id: 53
+    type: bool
+    default: false
+    help: "Get/Set PIR motion alarm notify on activation (true/false)."

--- a/app/src/app_config_ingest.c
+++ b/app/src/app_config_ingest.c
@@ -225,6 +225,26 @@ int app_config_apply_application(const AppConfigMessage_Application *src, uint32
 		config->history_sensors = src->history_sensors;
 	}
 
+	APPLY_BOOL(pir_notify_act);
+	if (src->has_alarm_limit) {
+		int val = src->alarm_limit;
+
+		if (val >= 0 && val <= 3600) {
+			config->alarm_limit = val;
+		} else {
+			FAULT(51);
+		}
+	}
+	if (src->has_alarm_notif_time) {
+		int val = src->alarm_notif_time;
+
+		if (val >= 1 && val <= 60) {
+			config->alarm_notif_time = val;
+		} else {
+			FAULT(52);
+		}
+	}
+
 	/* Cross-validate alarm lo/hi pairs — disable the alarm if lo >= hi */
 	if (config->alarm_temperature_lo >= config->alarm_temperature_hi) {
 		config->alarm_temperature_enabled = false;

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -111,10 +111,17 @@ def test_allocator_appends_next_free():
     rt_new["type"] = "bool"
     rt_doc["parameters"].append(rt_new)
 
+    # Expected id = next free in the application group (1 + current max),
+    # computed from the YAML so this doesn't break when fields are added.
+    app_ids = [p["proto_id"] for p in cfg["parameters"]
+               if p.get("proto_group") == "application" and "proto_id" in p
+               and p["name"] != "telemetry_split"]
+    expected = max(app_ids) + 1
+
     assigned = configen.allocate_proto_ids(cfg, rt_doc)
-    assert ("telemetry_split", 51) in assigned  # max(application)=50 -> 51
+    assert ("telemetry_split", expected) in assigned
     got = next(p for p in cfg["parameters"] if p["name"] == "telemetry_split")
-    assert got["proto_id"] == 51
+    assert got["proto_id"] == expected
 
 
 def test_guard_rejects_renumbering():


### PR DESCRIPTION
Scoped subset of #28 — the **additive, non-breaking** parts plus a new alarm-uplink rate-limit. The enum migration of the `*_notify_act/deact` bool pairs and the `alarm_*` namespace rename are **deferred** (breaking NVS + NFC wire, little gain). Bool style kept.

> **Draft:** builds are clean (debug + release) but on-hardware verification (physical PIR/hall trigger) is still pending — JLink was busy this session.

## What's included

**New config keys** (`app_config.yml` → `west configen` regenerates `app_config.{c,h}` + proto; additive, proto fields 51-53, no renumber):
- `alarm_limit` — `int` 0–3600 s, default `0` (disabled). One **global** minimum interval between alarm-triggered uplinks.
- `alarm_notif_time` — `int` 1–60 s, default `10`. Red-LED hold time, replacing the hardcoded `APP_ALARM_BOTH_BOOL_RED_HOLD_MS = 10000`.
- `pir_notify_act` — `bool`, default `false`. Unblocks the PIR alarm (also gated by existing `cap_pir_detector`).

**`app_alarm.c`:**
- `alarm_lrw_send()` rate-limits alarm uplinks by `alarm_limit`: the first alarm goes out immediately, bursts within the window are suppressed (the source latch, LED and counters still update — only the LoRaWAN message is throttled). Used by both the threshold path (`app_alarm_poll`) and the edge path (`app_alarm_event`). Anti-chatter for bouncing sensors. Periodic `interval_report` uplinks are unaffected.
- Red-LED hold now read from `alarm_notif_time` instead of the constant.
- PIR (`APP_ALARM_SOURCE_PIR_MOTION`, activation-only pulse) unblocked: latches with an `alarm_notif_time` expiry so `app_alarm_poll()` auto-clears it; removed the `source != PIR` LRW-skip.

**`app_config_ingest.c`:** apply `pir_notify_act` + range-checked `alarm_limit`/`alarm_notif_time`. No legacy translation (bools stay).

## Design note
CHESTER debounces chatter in `ctr_edge` (`cooldown_time` + `active/inactive_duration`) at edge-detection time. The sticker has no `ctr_edge` (hall/input are polled, PIR is a pulse interrupt), so the minimal equivalent here is a **cooldown on the send path**. The counter keeps counting bounces; only the uplink rate is limited (per the agreed scope: "řešíme jen množství odeslaných zpráv").

## Verification
- Debug + release builds clean (debug FLASH 91.65%/RAM 89.29%, release 56.37%/65.27%); `app_config.proto` diff = only the 3 added fields (`guard_no_renumber` passed).
- **Pending (next session, on HW via rttt):** `config alarm-limit 20; alarm-notif-time 3; pir-notify-act true; settings save`; physically wave PIR → alarm send no longer skipped, `app_alarm_poll()` true ~3 s then auto-clears; rapid hall/input toggle → one uplink per 20 s window while the counter still increments; `alarm-limit 0` → every edge sends (old behavior).

## Deferred (not here)
`alarm_edge_mode` enum migration; `alarm_*` namespace rename; per-source limits; edge-level debounce of the polled detection; `alarm_motion` accel key (→ #18).

Refs #28.