### PR TITLE
Batched alarm detail on fPort 3 (#27, Phase B of #28/#67)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -687,15 +687,66 @@ function decodeDownlink(input) {
   return { data: { bytes_hex: _pbBytesToHex(input.bytes) }, warnings: [], errors: [] };
 }
 
+// fPort 3: alarm-detail batch (#27). Header [total u8][base_unix u32 LE] then
+// records [hdr u8: source<<3 | side<<1 | active][rel_s u16][threshold i16]
+// [value i16][hyst i16]. threshold/value/hyst scaled like the periodic payload
+// (temp/hum ×100, pressure ×10); 0x8000 = N/A (discrete sources). Per-event
+// time = base_unix + rel_s. `total` may exceed the records present (DR-capped).
+var _ALARM_SOURCES = ["hall-left", "hall-right", "pir", "input-a", "input-b",
+  "temperature", "humidity", "pressure", "t1-temperature", "t2-temperature"];
+var _ALARM_SIDES = ["na", "lo", "hi"];
+var _ALARM_SENTINEL = 0x8000;
+
+function _alarmUnscale(source, raw) {
+  if (raw === _ALARM_SENTINEL) return null;
+  var v = raw > 0x7fff ? raw - 0x10000 : raw; // int16
+  return source === 7 ? v / 10 : v / 100;     // 7 = pressure (hPa×10)
+}
+
+function decodeAlarmBatch(bytes) {
+  if (bytes.length < 5) return { total: 0, base_time: 0, alarms: [] };
+  var total = bytes[0];
+  var base = (bytes[1] | (bytes[2] << 8) | (bytes[3] << 16) | (bytes[4] << 24)) >>> 0;
+  var out = { total: total, base_time: base, alarms: [] };
+  var p = 5;
+  while (p + 9 <= bytes.length) {
+    var hdr = bytes[p++];
+    var source = hdr >> 3;
+    var side = (hdr >> 1) & 0x3;
+    var active = (hdr & 1) !== 0;
+    var rel = bytes[p] | (bytes[p + 1] << 8); p += 2;
+    var thr = bytes[p] | (bytes[p + 1] << 8); p += 2;
+    var val = bytes[p] | (bytes[p + 1] << 8); p += 2;
+    var hyst = bytes[p] | (bytes[p + 1] << 8); p += 2;
+    out.alarms.push({
+      source: _ALARM_SOURCES[source] || ("src" + source),
+      event: active ? "activate" : "deactivate",
+      side: _ALARM_SIDES[side] || "na",
+      threshold: _alarmUnscale(source, thr),
+      value: _alarmUnscale(source, val),
+      hysteresis: _alarmUnscale(source, hyst),
+      time: (base + rel) >>> 0,
+    });
+  }
+  out.truncated = out.alarms.length < total; // some alarms dropped to fit the DR
+  return out;
+}
+
 function decodeUplink(input) {
 
   // fPort 85: DownlinkResponse (Ack / Info / Error from command dispatcher).
   if (input.fPort === 85) {
+
     return {
       data: decodeDownlinkResponse(input.bytes),
       warnings: [],
       errors: []
     };
+  }
+
+  // fPort 3: alarm-detail batch (#27).
+  if (input.fPort === 3) {
+    return { data: decodeAlarmBatch(input.bytes), warnings: [], errors: [] };
   }
 
   // fPort 2: protobuf Telemetry (new format). fPort 1 stays the legacy bitmap.
@@ -916,6 +967,6 @@ function decodeUplink(input) {
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     decodeUplink, encodeDownlink, decodeDownlink, Decode,
-    decodeTelemetry, decodeDownlinkResponse,
+    decodeTelemetry, decodeDownlinkResponse, decodeAlarmBatch,
   };
 }

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -164,6 +164,62 @@ test("history sentinel values decode to null", () => {
   assert.equal(rec.humidity, null);    // 0xff sentinel
 });
 
