### PR TITLE
Fix flash map: image overlapped NVS storage — settings save bricked the device

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -18,6 +18,13 @@ CONFIG_FLASH=y
 CONFIG_FLASH_MAP=y
 CONFIG_SETTINGS=y
 
+# Image size budget — must equal the storage_partition offset (sticker.dts).
+# The flat image must never grow into the NVS storage area: NVS (settings +
+# LoRaWAN NVM) erases/rewrites those sectors at runtime, corrupting the image
+# in flash → hard fault on next boot, recoverable only by mass erase. With
+# this set, the linker fails the build instead ("region ROM overflowed").
+CONFIG_FLASH_LOAD_SIZE=0x3C000
+
 CONFIG_LORA=y
 CONFIG_LORAMAC_REGION_AU915=y
 CONFIG_LORAMAC_REGION_EU868=y

--- a/boards/sticker/sticker.dts
+++ b/boards/sticker/sticker.dts
@@ -17,7 +17,7 @@
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
+		zephyr,code-partition = &code_partition;
 	};
 
 	leds {
@@ -216,20 +216,19 @@ stm32_lp_tick_source: &lptim1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(32)>;
+		/* Flat application image from the flash base — no bootloader is
+		 * active today (a future MCUboot/FUOTA layout redesigns this map).
+		 * The image is linked against this region via
+		 * CONFIG_FLASH_LOAD_SIZE (prj.conf), which must equal the
+		 * storage_partition offset: NVS (settings + LoRaWAN NVM) erases
+		 * and rewrites its sectors at runtime, so an image leaking into
+		 * it is corrupted in flash and the device hard-faults on the
+		 * next boot (recoverable only by mass erase).
+		 */
+		code_partition: partition@0 {
+			label = "code";
+			reg = <0x00000000 DT_SIZE_K(240)>;
 			read-only;
-		};
-
-		slot0_partition: partition@8000 {
-			label = "image-0";
-			reg = <0x00008000 DT_SIZE_K(104)>;
-		};
-
-		slot1_partition: partition@22000 {
-			label = "image-1";
-			reg = <0x00022000 DT_SIZE_K(104)>;
 		};
 
 		storage_partition: partition@3c000 {


### PR DESCRIPTION
## Problem

Devices brick after any `settings save` (and eventually after LoRaWAN NVM writes, which `CONFIG_LORAWAN_NVM_SETTINGS=y` performs automatically after joins/uplinks): the device hard-faults on the next boot before console init — no LED, empty RTT, IWDG not yet started — and only a mass erase recovers it.

## Root cause

The application links as a flat image from the flash base, and nothing bounded its size against the partition map. The debug image grew past `0x3C000` (`storage_partition`), so every NVS write erased/rewrote flash sectors holding the image's `.data`/kernel-object initializers (`device_states`, `log_dynamic`, `k_*_area`). The next boot copied the corrupted initializers into RAM and jumped through a garbage pointer.

Confirmed by J-Link forensics on a bricked unit:

- CPU spinning in `arch_system_halt`, `IPSR = HardFault`, IWDG never started (fault precedes `app_wdog_init`)
- `verifybin` flash-vs-build diff starting exactly at `storage_partition + 1` (662 bytes)
- an NVS settings record (`lorawan/nvm/RegionGroup1`) written over the image tail

This had been misattributed to a LIS2DH any-motion interrupt storm (#18 HW-test note); the actual correlation was config-save vs no-save, not motion sensitivity. Additionally, the release image (151.2 KB) had already crossed the old `history_partition` offset (144 KB), so enabling `history-enable` on a release build would corrupt the image the same way — a latent variant of the same bug.

## Fix

- Replace the stale MCUboot triple-slot map (no bootloader is active; the flat image already spanned boot+slot0+slot1) with the real layout: **code 240 KB + storage 16 KB** (storage offset unchanged — existing NVS content stays compatible).
- **Enforce the image budget at link time** via `CONFIG_FLASH_LOAD_SIZE=0x3C000`: an oversized image now fails the build with a linker `region FLASH overflowed` error instead of field-bricking devices.

## Verification (on HW, J-Link/RTT)

- mass erase → flash (debug 224 476 / 245 760 B) → three consecutive `settings save` reboot cycles survive, shell alive
- `verifybin` after the NVS writes: image byte-identical, NVS records confined to `storage_partition`
- the enforcement itself proven on the `accel-motion` branch, where the oversized debug image fails the link with `region FLASH overflowed by 752 bytes`

## Notes

- `accel-motion` (#75) already integrates this fix via merge and extends the map with a `history_partition` budget split (code 160 KB + history 80 KB @ 0x28000, debug relaxed to 0x3C000 with history in RAM).
- Other release-train branches will want the same treatment when they pick this up.
