### PR TITLE
app_alarm: protobuf AlarmReport for fPort-3 alarm detail (#27)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -687,48 +687,76 @@ function decodeDownlink(input) {
   return { data: { bytes_hex: _pbBytesToHex(input.bytes) }, warnings: [], errors: [] };
 }
 
-// fPort 3: alarm-detail batch (#27). Header [total u8][base_unix u32 LE] then
-// records [hdr u8: source<<3 | side<<1 | active][rel_s u16][threshold i16]
-// [value i16][hyst i16]. threshold/value/hyst scaled like the periodic payload
-// (temp/hum ×100, pressure ×10); 0x8000 = N/A (discrete sources). Per-event
-// time = base_unix + rel_s. `total` may exceed the records present (DR-capped).
+// fPort 3: alarm-detail batch (#27), protobuf AlarmReport. Top-level fields:
+// base_time(1, varint), total(2, varint), repeated AlarmEvent events(3, len-
+// delimited). AlarmEvent: source(1), edge(2), side(3), rel_s(4) varints +
+// optional sint32 value(5). source/edge/side are the AlarmEvent_Source/Edge/Side
+// enums; value is scaled (temp/hum ×100, pressure ×10) and absent for discrete
+// sources. Per-event time = base_time + rel_s. `total` may exceed the events
+// present (some dropped to fit the data rate → truncated).
 var _ALARM_SOURCES = ["hall-left", "hall-right", "pir", "input-a", "input-b",
   "temperature", "humidity", "pressure", "t1-temperature", "t2-temperature"];
-var _ALARM_SIDES = ["na", "lo", "hi"];
-var _ALARM_SENTINEL = 0x8000;
+var _ALARM_EDGES = ["activate", "deactivate"];
+var _ALARM_SIDES = ["none", "lo", "hi"];
 
 function _alarmUnscale(source, raw) {
-  if (raw === _ALARM_SENTINEL) return null;
-  var v = raw > 0x7fff ? raw - 0x10000 : raw; // int16
-  return source === 7 ? v / 10 : v / 100;     // 7 = pressure (hPa×10)
+  return source === 7 ? raw / 10 : raw / 100; // 7 = pressure (hPa×10)
+}
+
+function _decodeAlarmEvent(bytes, start, end) {
+  var ev = { source: 0, edge: 0, side: 0, rel_s: 0, value: null };
+  var p = start;
+  while (p < end) {
+    var t = _pbReadVarint(bytes, p); p = t.next;
+    var field = t.value >>> 3, wire = t.value & 0x7;
+    if (wire === 0) {
+      var v = _pbReadVarint(bytes, p); p = v.next;
+      if (field === 1) ev.source = v.value;
+      else if (field === 2) ev.edge = v.value;
+      else if (field === 3) ev.side = v.value;
+      else if (field === 4) ev.rel_s = v.value;
+      else if (field === 5) ev.value = _pbZigzag(v.value);
+    } else if (wire === 2) {
+      var l = _pbReadVarint(bytes, p); p = l.next + l.value;
+    } else { break; }
+  }
+  return ev;
 }
 
 function decodeAlarmBatch(bytes) {
-  if (bytes.length < 5) return { total: 0, base_time: 0, alarms: [] };
-  var total = bytes[0];
-  var base = (bytes[1] | (bytes[2] << 8) | (bytes[3] << 16) | (bytes[4] << 24)) >>> 0;
-  var out = { total: total, base_time: base, alarms: [] };
-  var p = 5;
-  while (p + 9 <= bytes.length) {
-    var hdr = bytes[p++];
-    var source = hdr >> 3;
-    var side = (hdr >> 1) & 0x3;
-    var active = (hdr & 1) !== 0;
-    var rel = bytes[p] | (bytes[p + 1] << 8); p += 2;
-    var thr = bytes[p] | (bytes[p + 1] << 8); p += 2;
-    var val = bytes[p] | (bytes[p + 1] << 8); p += 2;
-    var hyst = bytes[p] | (bytes[p + 1] << 8); p += 2;
-    out.alarms.push({
-      source: _ALARM_SOURCES[source] || ("src" + source),
-      event: active ? "activate" : "deactivate",
-      side: _ALARM_SIDES[side] || "na",
-      threshold: _alarmUnscale(source, thr),
-      value: _alarmUnscale(source, val),
-      hysteresis: _alarmUnscale(source, hyst),
-      time: (base + rel) >>> 0,
-    });
+  var out = { base_time: 0, total: 0, alarms: [] };
+  var rels = [];
+  var pos = 0;
+  while (pos < bytes.length) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var field = tag.value >>> 3, wire = tag.value & 0x7;
+    if (wire === 0) {
+      var v = _pbReadVarint(bytes, pos); pos = v.next;
+      if (field === 1) out.base_time = v.value >>> 0;
+      else if (field === 2) out.total = v.value;
+    } else if (wire === 2) {
+      var len = _pbReadVarint(bytes, pos); pos = len.next;
+      var endE = pos + len.value;
+      if (field === 3) {
+        var ev = _decodeAlarmEvent(bytes, pos, endE);
+        out.alarms.push({
+          source: _ALARM_SOURCES[ev.source] || ("src" + ev.source),
+          event: _ALARM_EDGES[ev.edge] || "activate",
+          side: _ALARM_SIDES[ev.side] || "none",
+          value: ev.value === null ? null : _alarmUnscale(ev.source, ev.value),
+          time: 0,
+        });
+        rels.push(ev.rel_s);
+      }
+      pos = endE;
+    } else { break; }
   }
-  out.truncated = out.alarms.length < total; // some alarms dropped to fit the DR
+  // base_time (field 1) precedes events (field 3) on the wire, but resolve the
+  // per-event times after the loop so order can't bite us.
+  for (var i = 0; i < out.alarms.length; i++) {
+    out.alarms[i].time = (out.base_time + rels[i]) >>> 0;
+  }
+  out.truncated = out.alarms.length < out.total; // some alarms dropped to fit the DR
   return out;
 }
 

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -164,26 +164,32 @@ test("history sentinel values decode to null", () => {
   assert.equal(rec.humidity, null);    // 0xff sentinel
 });
 