+// --- Uplink: alarm-detail batch (fPort 3, #27) ----------------------------
+function leU16(v) { return [v & 0xff, (v >> 8) & 0xff]; }
+function leI16(v) { const u = v < 0 ? v + 0x10000 : v; return [u & 0xff, (u >> 8) & 0xff]; }
+function leU32(v) { return [v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >>> 24) & 0xff]; }
+function alarmRec(source, side, active, rel, thr, val, hyst) {
+  return [(source << 3) | (side << 1) | (active ? 1 : 0)]
+    .concat(leU16(rel)).concat(leI16(thr)).concat(leI16(val)).concat(leI16(hyst));
+}
+function buildAlarmFrame(total, base, recs) {
+  let b = [total & 0xff].concat(leU32(base));
+  for (const r of recs) b = b.concat(r);
+  return b;
+}
+const SENT = 0x8000; // discrete N/A sentinel
+
+test("decodeUplink decodes an fPort-3 alarm batch (threshold + discrete)", () => {
+  const base = 1780000000;
+  const f = buildAlarmFrame(2, base, [
+    alarmRec(5, 2, true, 10, 2000, 2660, 0),    // temperature, HI, activate, 20→26.6 °C
+    alarmRec(0, 0, true, 15, SENT, SENT, SENT), // hall-left, discrete activate
+  ]);
+  const d = codec.decodeUplink({ bytes: f, fPort: 3 }).data;
+
+  assert.equal(d.total, 2);
+  assert.equal(d.base_time, base);
+  assert.equal(d.truncated, false);
+  assert.equal(d.alarms.length, 2);
+
+  assert.equal(d.alarms[0].source, "temperature");
+  assert.equal(d.alarms[0].event, "activate");
+  assert.equal(d.alarms[0].side, "hi");
+  assert.equal(d.alarms[0].threshold, 20);
+  assert.equal(d.alarms[0].value, 26.6);
+  assert.equal(d.alarms[0].time, base + 10);
+
+  assert.equal(d.alarms[1].source, "hall-left");
+  assert.equal(d.alarms[1].side, "na");
+  assert.equal(d.alarms[1].threshold, null); // sentinel → null
+  assert.equal(d.alarms[1].value, null);
+  assert.equal(d.alarms[1].time, base + 15);
+});
+
+test("fPort-3 batch: humidity deactivate + truncation flag (total > records)", () => {
+  const f = buildAlarmFrame(5, 1780000000, [alarmRec(6, 1, false, 0, 5000, 4500, 200)]);
+  const d = codec.decodeUplink({ bytes: f, fPort: 3 }).data;
+  assert.equal(d.total, 5);
+  assert.equal(d.alarms.length, 1);
+  assert.equal(d.truncated, true); // 5 alarms occurred, only 1 fit the frame
+  assert.equal(d.alarms[0].source, "humidity");
+  assert.equal(d.alarms[0].event, "deactivate");
+  assert.equal(d.alarms[0].side, "lo");
+  assert.equal(d.alarms[0].threshold, 50);
+  assert.equal(d.alarms[0].value, 45);
+  assert.equal(d.alarms[0].hysteresis, 2);
+});
+
 // --- Negative: a corrupted frame must change the result (tests are sensitive) ---
 test("a tampered command byte does not silently decode to the original", () => {
   const good = codec.decodeDownlink({ bytes: hex("08032200"), fPort: 85 }).data;

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -10,9 +10,17 @@
 #include "app_lrw.h"
 #include "app_sensor.h"
 
+#if defined(__has_include) && __has_include("app_clock.h")
+#include "app_clock.h"
+#define APP_ALARM_HAVE_CLOCK 1
+#endif
+
 /* Zephyr includes */
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 /* Standard includes */
 #include <errno.h>
@@ -29,6 +37,58 @@ static app_alarm_event_cb m_event_cb;
 static void *m_event_cb_user_data;
 
 K_MUTEX_DEFINE(m_lock);
+
+/* ---- Alarm-detail batch on fPort 3 (#27) -------------------------------- */
+
+/* Threshold side crossed (encoded in the fPort-3 record header). */
+#define ALARM_SIDE_NA 0
+#define ALARM_SIDE_LO 1
+#define ALARM_SIDE_HI 2
+
+#define ALARM_VALUE_SENTINEL ((int16_t)0x8000) /* discrete records: no threshold/value */
+
+/* One collected alarm edge. threshold/value/hyst are already scaled to the
+ * sensor's wire units (temp/hum ×100, pressure ×10); sentinel for discrete. */
+struct alarm_event {
+	uint8_t source; /* enum app_alarm_source */
+	uint8_t side;   /* ALARM_SIDE_* */
+	bool active;    /* true = activate, false = deactivate */
+	int16_t threshold;
+	int16_t value;
+	int16_t hyst;
+	uint16_t rel_s; /* seconds since the window base time */
+};
+
+#define ALARM_BATCH_MAX 8 /* records held per window; overflow counted in m_window_total */
+
+static struct alarm_event m_batch[ALARM_BATCH_MAX];
+static uint8_t m_batch_count;
+static uint16_t m_window_total; /* all alarms in the window (may exceed m_batch_count) */
+static uint32_t m_window_base_unix;
+static int64_t m_window_start_ms;
+static bool m_window_open;
+static struct k_work_delayable m_alarm_batch_work;
+
+static const char *const m_source_names[APP_ALARM_SOURCE_COUNT] = {
+	[APP_ALARM_SOURCE_HALL_LEFT] = "hall-left",
+	[APP_ALARM_SOURCE_HALL_RIGHT] = "hall-right",
+	[APP_ALARM_SOURCE_PIR_MOTION] = "pir",
+	[APP_ALARM_SOURCE_INPUT_A] = "input-a",
+	[APP_ALARM_SOURCE_INPUT_B] = "input-b",
+	[APP_ALARM_SOURCE_TEMPERATURE] = "temperature",
+	[APP_ALARM_SOURCE_HUMIDITY] = "humidity",
+	[APP_ALARM_SOURCE_PRESSURE] = "pressure",
+	[APP_ALARM_SOURCE_T1_TEMPERATURE] = "t1-temperature",
+	[APP_ALARM_SOURCE_T2_TEMPERATURE] = "t2-temperature",
+};
+
+const char *app_alarm_source_name(enum app_alarm_source source)
+{
+	if (source < 0 || source >= APP_ALARM_SOURCE_COUNT) {
+		return "?";
+	}
+	return m_source_names[source];
+}
 
 /* Red-LED hold for both-mode and pulse sources, in ms (config alarm_notif_time). */
 static inline int64_t notif_hold_ms(void)
@@ -55,6 +115,124 @@ static void alarm_lrw_send(void)
 	m_last_alarm_send_ms = now;
 	app_lrw_send();
 #endif /* defined(CONFIG_LORAWAN) */
+}
+
+#define ALARM_FRAME_MAX  64 /* fPort-3 frame buffer (matches app_lrw pending slot) */
+#define ALARM_RECORD_LEN 9  /* hdr + rel_s + threshold + value + hyst */
+#define ALARM_HEADER_LEN 5  /* total_count(1) + base_unix(4) */
+
+static uint32_t now_unix_or_uptime(void)
+{
+#ifdef APP_ALARM_HAVE_CLOCK
+	uint32_t u;
+	if (app_clock_get_unix(&u) == 0) {
+		return u;
+	}
+#endif
+	return (uint32_t)(k_uptime_get() / 1000);
+}
+
+/* Encode the collected batch into the fPort-3 frame and hand it to app_lrw.
+ * Records are capped to the current DR budget; m_window_total still reports the
+ * true count so the backend knows if some were dropped. Caller holds m_lock. */
+static void alarm_batch_flush(void)
+{
+	if (m_batch_count == 0) {
+		m_window_open = false;
+		m_window_total = 0;
+		return;
+	}
+
+	uint8_t buf[ALARM_FRAME_MAX];
+	size_t pos = 0;
+	size_t cap = ALARM_FRAME_MAX;
+#if defined(CONFIG_LORAWAN)
+	uint8_t dr = app_lrw_get_max_payload();
+	if (dr > 0 && dr < cap) {
+		cap = dr;
+	}
+#endif
+
+	buf[pos++] = (uint8_t)MIN(m_window_total, 0xFF);
+	sys_put_le32(m_window_base_unix, &buf[pos]);
+	pos += 4;
+
+	uint8_t written = 0;
+	for (uint8_t i = 0; i < m_batch_count; i++) {
+		if (pos + ALARM_RECORD_LEN > cap) {
+			break; /* DR-bounded; total_count signals the rest */
+		}
+		struct alarm_event *e = &m_batch[i];
+		buf[pos++] = (uint8_t)((e->source << 3) | (e->side << 1) | (e->active ? 1 : 0));
+		sys_put_le16(e->rel_s, &buf[pos]);
+		pos += 2;
+		sys_put_le16((uint16_t)e->threshold, &buf[pos]);
+		pos += 2;
+		sys_put_le16((uint16_t)e->value, &buf[pos]);
+		pos += 2;
+		sys_put_le16((uint16_t)e->hyst, &buf[pos]);
+		pos += 2;
+		written++;
+	}
+
+#if defined(CONFIG_LORAWAN)
+	(void)app_lrw_send_alarm(buf, pos);
+#endif
+	LOG_INF("Alarm batch: %u/%u records on fPort 3", written, m_window_total);
+
+	m_batch_count = 0;
+	m_window_total = 0;
+	m_window_open = false;
+}
+
+static void alarm_batch_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	k_mutex_lock(&m_lock, K_FOREVER);
+	alarm_batch_flush();
+	k_mutex_unlock(&m_lock);
+}
+
+/* Record one alarm edge for the fPort-3 detail batch (#27). Threshold sources
+ * pass scaled threshold/value/hyst; discrete sources pass sentinels + side N/A.
+ * With alarm_limit == 0 the record is sent immediately as a 1-record frame;
+ * otherwise it joins the current collection window (opened on the first edge,
+ * flushed by m_alarm_batch_work after alarm_limit seconds). */
+static void alarm_collect(uint8_t source, bool active, uint8_t side, int16_t threshold,
+			  int16_t value, int16_t hyst)
+{
+	int limit = g_app_config.alarm_limit;
+	int64_t now = k_uptime_get();
+
+	k_mutex_lock(&m_lock, K_FOREVER);
+
+	if (limit <= 0) {
+		m_window_base_unix = now_unix_or_uptime();
+		m_window_total = 1;
+		m_batch_count = 1;
+		m_batch[0] = (struct alarm_event){source, side, active, threshold, value, hyst, 0};
+		alarm_batch_flush();
+		k_mutex_unlock(&m_lock);
+		return;
+	}
+
+	if (!m_window_open) {
+		m_window_open = true;
+		m_window_start_ms = now;
+		m_window_base_unix = now_unix_or_uptime();
+		m_window_total = 0;
+		m_batch_count = 0;
+		k_work_schedule(&m_alarm_batch_work, K_SECONDS(limit));
+	}
+
+	m_window_total++;
+	if (m_batch_count < ALARM_BATCH_MAX) {
+		uint16_t rel = (uint16_t)MIN((now - m_window_start_ms) / 1000, 0xFFFF);
+		m_batch[m_batch_count++] =
+			(struct alarm_event){source, side, active, threshold, value, hyst, rel};
+	}
+
+	k_mutex_unlock(&m_lock);
 }
 
 static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deact)
@@ -85,12 +263,31 @@ static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deac
 	}
 }
 
-/* Evaluate a single threshold with hysteresis. Updates *active to reflect the
- * latched state and sets *should_send = true on every Activated/Deactivated
- * edge. Returns the latched state for the caller to OR into the aggregate. */
-static bool eval_threshold(bool *active, bool enabled, float value, float lo, float hi, float hst,
-			   const char *name, bool *should_send)
+/* Per-source wire scaling for the fPort-3 detail (threshold sources only): temp
+ * and humidity ×100, pressure already hPa×10 from the poll call. */
+static int16_t alarm_scale(enum app_alarm_source source, float v)
 {
+	switch (source) {
+	case APP_ALARM_SOURCE_TEMPERATURE:
+	case APP_ALARM_SOURCE_T1_TEMPERATURE:
+	case APP_ALARM_SOURCE_T2_TEMPERATURE:
+	case APP_ALARM_SOURCE_HUMIDITY:
+		return (int16_t)lroundf(v * 100.0f);
+	case APP_ALARM_SOURCE_PRESSURE:
+		return (int16_t)lroundf(v);
+	default:
+		return ALARM_VALUE_SENTINEL;
+	}
+}
+
+/* Evaluate one threshold with hysteresis. Latches into m_alarm_active[source],
+ * sets *should_send on every edge, and records the edge (source/side/threshold/
+ * value/hysteresis) for the fPort-3 detail batch. Returns the latched state. */
+static bool eval_threshold(enum app_alarm_source source, bool enabled, float value, float lo,
+			   float hi, float hst, bool *should_send)
+{
+	bool *active = &m_alarm_active[source];
+
 	if (!enabled || isnan(value)) {
 		*active = false;
 		return false;
@@ -98,16 +295,24 @@ static bool eval_threshold(bool *active, bool enabled, float value, float lo, fl
 
 	if (*active) {
 		if (value > lo + hst && value < hi - hst) {
-			LOG_INF("Deactivated alarm for %s", name);
+			LOG_INF("Deactivated alarm for %s", app_alarm_source_name(source));
 			*active = false;
 			*should_send = true;
+			alarm_collect(source, false, ALARM_SIDE_NA, ALARM_VALUE_SENTINEL,
+				      alarm_scale(source, value), alarm_scale(source, hst));
 		}
-	} else {
-		if (value < lo - hst || value > hi + hst) {
-			LOG_INF("Activated alarm for %s", name);
-			*active = true;
-			*should_send = true;
-		}
+	} else if (value < lo - hst) {
+		LOG_INF("Activated alarm for %s (lo)", app_alarm_source_name(source));
+		*active = true;
+		*should_send = true;
+		alarm_collect(source, true, ALARM_SIDE_LO, alarm_scale(source, lo),
+			      alarm_scale(source, value), alarm_scale(source, hst));
+	} else if (value > hi + hst) {
+		LOG_INF("Activated alarm for %s (hi)", app_alarm_source_name(source));
+		*active = true;
+		*should_send = true;
+		alarm_collect(source, true, ALARM_SIDE_HI, alarm_scale(source, hi),
+			      alarm_scale(source, value), alarm_scale(source, hst));
 	}
 
 	return *active;
@@ -118,42 +323,36 @@ bool app_alarm_poll(void)
 	bool should_send = false;
 	bool alarm = false;
 
-	static bool alarm_temperature;
-	static bool alarm_humidity;
-	static bool alarm_pressure;
-	static bool alarm_t1_temperature;
-	static bool alarm_t2_temperature;
-
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);
 
-	alarm |= eval_threshold(&alarm_temperature, g_app_config.alarm_temperature_enabled,
-				g_app_sensor_data.temperature, g_app_config.alarm_temperature_lo,
-				g_app_config.alarm_temperature_hi,
-				g_app_config.alarm_temperature_hst, "internal temperature",
-				&should_send);
+	alarm |=
+		eval_threshold(APP_ALARM_SOURCE_TEMPERATURE, g_app_config.alarm_temperature_enabled,
+			       g_app_sensor_data.temperature, g_app_config.alarm_temperature_lo,
+			       g_app_config.alarm_temperature_hi,
+			       g_app_config.alarm_temperature_hst, &should_send);
 
-	alarm |= eval_threshold(&alarm_humidity, g_app_config.alarm_humidity_enabled,
+	alarm |= eval_threshold(APP_ALARM_SOURCE_HUMIDITY, g_app_config.alarm_humidity_enabled,
 				g_app_sensor_data.humidity, g_app_config.alarm_humidity_lo,
 				g_app_config.alarm_humidity_hi, g_app_config.alarm_humidity_hst,
-				"humidity", &should_send);
+				&should_send);
 
 	/* Pressure config thresholds are stored in hPa × 10, sensor reports hPa. */
-	alarm |= eval_threshold(&alarm_pressure, g_app_config.alarm_pressure_enabled,
+	alarm |= eval_threshold(APP_ALARM_SOURCE_PRESSURE, g_app_config.alarm_pressure_enabled,
 				g_app_sensor_data.pressure * 10.f, g_app_config.alarm_pressure_lo,
 				g_app_config.alarm_pressure_hi, g_app_config.alarm_pressure_hst,
-				"pressure", &should_send);
+				&should_send);
 
 	alarm |= eval_threshold(
-		&alarm_t1_temperature, g_app_config.alarm_t1_temperature_enabled,
+		APP_ALARM_SOURCE_T1_TEMPERATURE, g_app_config.alarm_t1_temperature_enabled,
 		g_app_sensor_data.t1_temperature, g_app_config.alarm_t1_temperature_lo,
 		g_app_config.alarm_t1_temperature_hi, g_app_config.alarm_t1_temperature_hst,
-		"external temperature 1", &should_send);
+		&should_send);
 
 	alarm |= eval_threshold(
-		&alarm_t2_temperature, g_app_config.alarm_t2_temperature_enabled,
+		APP_ALARM_SOURCE_T2_TEMPERATURE, g_app_config.alarm_t2_temperature_enabled,
 		g_app_sensor_data.t2_temperature, g_app_config.alarm_t2_temperature_lo,
 		g_app_config.alarm_t2_temperature_hi, g_app_config.alarm_t2_temperature_hst,
-		"external temperature 2", &should_send);
+		&should_send);
 
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
@@ -222,6 +421,9 @@ void app_alarm_event(enum app_alarm_source source, bool active)
 
 	if (send) {
 		alarm_lrw_send();
+		/* Discrete sources have no threshold/value — sentinels, side N/A. */
+		alarm_collect(source, active, ALARM_SIDE_NA, ALARM_VALUE_SENTINEL,
+			      ALARM_VALUE_SENTINEL, ALARM_VALUE_SENTINEL);
 	}
 
 	if (cb) {
@@ -238,3 +440,11 @@ int app_alarm_set_event_callback(app_alarm_event_cb cb, void *user_data)
 
 	return 0;
 }