-// --- Uplink: alarm-detail batch (fPort 3, #27) ----------------------------
-function leU16(v) { return [v & 0xff, (v >> 8) & 0xff]; }
-function leI16(v) { const u = v < 0 ? v + 0x10000 : v; return [u & 0xff, (u >> 8) & 0xff]; }
-function leU32(v) { return [v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >>> 24) & 0xff]; }
-function alarmRec(source, side, active, rel, thr, val, hyst) {
-  return [(source << 3) | (side << 1) | (active ? 1 : 0)]
-    .concat(leU16(rel)).concat(leI16(thr)).concat(leI16(val)).concat(leI16(hyst));
+// --- Uplink: alarm-detail batch (fPort 3, #27, protobuf AlarmReport) -------
+// AlarmReport{ base_time(1), total(2), repeated AlarmEvent events(3) };
+// AlarmEvent{ source(1), edge(2), side(3), rel_s(4), optional sint32 value(5) }.
+// proto3 omits zero fields — the builders mirror that so default-to-0 decoding
+// (activate / side none / hall-left source) is exercised.
+function pbSint(tag, v) { return pbTV(tag, v < 0 ? -v * 2 - 1 : v * 2); }
+function alarmEvent(source, edge, side, rel, value) {
+  let e = [];
+  if (source) e = e.concat(pbTV(1, source));
+  if (edge) e = e.concat(pbTV(2, edge));
+  if (side) e = e.concat(pbTV(3, side));
+  if (rel) e = e.concat(pbTV(4, rel));
+  if (value !== null && value !== undefined) e = e.concat(pbSint(5, value));
+  return e;
 }
-function buildAlarmFrame(total, base, recs) {
-  let b = [total & 0xff].concat(leU32(base));
-  for (const r of recs) b = b.concat(r);
+function buildAlarmReport(base, total, events) {
+  let b = pbTV(1, base).concat(pbTV(2, total));
+  for (const e of events) b = b.concat(pbLD(3, e));
   return b;
 }
-const SENT = 0x8000; // discrete N/A sentinel
 
 test("decodeUplink decodes an fPort-3 alarm batch (threshold + discrete)", () => {
   const base = 1780000000;
-  const f = buildAlarmFrame(2, base, [
-    alarmRec(5, 2, true, 10, 2000, 2660, 0),    // temperature, HI, activate, 20→26.6 °C
-    alarmRec(0, 0, true, 15, SENT, SENT, SENT), // hall-left, discrete activate
+  const f = buildAlarmReport(base, 2, [
+    alarmEvent(5, 0, 2, 10, 2660), // temperature, activate, HI, 26.6 °C
+    alarmEvent(0, 0, 0, 15, null), // hall-left, activate, side none, discrete
   ]);
   const d = codec.decodeUplink({ bytes: f, fPort: 3 }).data;
 
@@ -195,19 +201,19 @@ test("decodeUplink decodes an fPort-3 alarm batch (threshold + discrete)", () =>
   assert.equal(d.alarms[0].source, "temperature");
   assert.equal(d.alarms[0].event, "activate");
   assert.equal(d.alarms[0].side, "hi");
-  assert.equal(d.alarms[0].threshold, 20);
   assert.equal(d.alarms[0].value, 26.6);
   assert.equal(d.alarms[0].time, base + 10);
 
   assert.equal(d.alarms[1].source, "hall-left");
-  assert.equal(d.alarms[1].side, "na");
-  assert.equal(d.alarms[1].threshold, null); // sentinel → null
-  assert.equal(d.alarms[1].value, null);
+  assert.equal(d.alarms[1].event, "activate");
+  assert.equal(d.alarms[1].side, "none");
+  assert.equal(d.alarms[1].value, null); // discrete → absent
   assert.equal(d.alarms[1].time, base + 15);
 });
 
-test("fPort-3 batch: humidity deactivate + truncation flag (total > records)", () => {
-  const f = buildAlarmFrame(5, 1780000000, [alarmRec(6, 1, false, 0, 5000, 4500, 200)]);
+test("fPort-3 batch: humidity deactivate + truncation flag (total > events)", () => {
+  const base = 1780000000;
+  const f = buildAlarmReport(base, 5, [alarmEvent(6, 1, 1, 0, 4500)]);
   const d = codec.decodeUplink({ bytes: f, fPort: 3 }).data;
   assert.equal(d.total, 5);
   assert.equal(d.alarms.length, 1);
@@ -215,9 +221,17 @@ test("fPort-3 batch: humidity deactivate + truncation flag (total > records)", (
   assert.equal(d.alarms[0].source, "humidity");
   assert.equal(d.alarms[0].event, "deactivate");
   assert.equal(d.alarms[0].side, "lo");
-  assert.equal(d.alarms[0].threshold, 50);
   assert.equal(d.alarms[0].value, 45);
-  assert.equal(d.alarms[0].hysteresis, 2);
+  assert.equal(d.alarms[0].time, base);
+});
+
+test("fPort-3 batch: negative threshold value round-trips via sint zigzag", () => {
+  const base = 1780000000;
+  const f = buildAlarmReport(base, 1, [alarmEvent(5, 0, 1, 5, -1234)]); // temp -12.34 °C
+  const d = codec.decodeUplink({ bytes: f, fPort: 3 }).data;
+  assert.equal(d.alarms[0].source, "temperature");
+  assert.equal(d.alarms[0].side, "lo");
+  assert.equal(d.alarms[0].value, -12.34);
 });
 
 // --- Negative: a corrupted frame must change the result (tests are sensitive) ---

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -5,6 +5,7 @@
  */
 
 #include "app_alarm.h"
+#include "app_cmd.h"
 #include "app_config.h"
 #include "app_log.h"
 #include "app_lrw.h"
@@ -19,7 +20,6 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
 /* Standard includes */
@@ -40,33 +40,27 @@ K_MUTEX_DEFINE(m_lock);
 
 /* ---- Alarm-detail batch on fPort 3 (#27) -------------------------------- */
 
-/* Threshold side crossed (encoded in the fPort-3 record header). */
-#define ALARM_SIDE_NA 0
-#define ALARM_SIDE_LO 1
-#define ALARM_SIDE_HI 2
+/* Threshold side crossed (AlarmEvent.Side wire values). */
+#define ALARM_SIDE_NONE 0
+#define ALARM_SIDE_LO   1
+#define ALARM_SIDE_HI   2
 
-#define ALARM_VALUE_SENTINEL ((int16_t)0x8000) /* discrete records: no threshold/value */
-
-/* One collected alarm edge. threshold/value/hyst are already scaled to the
- * sensor's wire units (temp/hum ×100, pressure ×10); sentinel for discrete. */
-struct alarm_event {
-	uint8_t source; /* enum app_alarm_source */
-	uint8_t side;   /* ALARM_SIDE_* */
-	bool active;    /* true = activate, false = deactivate */
-	int16_t threshold;
-	int16_t value;
-	int16_t hyst;
-	uint16_t rel_s; /* seconds since the window base time */
-};
+/* Transition direction (AlarmEvent.Edge wire values). */
+#define ALARM_EDGE_ACT   0
+#define ALARM_EDGE_DEACT 1
 
 #define ALARM_BATCH_MAX 8 /* records held per window; overflow counted in m_window_total */
 
-static struct alarm_event m_batch[ALARM_BATCH_MAX];
+/* Collected edges, ready to hand to app_cmd_build_alarm_report() verbatim. */
+static struct app_cmd_alarm_event m_batch[ALARM_BATCH_MAX];
 static uint8_t m_batch_count;
 static uint16_t m_window_total; /* all alarms in the window (may exceed m_batch_count) */
 static uint32_t m_window_base_unix;
 static int64_t m_window_start_ms;
 static bool m_window_open;
+/* Side latched when a threshold activates, reused so the deactivate edge keeps
+ * the same hi/lo (the deactivate condition itself doesn't know which bound). */
+static uint8_t m_alarm_side[APP_ALARM_SOURCE_COUNT];
 static struct k_work_delayable m_alarm_batch_work;
 
 static const char *const m_source_names[APP_ALARM_SOURCE_COUNT] = {
@@ -117,9 +111,7 @@ static void alarm_lrw_send(void)
 #endif /* defined(CONFIG_LORAWAN) */
 }
 
-#define ALARM_FRAME_MAX  64 /* fPort-3 frame buffer (matches app_lrw pending slot) */
-#define ALARM_RECORD_LEN 9  /* hdr + rel_s + threshold + value + hyst */
-#define ALARM_HEADER_LEN 5  /* total_count(1) + base_unix(4) */
+#define ALARM_FRAME_MAX 64 /* fPort-3 frame buffer (matches app_lrw pending slot) */
 
 static uint32_t now_unix_or_uptime(void)
 {
@@ -132,9 +124,11 @@ static uint32_t now_unix_or_uptime(void)
 	return (uint32_t)(k_uptime_get() / 1000);
 }
 
-/* Encode the collected batch into the fPort-3 frame and hand it to app_lrw.
- * Records are capped to the current DR budget; m_window_total still reports the
- * true count so the backend knows if some were dropped. Caller holds m_lock. */
+/* Encode the collected batch into an AlarmReport (fPort 3) and hand it to
+ * app_lrw. Events are trimmed to the current DR budget by retrying the encode
+ * with fewer events; m_window_total still reports the true count so the backend
+ * knows some were dropped (decoder: truncated = events < total). Caller holds
+ * m_lock. */
 static void alarm_batch_flush(void)
 {
 	if (m_batch_count == 0) {
@@ -143,8 +137,6 @@ static void alarm_batch_flush(void)
 		return;
 	}
 
-	uint8_t buf[ALARM_FRAME_MAX];
-	size_t pos = 0;
 	size_t cap = ALARM_FRAME_MAX;
 #if defined(CONFIG_LORAWAN)
 	uint8_t dr = app_lrw_get_max_payload();
@@ -153,32 +145,30 @@ static void alarm_batch_flush(void)
 	}
 #endif
 
-	buf[pos++] = (uint8_t)MIN(m_window_total, 0xFF);
-	sys_put_le32(m_window_base_unix, &buf[pos]);
-	pos += 4;
+	uint8_t buf[ALARM_FRAME_MAX];
+	size_t len = 0;
+	uint8_t n = m_batch_count;
+	int ret = -EMSGSIZE;
 
-	uint8_t written = 0;
-	for (uint8_t i = 0; i < m_batch_count; i++) {
-		if (pos + ALARM_RECORD_LEN > cap) {
-			break; /* DR-bounded; total_count signals the rest */
+	/* Drop the newest events first until the report fits the DR budget. */
+	while (n > 0) {
+		ret = app_cmd_build_alarm_report(m_window_base_unix, m_window_total, m_batch, n,
+						 buf, cap, &len);
+		if (ret == 0) {
+			break;
 		}
-		struct alarm_event *e = &m_batch[i];
-		buf[pos++] = (uint8_t)((e->source << 3) | (e->side << 1) | (e->active ? 1 : 0));
-		sys_put_le16(e->rel_s, &buf[pos]);
-		pos += 2;
-		sys_put_le16((uint16_t)e->threshold, &buf[pos]);
-		pos += 2;
-		sys_put_le16((uint16_t)e->value, &buf[pos]);
-		pos += 2;
-		sys_put_le16((uint16_t)e->hyst, &buf[pos]);
-		pos += 2;
-		written++;
+		n--;
 	}
 
+	if (ret == 0) {
 #if defined(CONFIG_LORAWAN)
-	(void)app_lrw_send_alarm(buf, pos);
+		(void)app_lrw_send_alarm(buf, len);
 #endif
-	LOG_INF("Alarm batch: %u/%u records on fPort 3", written, m_window_total);
+		LOG_INF("Alarm batch: %u/%u events on fPort 3 (%u B)", n, m_window_total,
+			(unsigned)len);
+	} else {
+		LOG_ERR_CALL_FAILED_INT("app_cmd_build_alarm_report", ret);
+	}
 
 	m_batch_count = 0;
 	m_window_total = 0;
@@ -194,15 +184,23 @@ static void alarm_batch_work_handler(struct k_work *work)
 }
 
 /* Record one alarm edge for the fPort-3 detail batch (#27). Threshold sources
- * pass scaled threshold/value/hyst; discrete sources pass sentinels + side N/A.
- * With alarm_limit == 0 the record is sent immediately as a 1-record frame;
- * otherwise it joins the current collection window (opened on the first edge,
- * flushed by m_alarm_batch_work after alarm_limit seconds). */
-static void alarm_collect(uint8_t source, bool active, uint8_t side, int16_t threshold,
-			  int16_t value, int16_t hyst)
+ * pass has_value=true with the scaled current value; discrete sources pass
+ * has_value=false + side none. With alarm_limit == 0 the event is sent
+ * immediately as a 1-event report; otherwise it joins the current collection
+ * window (opened on the first edge, flushed by m_alarm_batch_work after
+ * alarm_limit seconds). */
+static void alarm_collect(uint8_t source, bool active, uint8_t side, bool has_value, int32_t value)
 {
 	int limit = g_app_config.alarm_limit;
 	int64_t now = k_uptime_get();
+	struct app_cmd_alarm_event ev = {
+		.source = source,
+		.edge = active ? ALARM_EDGE_ACT : ALARM_EDGE_DEACT,
+		.side = side,
+		.has_value = has_value,
+		.value = value,
+		.rel_s = 0,
+	};
 
 	k_mutex_lock(&m_lock, K_FOREVER);
 
@@ -210,7 +208,7 @@ static void alarm_collect(uint8_t source, bool active, uint8_t side, int16_t thr
 		m_window_base_unix = now_unix_or_uptime();
 		m_window_total = 1;
 		m_batch_count = 1;
-		m_batch[0] = (struct alarm_event){source, side, active, threshold, value, hyst, 0};
+		m_batch[0] = ev;
 		alarm_batch_flush();
 		k_mutex_unlock(&m_lock);
 		return;
@@ -227,9 +225,8 @@ static void alarm_collect(uint8_t source, bool active, uint8_t side, int16_t thr
 
 	m_window_total++;
 	if (m_batch_count < ALARM_BATCH_MAX) {
-		uint16_t rel = (uint16_t)MIN((now - m_window_start_ms) / 1000, 0xFFFF);
-		m_batch[m_batch_count++] =
-			(struct alarm_event){source, side, active, threshold, value, hyst, rel};
+		ev.rel_s = (uint32_t)MIN((now - m_window_start_ms) / 1000, 0xFFFF);
+		m_batch[m_batch_count++] = ev;
 	}
 
 	k_mutex_unlock(&m_lock);
@@ -263,26 +260,28 @@ static int read_notify_bools(enum app_alarm_source source, bool *act, bool *deac
 	}
 }
 
-/* Per-source wire scaling for the fPort-3 detail (threshold sources only): temp
- * and humidity ×100, pressure already hPa×10 from the poll call. */
-static int16_t alarm_scale(enum app_alarm_source source, float v)
+/* Per-source wire scaling for the fPort-3 detail value (threshold sources only):
+ * temp and humidity ×100, pressure already hPa×10 from the poll call. */
+static int32_t alarm_scale(enum app_alarm_source source, float v)
 {
 	switch (source) {
 	case APP_ALARM_SOURCE_TEMPERATURE:
 	case APP_ALARM_SOURCE_T1_TEMPERATURE:
 	case APP_ALARM_SOURCE_T2_TEMPERATURE:
 	case APP_ALARM_SOURCE_HUMIDITY:
-		return (int16_t)lroundf(v * 100.0f);
+		return (int32_t)lroundf(v * 100.0f);
 	case APP_ALARM_SOURCE_PRESSURE:
-		return (int16_t)lroundf(v);
+		return (int32_t)lroundf(v);
 	default:
-		return ALARM_VALUE_SENTINEL;
+		return 0;
 	}
 }
 
 /* Evaluate one threshold with hysteresis. Latches into m_alarm_active[source],
- * sets *should_send on every edge, and records the edge (source/side/threshold/
- * value/hysteresis) for the fPort-3 detail batch. Returns the latched state. */
+ * sets *should_send on every edge, and records the edge (source/edge/side +
+ * scaled current value) for the fPort-3 detail batch. The deactivate edge
+ * carries the side latched at activation (m_alarm_side). Returns the latched
+ * state. */
 static bool eval_threshold(enum app_alarm_source source, bool enabled, float value, float lo,
 			   float hi, float hst, bool *should_send)
 {
@@ -298,21 +297,21 @@ static bool eval_threshold(enum app_alarm_source source, bool enabled, float val
 			LOG_INF("Deactivated alarm for %s", app_alarm_source_name(source));
 			*active = false;
 			*should_send = true;
-			alarm_collect(source, false, ALARM_SIDE_NA, ALARM_VALUE_SENTINEL,
-				      alarm_scale(source, value), alarm_scale(source, hst));
+			alarm_collect(source, false, m_alarm_side[source], true,
+				      alarm_scale(source, value));
 		}
 	} else if (value < lo - hst) {
 		LOG_INF("Activated alarm for %s (lo)", app_alarm_source_name(source));
 		*active = true;
 		*should_send = true;
-		alarm_collect(source, true, ALARM_SIDE_LO, alarm_scale(source, lo),
-			      alarm_scale(source, value), alarm_scale(source, hst));
+		m_alarm_side[source] = ALARM_SIDE_LO;
+		alarm_collect(source, true, ALARM_SIDE_LO, true, alarm_scale(source, value));
 	} else if (value > hi + hst) {
 		LOG_INF("Activated alarm for %s (hi)", app_alarm_source_name(source));
 		*active = true;
 		*should_send = true;
-		alarm_collect(source, true, ALARM_SIDE_HI, alarm_scale(source, hi),
-			      alarm_scale(source, value), alarm_scale(source, hst));
+		m_alarm_side[source] = ALARM_SIDE_HI;
+		alarm_collect(source, true, ALARM_SIDE_HI, true, alarm_scale(source, value));
 	}
 
 	return *active;
@@ -421,9 +420,8 @@ void app_alarm_event(enum app_alarm_source source, bool active)
 
 	if (send) {
 		alarm_lrw_send();
-		/* Discrete sources have no threshold/value — sentinels, side N/A. */
-		alarm_collect(source, active, ALARM_SIDE_NA, ALARM_VALUE_SENTINEL,
-			      ALARM_VALUE_SENTINEL, ALARM_VALUE_SENTINEL);
+		/* Discrete sources have no value — side none, value absent. */
+		alarm_collect(source, active, ALARM_SIDE_NONE, false, 0);
 	}
 
 	if (cb) {

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -466,3 +466,37 @@ int app_cmd_build_history_frame(uint32_t seq, uint32_t frame_index, uint32_t fra
 	return 0;
 }
 #endif /* APP_CMD_HAVE_HISTORY */
+
+int app_cmd_build_alarm_report(uint32_t base_time, uint32_t total,
+			       const struct app_cmd_alarm_event *events, size_t n_events,
+			       uint8_t *out, size_t out_cap, size_t *out_len)
+{
+	if (!out || !out_len || (n_events > 0 && !events)) {
+		return -EINVAL;
+	}
+
+	AlarmReport report = AlarmReport_init_zero;
+	report.base_time = base_time;
+	report.total = total;
+
+	size_t n = MIN(n_events, ARRAY_SIZE(report.events));
+	for (size_t i = 0; i < n; i++) {
+		AlarmEvent *ev = &report.events[i];
+		ev->source = (AlarmEvent_Source)events[i].source;
+		ev->edge = (AlarmEvent_Edge)events[i].edge;
+		ev->side = (AlarmEvent_Side)events[i].side;
+		ev->rel_s = events[i].rel_s;
+		ev->has_value = events[i].has_value;
+		ev->value = events[i].value;
+	}
+	report.events_count = (pb_size_t)n;
+
+	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
+	if (!pb_encode(&ostream, AlarmReport_fields, &report)) {
+		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
+		return -EMSGSIZE;
+	}
+
+	*out_len = ostream.bytes_written;
+	return 0;
+}

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -8,6 +8,7 @@
 #define APP_CMD_H_
 
 /* Standard includes */
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -63,6 +64,28 @@ int app_cmd_build_history_frame(uint32_t seq, uint32_t frame_index, uint32_t fra
 				uint32_t t0_unix, uint32_t present, uint32_t interval_s,
 				const uint8_t *samples, size_t samples_len, uint8_t *out,
 				size_t out_cap, size_t *out_len);
+
+/* One alarm edge for app_cmd_build_alarm_report(). source/edge/side carry the
+ * AlarmEvent_Source/Edge/Side enum values (app_alarm fills these without
+ * including the nanopb header). value is the scaled current reading and is only
+ * meaningful when has_value is true (discrete sources leave it absent). */
+struct app_cmd_alarm_event {
+	uint8_t source; /* AlarmEvent_Source / enum app_alarm_source */
+	uint8_t edge;   /* AlarmEvent_Edge: 0=activate, 1=deactivate */
+	uint8_t side;   /* AlarmEvent_Side: 0=none, 1=lo, 2=hi */
+	bool has_value; /* value present (threshold sources) */
+	int32_t value;  /* scaled current value (×100 temp/hum, ×10 pressure) */
+	uint32_t rel_s; /* seconds since base_time */
+};
+
+/* Build an alarm-detail batch (AlarmReport) for fPort 3 (#27) into `out`.
+ * `events[0..n_events)` are encoded (capped to the message's 8-event array);
+ * `total` is the true window count and may exceed the encoded events when the
+ * caller trimmed to fit the data rate. Returns 0 with *out_len set, -EINVAL on
+ * a NULL argument, or -EMSGSIZE if it won't fit `out_cap`. */
+int app_cmd_build_alarm_report(uint32_t base_time, uint32_t total,
+			       const struct app_cmd_alarm_event *events, size_t n_events,
+			       uint8_t *out, size_t out_cap, size_t *out_len);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_config.options.in
+++ b/app/src/app_config.options.in
@@ -11,6 +11,10 @@ AppConfigMessage.Lorawan.appskey max_length:32
 Response.Error.detail       max_size:32
 Response.HistoryFrame.samples max_size:48
 
+# Alarm-detail batch (fPort 3, #27). 8 events fit the smallest practical DR; the
+# encoder further caps by the live payload budget.
+AlarmReport.events max_count:8
+
 # GetParam field-id lists as static arrays (no nanopb callback). A batch is
 # bounded by the LoRaWAN downlink size anyway, so 16 ids each is plenty.
 Command.GetParam.lorawan_field     max_count:16

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -208,6 +208,58 @@ message Response {
     }
 }
 
+// Alarm-detail batch, sent on fPort 3 (#27). Alarm edges (threshold + discrete)
+// collected over one alarm_limit window are reported as a list; each event names
+// its source, transition and (for thresholds) bound, plus a time offset and the
+// current value. base_time is the window start (unix, or uptime-s before the RTC
+// syncs); per-event time = base_time + rel_s. total counts every alarm in the
+// window and may exceed events[] when records are dropped to fit the data rate.
+message AlarmReport {
+    uint32 base_time = 1;
+    uint32 total     = 2;
+    repeated AlarmEvent events = 3;
+}
+
+message AlarmEvent {
+    // An alarm edge described by three orthogonal enums instead of one combined
+    // flag: which sensor (source), the transition (edge), and — for thresholds —
+    // which bound was crossed (side). Discrete sources (hall/input/PIR) report
+    // SIDE_NONE; PIR is activate-only.
+
+    // Sensor that raised the event. Values match enum app_alarm_source 1:1.
+    enum Source {
+        HALL_LEFT      = 0;
+        HALL_RIGHT     = 1;
+        PIR_MOTION     = 2;
+        INPUT_A        = 3;
+        INPUT_B        = 4;
+        TEMPERATURE    = 5;
+        HUMIDITY       = 6;
+        PRESSURE       = 7;
+        T1_TEMPERATURE = 8;
+        T2_TEMPERATURE = 9;
+    }
+
+    // Transition direction. ACTIVATE = 0 so the common case omits the field.
+    enum Edge {
+        ACTIVATE   = 0;
+        DEACTIVATE = 1;
+    }
+
+    // Which threshold bound was crossed; SIDE_NONE for discrete sources.
+    enum Side {
+        SIDE_NONE = 0;
+        SIDE_LO   = 1;
+        SIDE_HI   = 2;
+    }
+
+    Source source = 1;           // which sensor
+    Edge   edge   = 2;           // activate / deactivate
+    Side   side   = 3;           // hi / lo / none
+    uint32 rel_s  = 4;           // seconds since AlarmReport.base_time
+    optional sint32 value = 5;   // current value, scaled (×100 temp/hum, ×10 pressure); absent for discrete
+}
+
 // Periodic / event-triggered telemetry uplink, sent on fPort 2 (legacy bitmap
 // stays on fPort 1). Fields are grouped per sensor; each group's boolean state
 // lives in its own `*_flags` field so a sensor's data stays together as an

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -70,11 +70,71 @@ The decoded field set (voltage, temperature, humidity, pressure/altitude, illumi
 
 ## 3. Alarm-detail batch on fPort 3 (NEW)
 
-When alarms occur, the device sends a batch of alarm events on **fPort 3**. Decoded fields:
+When alarms occur, the device sends a batch of alarm events on **fPort 3** as a **protobuf `AlarmReport`** (same wire family as the fPort-2 telemetry and the fPort-85 responses), so it decodes with the generated codec rather than a packed byte layout.
 
-- `total` — total alarms in the window (may exceed the records carried if rate-limited); `truncated` flags this.
-- `base_time` — Unix timestamp the records are relative to.
-- `alarms[]` — each with `source` (`temperature` / `humidity` / `pressure` / `t1-temperature` / `t2-temperature` / `hall-left` / `hall-right` / `pir` / `input-a` / `input-b`), `event` (`activate` / `deactivate`), `side` (`lo` / `hi` / `na`), `threshold` / `value` / `hysteresis` (sensor units; `null` for discrete sources), and `time`.
+### Message
+
+```proto
+message AlarmReport {
+    uint32 base_time = 1;            // Unix time the events are relative to (uptime-s until the clock syncs)
+    uint32 total     = 2;            // every alarm in the window (may exceed events[] if trimmed)
+    repeated AlarmEvent events = 3;  // up to 8, further trimmed to the data-rate budget
+}
+message AlarmEvent {
+    Source source = 1;               // which sensor
+    Edge   edge   = 2;               // ACTIVATE / DEACTIVATE
+    Side   side   = 3;               // SIDE_NONE / SIDE_LO / SIDE_HI
+    uint32 rel_s  = 4;               // seconds since base_time
+    optional sint32 value = 5;       // current reading, scaled; absent for discrete sources
+}
+```
+
+Each event is described by **three orthogonal enums** — an integration that only wants "did `hall-left` activate?" or "did `temperature` cross its high bound?" reads one field instead of unpacking a combined flag.
+
+### Decoded fields (`ttn.js`)
+
+- `base_time` — Unix timestamp the events are relative to.
+- `total` — total alarms that occurred in the window. `truncated` is `true` when `total` exceeds the events actually carried (some were dropped to fit the data rate).
+- `alarms[]` — each with:
+  - `source` — `temperature` / `humidity` / `pressure` / `t1-temperature` / `t2-temperature` / `hall-left` / `hall-right` / `pir` / `input-a` / `input-b`
+  - `event` — `activate` / `deactivate`
+  - `side` — `hi` / `lo` for threshold sources, `none` for discrete sources (hall/input/PIR). The **deactivate** edge keeps the side that was crossed on activation.
+  - `value` — the current reading at the edge (temperature/humidity in °C/%RH, pressure in hPa); `null` for discrete sources. *(Threshold and hysteresis are not carried — they are the device's own configuration.)*
+  - `time` — `base_time + rel_s` (per-event Unix time)
+
+### When the messages are sent (fPort 2 vs fPort 3)
+
+An alarm edge produces **two independent uplinks**:
+
+| Port | Content | Timing |
+|---|---|---|
+| **fPort 2** | a normal telemetry snapshot (current sensor values) | **immediately** on the first edge, so the backend sees fresh values at once |
+| **fPort 3** | the `AlarmReport` with the list of edges collected during the window | **at the end of the collection window** (`alarm-limit` seconds after the first edge) |
+
+The collection window is **shared across all sources**: the first edge opens it, and every edge during the window (any sensor, both activate and deactivate) accumulates into **one** `AlarmReport`. The immediate fPort-2 telemetry is **rate-limited to once per window** (`alarm-limit`, see §7) — the first edge sends it, later edges in the same window only add to the batch. Periodic telemetry continues on its own `interval_report` cadence.
+
+**Example — temperature crosses its high threshold** (`alarm-limit = 20 s`):
+
+```
+t = 0 s    threshold crossed → fPort 2 telemetry (immediate); 20 s window opens
+t ≈ 20 s   window flushes → fPort 3 AlarmReport
+           { total:1, alarms:[{ source:"temperature", event:"activate", side:"hi", value:26.5, time:base }] }
+```
+
+When the temperature later falls back below the band, the deactivate edge behaves the same way (immediate fPort-2 if the rate-limit has elapsed, then `event:"deactivate", side:"hi"` in the next window's fPort-3).
+
+**Example — a hall sensor is activated then deactivated within one window:**
+
+```
+t = 0 s    magnet applied   → hall-left activate   → fPort 2 (immediate); window opens
+t = 8 s    magnet removed   → hall-left deactivate → batched (fPort-2 suppressed by rate-limit)
+t ≈ 20 s   window flushes   → fPort 3 AlarmReport {
+             total:2, alarms:[
+               { source:"hall-left", event:"activate",   side:"none", value:null, time:base+0 },
+               { source:"hall-left", event:"deactivate", side:"none", value:null, time:base+8 } ] }
+```
+
+> Hall/input/PIR edges are only raised (and only collected) when their `*-notify-act` / `*-notify-deact` configuration is enabled and the sensor's `cap-*` capability is on. With `alarm-limit = 0` there is no window: each edge is sent immediately as its own one-event fPort-3 frame and the fPort-2 telemetry is not rate-limited.
 
 ---
 


### PR DESCRIPTION
Converts the fPort-3 alarm-detail payload from the packed binary format (PR #70) to a **protobuf `AlarmReport`**, matching the project's other wire formats (`Telemetry`, `Response`, `HistoryFrame`). External integrations now decode it with the generated codec instead of parsing a packed header byte.

### What changed vs #70
Each event is described by **three orthogonal enums** instead of one combined flag:

- `source` — `AlarmEvent.Source` (TEMPERATURE, HUMIDITY, HALL_LEFT, …; values match `enum app_alarm_source` 1:1)
- `edge` — `AlarmEvent.Edge` (`ACTIVATE` / `DEACTIVATE`)
- `side` — `AlarmEvent.Side` (`SIDE_NONE` / `SIDE_LO` / `SIDE_HI`)

plus `rel_s` (offset from `base_time`) and an `optional sint32 value` (scaled current reading; absent for discrete sources). Threshold bound and hysteresis are dropped from the wire. The deactivate edge carries the side latched at activation (`m_alarm_side`).

```proto
message AlarmReport {
    uint32 base_time = 1;
    uint32 total     = 2;            // true window count (may exceed events[] -> truncated)
    repeated AlarmEvent events = 3;  // max_count 8, further trimmed to the DR budget
}
message AlarmEvent {
    Source source = 1; Edge edge = 2; Side side = 3;
    uint32 rel_s = 4; optional sint32 value = 5;
}
```

### Implementation
- **app_cmd**: `app_cmd_build_alarm_report()` encodes the `AlarmReport`; `app_alarm` fills a plain `struct app_cmd_alarm_event`, keeping the nanopb header out of `app_alarm`.
- **app_alarm**: events trimmed to the DR budget by retrying the encode with fewer events; `total` still reports the true count (decoder derives `truncated = events < total`).
- **ttn.js**: `decodeAlarmBatch` parses the protobuf `AlarmReport`; tests rewritten + a negative-value sint round-trip case.

### Verification
- Release + debug builds clean; `node --test` (12) + native_sim `cmd`/`compose`/`history` green; clang-format (18.1.8) clean.
- **HW + TTN end-to-end** (device `eui-58760702772bc3ab`, temperature+humidity hi thresholds + hall edges). Real frames captured from the TTN storage API and decoded with this `ttn.js`:

`08b2c387d10610051a001a0908051802200228b0291a0908061802200228fe711a04080120171a0608011001201b` (46 B):
```json
{ "base_time": 1780605362, "total": 5, "truncated": false, "alarms": [
  { "source": "hall-left",   "event": "activate",   "side": "none", "value": null,  "time": 1780605362 },
  { "source": "temperature", "event": "activate",   "side": "hi",   "value": 26.48, "time": 1780605364 },
  { "source": "humidity",    "event": "activate",   "side": "hi",   "value": 72.95, "time": 1780605364 },
  { "source": "hall-right",  "event": "activate",   "side": "none", "value": null,  "time": 1780605385 },
  { "source": "hall-right",  "event": "deactivate", "side": "none", "value": null,  "time": 1780605389 }
] }
```

`08a7c487d10610031a001a0908051802200228bc291a0908061802200228a473` (32 B):
```json
{ "base_time": 1780605479, "total": 3, "truncated": false, "alarms": [
  { "source": "hall-left",   "event": "activate", "side": "none", "value": null,  "time": 1780605479 },
  { "source": "temperature", "event": "activate", "side": "hi",   "value": 26.54, "time": 1780605481 },
  { "source": "humidity",    "event": "activate", "side": "hi",   "value": 73.78, "time": 1780605481 }
] }
```

`08bec487d10610011a020801` (12 B):
```json
{ "base_time": 1780605502, "total": 1, "truncated": false, "alarms": [
  { "source": "hall-right", "event": "activate", "side": "none", "value": null, "time": 1780605502 }
] }
```

Frame sizes match the device log (`Alarm batch: 3/3 events on fPort 3 (32 B)`, `1/1 events (12 B)`), confirming the on-device encoder and `ttn.js` agree byte-exact.

Supersedes the packed fPort-3 from #70. TTN payload formatter being uploaded for live decoding.

Closes #27.