+
+static int app_alarm_init(void)
+{
+	k_work_init_delayable(&m_alarm_batch_work, alarm_batch_work_handler);
+	return 0;
+}
+
+SYS_INIT(app_alarm_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/app/src/app_alarm.h
+++ b/app/src/app_alarm.h
@@ -14,12 +14,21 @@
 extern "C" {
 #endif
 
+/* Alarm sources. The first five are discrete (edge) sources driven by
+ * app_alarm_event(); the threshold sources are driven by app_alarm_poll(). The
+ * enum value is the source id used in the fPort-3 alarm-detail payload (#27).
+ * New sources insert before _COUNT (the id is stable per position). */
 enum app_alarm_source {
 	APP_ALARM_SOURCE_HALL_LEFT,
 	APP_ALARM_SOURCE_HALL_RIGHT,
 	APP_ALARM_SOURCE_PIR_MOTION,
 	APP_ALARM_SOURCE_INPUT_A,
 	APP_ALARM_SOURCE_INPUT_B,
+	APP_ALARM_SOURCE_TEMPERATURE,
+	APP_ALARM_SOURCE_HUMIDITY,
+	APP_ALARM_SOURCE_PRESSURE,
+	APP_ALARM_SOURCE_T1_TEMPERATURE,
+	APP_ALARM_SOURCE_T2_TEMPERATURE,
 	APP_ALARM_SOURCE_COUNT,
 };
 
@@ -28,6 +37,9 @@ typedef void (*app_alarm_event_cb)(enum app_alarm_source source, bool active, vo
 bool app_alarm_poll(void);
 void app_alarm_event(enum app_alarm_source source, bool active);
 int app_alarm_set_event_callback(app_alarm_event_cb cb, void *user_data);
+
+/* Human-readable source name (for logs / decoder parity). */
+const char *app_alarm_source_name(enum app_alarm_source source);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -146,6 +146,14 @@ static size_t m_pending_response_len;
 static uint8_t m_pending_response_port;
 static K_MUTEX_DEFINE(m_pending_response_lock);
 
+/* Pending alarm-detail batch (#27) staged by app_lrw_send_alarm(), sent on
+ * fPort 3. Own slot so it never collides with the command response (port 85);
+ * send_work_handler drains command first, then alarm, then telemetry. */
+#define APP_LRW_ALARM_PORT 3
+static uint8_t m_pending_alarm_buf[APP_LRW_RESPONSE_BUF_SIZE];
+static size_t m_pending_alarm_len;
+static K_MUTEX_DEFINE(m_pending_alarm_lock);
+
 /* Inbound downlink request on port 85 captured from downlink_callback().
  * The callback runs on the LoRaMac stack (restricted), so it only copies the
  * payload and defers parsing to m_dl_request_work on m_work_q. */
@@ -720,10 +728,36 @@ static void send_work_handler(struct k_work *work)
 		} else {
 			LOG_INF("Response sent on port %u (%zu B)", port, len);
 		}
-		k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report), K_FOREVER);
+		/* If an alarm batch is also queued, send it ASAP; else resume periodic. */
+		if (m_pending_alarm_len) {
+			k_work_submit_to_queue(&m_work_q, &m_send_work);
+		} else {
+			k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report),
+				      K_FOREVER);
+		}
 		return;
 	}
 	k_mutex_unlock(&m_pending_response_lock);
+
+	/* Drain a pending alarm-detail batch (fPort 3) before composing telemetry. */
+	k_mutex_lock(&m_pending_alarm_lock, K_FOREVER);
+	if (m_pending_alarm_len) {
+		uint8_t buf[APP_LRW_RESPONSE_BUF_SIZE];
+		size_t len = m_pending_alarm_len;
+		memcpy(buf, m_pending_alarm_buf, len);
+		m_pending_alarm_len = 0;
+		k_mutex_unlock(&m_pending_alarm_lock);
+
+		ret = lorawan_send(APP_LRW_ALARM_PORT, buf, len, LORAWAN_MSG_UNCONFIRMED);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("lorawan_send(alarm)", ret);
+		} else {
+			LOG_INF("Alarm batch sent on port %u (%zu B)", APP_LRW_ALARM_PORT, len);
+		}
+		k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report), K_FOREVER);
+		return;
+	}
+	k_mutex_unlock(&m_pending_alarm_lock);
 
 	/* Sample fresh sensor values for a new report (the snapshot is taken inside
 	 * app_compose on the first frame). */
@@ -1204,6 +1238,28 @@ int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len)
 
 	/* Wake send path so the response leaves at the next jitter window
 	 * instead of waiting for the periodic timer. */
+	k_work_submit_to_queue(&m_work_q, &m_send_work);
+	return 0;
+}
+
+int app_lrw_send_alarm(const uint8_t *buf, size_t len)
+{
+	if (!buf || len == 0) {
+		return -EINVAL;
+	}
+	if (len > sizeof(m_pending_alarm_buf)) {
+		LOG_ERR("Alarm batch too large: %zu B (max %zu)", len, sizeof(m_pending_alarm_buf));
+		return -EMSGSIZE;
+	}
+
+	k_mutex_lock(&m_pending_alarm_lock, K_FOREVER);
+	if (m_pending_alarm_len) {
+		LOG_WRN("Overwriting unsent alarm batch (%zu B)", m_pending_alarm_len);
+	}
+	memcpy(m_pending_alarm_buf, buf, len);
+	m_pending_alarm_len = len;
+	k_mutex_unlock(&m_pending_alarm_lock);
+
 	k_work_submit_to_queue(&m_work_q, &m_send_work);
 	return 0;
 }

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -64,6 +64,11 @@ uint8_t app_lrw_get_max_payload(void);
  * a warning if a prior response hasn't been transmitted yet. */
 int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len);
 
+/* Stage an alarm-detail batch (issue #27) for the next uplink on fPort 3. Own
+ * slot, drained after the command response and before telemetry, so it never
+ * collides with app_lrw_queue_response(). Returns 0, -EINVAL, or -EMSGSIZE. */
+int app_lrw_send_alarm(const uint8_t *buf, size_t len);
+
 /* Start a device-driven history replay (issue #52): stream every stored record
  * in [from_unix, to_unix] back as N HistoryFrame uplinks on the command port,
  * back-to-back ASAP (duty-cycle permitting), echoing `seq`. Returns true when a


### PR DESCRIPTION
Closes #27. Phase B on top of #67 (alarm rate-limit).

## What

Turns #67's `alarm_limit` cooldown into a **collection window**: every alarm edge (threshold **and** discrete) during the window is recorded with its detail, and at window end one **fPort-3 frame carrying the list** is sent. One downlink-free, batched alarm-detail stream — instead of one frame per alarm. The fPort-2 periodic digest and #67's throttled immediate send are unchanged; fPort-3 is additional.

## Design (agreed)

- **All alarm kinds** — threshold (temp/hum/pressure/t1/t2) + discrete (hall/PIR/input).
- **Every edge** is a record (activate + deactivate), each with a per-event timestamp (`base + rel_s`).
- **`enum app_alarm_source` extended** with the threshold sources; the enum value is the fPort-3 source id (room for future sources). No #28 enum/namespace migration.
- **`alarm_limit == 0`** → single-record fPort-3 frame immediately.
- **One frame in v1** (multi-frame later): records capped to the DR, but `total` counts all alarms in the window (incl. dropped) — `truncated` flag in the decoder. Never silently truncated.

## Changes
- `app_alarm.h` — extend enum + `app_alarm_source_name()`.
- `app_alarm.c` — `eval_threshold(source,…)` latches into `m_alarm_active[]`, derives lo/hi side, records each edge via `alarm_collect()`; discrete `app_alarm_event()` records side N/A + sentinels; window via `m_alarm_batch_work` (`alarm_limit` s) + `m_window_total`; fPort-3 encoder.
- `app_lrw.{c,h}` — `app_lrw_send_alarm()` with its own pending slot; drain order command(85) → alarm(3) → telemetry(2).
- `app/decoder/ttn.js` (+ tests) — fPort-3 → `{total, base_time, alarms[], truncated}`.

## Payload (fPort 3)
`[total u8][base_unix u32]` + records `[source<<3|side<<1|active u8][rel_s u16][threshold i16][value i16][hyst i16]`. Scaling: temp/hum ×100, pressure ×10; `0x8000` = N/A (discrete).

## Verification
- Builds clean (debug 92.24%, release 56.81%); `node --test` 11/11; native_sim 5/5+6/6+4/4; clang-format clean.
- **HW (rttt + TTN):** threshold alarm (26.56 °C vs hi=20, `alarm-limit 20`) → after the window, fPort-3 frame on TTN decoding to `{total:1, alarms:[{source:"temperature", event:"activate", side:"hi", threshold:20, value:26.56, time:…}]}`. ✅
- **Pending (physical trigger):** multi-record window (threshold + hall/input together) and `alarm-limit 0` single-record path — bench.

Note: #27 was labelled v1.5.0; lands in v1.4.0 per decision (relabel).