### PR TITLE
telemetry: always send system + full sensor group when enabled (#78)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -344,7 +344,10 @@ function _pbZigzag(n) {
 
 // fPort 2: flat protobuf Telemetry (periodic / event-triggered report). Keys
 // match the legacy fPort-1 bitmap decoder so dashboards stay stable. Unknown
-// fields are skipped (forward-compatible with newer firmware).
+// fields are skipped (forward-compatible with newer firmware). Per #80 the
+// firmware always sends the system group and every enabled-sensor group whole,
+// so boolean fields (boot, *_is_active, *_notify_*, tilt) are surfaced as
+// explicit true/false rather than set-only-when-true.
 function decodeTelemetry(bytes) {
   var d = {};
   var pos = 0;

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -364,7 +364,7 @@ function decodeTelemetry(bytes) {
     switch (field) {
       // system
       case 1:  d.voltage = v.value / 50; break;
-      case 2:  if (v.value & (1 << 0)) d.boot = true; break;   // system_flags
+      case 2:  d.boot = (v.value & (1 << 0)) !== 0; break;     // system_flags (always sent)
       // internal (SHT4x)
       case 3:  d.temperature = _pbZigzag(v.value) / 100; break;
       case 4:  d.humidity = v.value / 2; break;
@@ -383,42 +383,42 @@ function decodeTelemetry(bytes) {
       // machine probe 1
       case 12: d.machine_probe_temperature_1 = _pbZigzag(v.value) / 100; break;
       case 13: d.machine_probe_humidity_1 = v.value / 2; break;
-      case 14: if (v.value & (1 << 0)) d.machine_probe_tilt_alert_1 = true; break;
+      case 14: d.machine_probe_tilt_alert_1 = (v.value & (1 << 0)) !== 0; break;
       // machine probe 2
       case 15: d.machine_probe_temperature_2 = _pbZigzag(v.value) / 100; break;
       case 16: d.machine_probe_humidity_2 = v.value / 2; break;
-      case 17: if (v.value & (1 << 0)) d.machine_probe_tilt_alert_2 = true; break;
+      case 17: d.machine_probe_tilt_alert_2 = (v.value & (1 << 0)) !== 0; break;
       // hall left
       case 18: d.hall_left_count = v.value; break;
       case 19:
         f = v.value;
-        if (f & (1 << 0)) d.hall_left_notify_act = true;
-        if (f & (1 << 1)) d.hall_left_notify_deact = true;
-        if (f & (1 << 2)) d.hall_left_is_active = true;
+        d.hall_left_notify_act = (f & (1 << 0)) !== 0;
+        d.hall_left_notify_deact = (f & (1 << 1)) !== 0;
+        d.hall_left_is_active = (f & (1 << 2)) !== 0;
         break;
       // hall right
       case 20: d.hall_right_count = v.value; break;
       case 21:
         f = v.value;
-        if (f & (1 << 0)) d.hall_right_notify_act = true;
-        if (f & (1 << 1)) d.hall_right_notify_deact = true;
-        if (f & (1 << 2)) d.hall_right_is_active = true;
+        d.hall_right_notify_act = (f & (1 << 0)) !== 0;
+        d.hall_right_notify_deact = (f & (1 << 1)) !== 0;
+        d.hall_right_is_active = (f & (1 << 2)) !== 0;
         break;
       // input A
       case 22: d.input_a_count = v.value; break;
       case 23:
         f = v.value;
-        if (f & (1 << 0)) d.input_a_notify_act = true;
-        if (f & (1 << 1)) d.input_a_notify_deact = true;
-        if (f & (1 << 2)) d.input_a_is_active = true;
+        d.input_a_notify_act = (f & (1 << 0)) !== 0;
+        d.input_a_notify_deact = (f & (1 << 1)) !== 0;
+        d.input_a_is_active = (f & (1 << 2)) !== 0;
         break;
       // input B
       case 24: d.input_b_count = v.value; break;
       case 25:
         f = v.value;
-        if (f & (1 << 0)) d.input_b_notify_act = true;
-        if (f & (1 << 1)) d.input_b_notify_deact = true;
-        if (f & (1 << 2)) d.input_b_is_active = true;
+        d.input_b_notify_act = (f & (1 << 0)) !== 0;
+        d.input_b_notify_deact = (f & (1 << 1)) !== 0;
+        d.input_b_is_active = (f & (1 << 2)) !== 0;
         break;
       default: break; /* unknown field: ignore (forward-compatible) */
     }

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -99,6 +99,21 @@ test("decodeUplink routes fPort 2 to the telemetry decoder", () => {
   assert.equal(typeof got.data, "object");
 });
 
+// #78: the system group and any enabled-sensor group are sent every report,
+// whole, even when the values are 0/false. The decoder must surface those as
+// explicit false/0 (not omit them). Frame: voltage=100 (field 1), system_flags=0
+// (field 2 -> boot=false), hall_left_count=0 (field 18), hall_left_flags=0
+// (field 19 -> all hall-left booleans false).
+test("decodeUplink fPort 2: zero-valued groups decode to explicit false/0", () => {
+  const got = codec.decodeUplink({ bytes: hex("08641000900100980100"), fPort: 2 }).data;
+  assert.equal(got.voltage, 2);
+  assert.equal(got.boot, false);
+  assert.equal(got.hall_left_count, 0);
+  assert.equal(got.hall_left_notify_act, false);
+  assert.equal(got.hall_left_notify_deact, false);
+  assert.equal(got.hall_left_is_active, false);
+});
+
 // --- Uplink: history replay frames (fPort 85, device-driven multi-frame) ---
 // HistoryFrame carries a shared present mask + interval_s; samples are fixed-size
 // values-only records, time(j) = t0 + j*interval. Build frames with a tiny pb

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -92,18 +92,43 @@ test("decodeUplink decodes an Ack response (fPort 85)", () => {
 });
 
 // --- Uplink: protobuf telemetry (fPort 2) ---------------------------------
-// TODO(#51): assert an exact HW telemetry frame once captured. Until then,
-// confirm the fPort-2 path is wired and returns an object without throwing.
-test("decodeUplink routes fPort 2 to the telemetry decoder", () => {
-  const got = codec.decodeUplink({ bytes: hex("0864"), fPort: 2 });
-  assert.equal(typeof got.data, "object");
+// Real HW capture (#78/#80 verification, device sticker-2162165131, 2026-06-09):
+// a non-boot report with hall-left + hall-right capabilities enabled but no
+// counts. Proves the #80 fix on the wire: the system group is always present
+// (boot=false encoded explicitly, not omitted) and an enabled sensor group is
+// sent whole even at count=0. Frame bytes:
+//   08 a8 01  voltage=168 -> 3.36 V
+//   10 00     system_flags=0 -> boot=false (present, not dropped)
+//   18 fa 24  temperature (sint zigzag) -> 23.65 degC
+//   20 6c     humidity=108 -> 54 %RH
+//   40 02     orientation=2
+//   90 01 00  hall_left_count=0          98 01 04  hall_left_flags=ACTIVE
+//   a0 01 00  hall_right_count=0         a8 01 04  hall_right_flags=ACTIVE
+test("decodeUplink fPort 2: real HW frame, system + enabled groups always present", () => {
+  const got = codec.decodeUplink({
+    bytes: hex("08a801100018fa24206c4002900100980104a00100a80104"),
+    fPort: 2,
+  }).data;
+  assert.equal(got.voltage, 3.36);
+  assert.equal(got.boot, false); // system group sent even when boot=false
+  assert.equal(got.temperature, 23.65);
+  assert.equal(got.humidity, 54);
+  assert.equal(got.orientation, 2);
+  // hall groups present in full although counts are 0 (capabilities enabled)
+  assert.equal(got.hall_left_count, 0);
+  assert.equal(got.hall_left_is_active, true);
+  assert.equal(got.hall_left_notify_act, false);
+  assert.equal(got.hall_left_notify_deact, false);
+  assert.equal(got.hall_right_count, 0);
+  assert.equal(got.hall_right_is_active, true);
+  assert.equal(got.hall_right_notify_act, false);
+  assert.equal(got.hall_right_notify_deact, false);
 });
 
-// #78: the system group and any enabled-sensor group are sent every report,
-// whole, even when the values are 0/false. The decoder must surface those as
-// explicit false/0 (not omit them). Frame: voltage=100 (field 1), system_flags=0
-// (field 2 -> boot=false), hall_left_count=0 (field 18), hall_left_flags=0
-// (field 19 -> all hall-left booleans false).
+// #78: an enabled-sensor group is sent whole even when ALL its values are 0 —
+// the decoder must surface those as explicit false/0, not omit them. Synthetic
+// frame: voltage=100 (field 1), system_flags=0 (field 2 -> boot=false),
+// hall_left_count=0 (field 18), hall_left_flags=0 (field 19 -> all false).
 test("decodeUplink fPort 2: zero-valued groups decode to explicit false/0", () => {
   const got = codec.decodeUplink({ bytes: hex("08641000900100980100"), fPort: 2 }).data;
   assert.equal(got.voltage, 2);

--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -164,16 +164,12 @@ static void fill_snapshot(void)
 	struct app_sensor_data d = g_app_sensor_data;
 	k_mutex_unlock(&g_app_sensor_data_lock);
 
-	/* system */
-	if (!isnan(d.voltage)) {
-		float v = CLAMP(d.voltage * 50.0f, 0.0f, 255.0f);
-		t.has_voltage = true;
-		t.voltage = (uint32_t)v;
-	}
-	if (system_flags) {
-		t.has_system_flags = true;
-		t.system_flags = system_flags;
-	}
+	/* system — always sent as one group; boot=false is encoded explicitly.
+	 * voltage uses 0 as a "no sample" sentinel (only the pre-sample case). */
+	t.has_voltage = true;
+	t.voltage = isnan(d.voltage) ? 0 : (uint32_t)CLAMP(d.voltage * 50.0f, 0.0f, 255.0f);
+	t.has_system_flags = true;
+	t.system_flags = system_flags;
 
 	/* internal */
 	if (!isnan(d.temperature)) {
@@ -208,8 +204,8 @@ static void fill_snapshot(void)
 		t.orientation = (uint32_t)(d.orientation & 0xf);
 	}
 
-	/* pir */
-	if (g_app_config.cap_pir_detector && d.motion_count > 0) {
+	/* pir — whole group sent whenever the detector is enabled (0 is valid) */
+	if (g_app_config.cap_pir_detector) {
 		t.has_motion_count = true;
 		t.motion_count = d.motion_count;
 	}
@@ -234,10 +230,8 @@ static void fill_snapshot(void)
 			t.has_mp1_humidity = true;
 			t.mp1_humidity = (uint32_t)(d.mp1_humidity * 2.0f);
 		}
-		if (d.mp1_is_tilt_alert) {
-			t.has_mp1_flags = true;
-			t.mp1_flags = MP_FLAG_TILT;
-		}
+		t.has_mp1_flags = true;
+		t.mp1_flags = d.mp1_is_tilt_alert ? MP_FLAG_TILT : 0;
 		if (!isnan(d.mp2_temperature)) {
 			t.has_mp2_temperature = true;
 			t.mp2_temperature = (int32_t)(d.mp2_temperature * 100.0f);
@@ -246,10 +240,8 @@ static void fill_snapshot(void)
 			t.has_mp2_humidity = true;
 			t.mp2_humidity = (uint32_t)(d.mp2_humidity * 2.0f);
 		}
-		if (d.mp2_is_tilt_alert) {
-			t.has_mp2_flags = true;
-			t.mp2_flags = MP_FLAG_TILT;
-		}
+		t.has_mp2_flags = true;
+		t.mp2_flags = d.mp2_is_tilt_alert ? MP_FLAG_TILT : 0;
 	}
 
 	/* hall left / right */
@@ -264,14 +256,10 @@ static void fill_snapshot(void)
 		if (hall.left_is_active) {
 			f |= CNT_FLAG_ACTIVE;
 		}
-		if (hall.left_count > 0) {
-			t.has_hall_left_count = true;
-			t.hall_left_count = hall.left_count;
-		}
-		if (f) {
-			t.has_hall_left_flags = true;
-			t.hall_left_flags = f;
-		}
+		t.has_hall_left_count = true;
+		t.hall_left_count = hall.left_count;
+		t.has_hall_left_flags = true;
+		t.hall_left_flags = f;
 	}
 	if (g_app_config.cap_hall_right) {
 		uint32_t f = 0;
@@ -284,14 +272,10 @@ static void fill_snapshot(void)
 		if (hall.right_is_active) {
 			f |= CNT_FLAG_ACTIVE;
 		}
-		if (hall.right_count > 0) {
-			t.has_hall_right_count = true;
-			t.hall_right_count = hall.right_count;
-		}
-		if (f) {
-			t.has_hall_right_flags = true;
-			t.hall_right_flags = f;
-		}
+		t.has_hall_right_count = true;
+		t.hall_right_count = hall.right_count;
+		t.has_hall_right_flags = true;
+		t.hall_right_flags = f;
 	}
 
 	/* input A / B */
@@ -306,14 +290,10 @@ static void fill_snapshot(void)
 		if (input.input_a_is_active) {
 			f |= CNT_FLAG_ACTIVE;
 		}
-		if (input.input_a_count > 0) {
-			t.has_input_a_count = true;
-			t.input_a_count = input.input_a_count;
-		}
-		if (f) {
-			t.has_input_a_flags = true;
-			t.input_a_flags = f;
-		}
+		t.has_input_a_count = true;
+		t.input_a_count = input.input_a_count;
+		t.has_input_a_flags = true;
+		t.input_a_flags = f;
 	}
 	if (g_app_config.cap_input_b) {
 		uint32_t f = 0;
@@ -326,14 +306,10 @@ static void fill_snapshot(void)
 		if (input.input_b_is_active) {
 			f |= CNT_FLAG_ACTIVE;
 		}
-		if (input.input_b_count > 0) {
-			t.has_input_b_count = true;
-			t.input_b_count = input.input_b_count;
-		}
-		if (f) {
-			t.has_input_b_flags = true;
-			t.input_b_flags = f;
-		}
+		t.has_input_b_count = true;
+		t.input_b_count = input.input_b_count;
+		t.has_input_b_flags = true;
+		t.input_b_flags = f;
 	}
 
 	m_snapshot = t;

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -263,11 +263,15 @@ message AlarmEvent {
 // Periodic / event-triggered telemetry uplink, sent on fPort 2 (legacy bitmap
 // stays on fPort 1). Fields are grouped per sensor; each group's boolean state
 // lives in its own `*_flags` field so a sensor's data stays together as an
-// atomic unit. A field is present only when its sensor is connected (capability
-// on) and has valid data. The composer packs whole groups by priority into one
-// or more frames to fit the LoRaWAN payload budget (split, never drop); all
-// frames of a report carry the same snapshot. Scalars are scaled-int varints.
-// The same message is emitted for periodic reports and event triggers.
+// atomic unit. A group is sent whenever its sensor is enabled (capability on),
+// as a whole, every report — its fields are present even when 0/false (e.g. a
+// hall counter at 0, or boot=false). The system group (voltage, system_flags)
+// is always present. Digital fields carry their real value (0 is valid); analog
+// scalars are omitted only when there is no valid sample yet (NaN). The composer
+// packs whole groups by priority into one or more frames to fit the LoRaWAN
+// payload budget (split, never drop); all frames of a report carry the same
+// snapshot. Scalars are scaled-int varints. The same message is emitted for
+// periodic reports and event triggers.
 message Telemetry {
     // system
     optional uint32 voltage          = 1;   // V    x50

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -61,7 +61,7 @@ Periodic and event reports now use a compact, extensible **protobuf** format on 
 
 Key differences from the v1.3.x bitmap:
 - **Extensible** — new sensors can be added in future firmware without breaking older decoders.
-- **Capability-gated** — a sensor's data is included only when its capability is enabled and the reading is valid.
+- **Capability-gated, whole-group** — a sensor's group is sent in full **every report** whenever its capability is enabled, even when the values are `0`/`false` (e.g. a hall counter at 0, all states inactive). The **system group** (voltage, `boot`) is **always** present, so `boot=false` is reported explicitly rather than by omission. Digital fields carry their real value (0 is valid); an analog scalar is omitted only when there is no valid sample yet.
 - **Multi-frame split** — if a report is larger than the current data rate allows, it is split across several fPort-2 frames sent a few seconds apart. Each frame carries whole sensor groups from the **same snapshot**, so the network server can merge them; nothing is lost.
 
 The decoded field set (voltage, temperature, humidity, pressure/altitude, illuminance, orientation, motion_count, external temperatures, machine-probe values, hall/input counters and states, `boot`) matches the familiar v1.3.x fields — see the payload formatter output (§8). Decode with the updated `ttn.js`.

--- a/tests/compose/src/main.c
+++ b/tests/compose/src/main.c
@@ -99,7 +99,10 @@ ZTEST(compose, test_boot_internal)
 	zassert_equal(fr[0].temperature, 2350, "temp scaled wrong: %d", fr[0].temperature);
 	zassert_true(fr[0].has_humidity, "humidity missing");
 	zassert_equal(fr[0].humidity, 100, "hum scaled wrong: %u", fr[0].humidity);
-	zassert_false(fr[0].has_voltage, "voltage should be absent (NaN)");
+	/* #80: the system group is always present; an absent (NaN) voltage is
+	 * sent as a 0 sentinel rather than omitted. */
+	zassert_true(fr[0].has_voltage, "system voltage must always be present");
+	zassert_equal(fr[0].voltage, 0, "absent voltage -> 0 sentinel, got %u", fr[0].voltage);
 	zassert_true(fr[0].has_system_flags, "boot system_flags missing");
 	zassert_equal(fr[0].system_flags, SYSTEM_FLAG_BOOT, "boot flag wrong");
 }
@@ -199,18 +202,24 @@ ZTEST(compose, test_multiframe_split)
 	zassert_equal(hall, 1, "hall_left not exactly once");
 }
 
-ZTEST(compose, test_nothing_to_report)
+ZTEST(compose, test_system_always_present)
 {
-	uint8_t buf[64];
-	size_t len = 1;
-	bool more = true;
+	Telemetry fr[8];
+	size_t n;
 
-	set_clean(); /* all NaN, boot flag already consumed */
-	int ret = app_compose(buf, sizeof(buf), &len, &more);
+	set_clean(); /* all NaN, boot flag already consumed by test_boot_internal */
+	run_report(fr, 8, &n);
 
-	zassert_equal(ret, 0, "ret %d", ret);
-	zassert_equal(len, 0, "expected empty report, got %zuB", len);
-	zassert_false(more, "more should be false");
+	/* #80: the system group is always emitted, so a report is never empty even
+	 * when every sensor reading is absent. boot was consumed earlier -> flags 0. */
+	zassert_equal(n, 1, "expected one frame, got %zu", n);
+	zassert_true(fr[0].has_voltage, "system voltage must always be present");
+	zassert_equal(fr[0].voltage, 0, "absent voltage -> 0 sentinel, got %u", fr[0].voltage);
+	zassert_true(fr[0].has_system_flags, "system_flags must always be present");
+	zassert_equal(fr[0].system_flags, 0, "boot consumed -> flags 0, got %u", fr[0].system_flags);
+	/* No sensor groups leak in when nothing is available. */
+	zassert_false(fr[0].has_temperature, "temperature leaked");
+	zassert_false(fr[0].has_hall_left_count, "hall_left leaked");
 }
 
 ZTEST(compose, test_budget_unknown_pre_join)


### PR DESCRIPTION
Fixes #78.

## Problem

The fPort-2 protobuf telemetry report omitted any field whose value was `0`/`false`:
- `boot=false` ⇒ `system_flags == 0` ⇒ the system flags field was dropped from the wire, so the system group could disappear entirely.
- Hall / input / PIR / machine-probe-flag fields vanished when their count/flags were `0`, **even though the sensor capability was enabled**.

Consumers could not tell a now-`false` state from an absent field, and a configured sensor with no activity simply disappeared from the report.

## Fix (approach decided in #78 — flat layout, no renumber)

Field numbers are unchanged; groups stay logical and atomic in the composer. The fix removes the inner value guards and sets `has_*` once a group is selected.

**`app_compose.c` (`fill_snapshot`)**
- **System group always sent** (`voltage` + `system_flags`); `boot=false` is now encoded explicitly. `voltage` uses `0` as a no-sample sentinel (only the pre-sample case).
- **Capability-gated digital groups sent in full** whenever the capability is on — PIR `motion_count`, hall L/R `count`+`flags`, input A/B `count`+`flags`, and machine-probe tilt `flags` — including when the value is `0`/`false`.
- Analog scalars (temperature, humidity, pressure, altitude, illuminance, ext/MP temperatures) remain **valid-only** (omitted when NaN) — we don't fabricate physical readings. *Open question carried from #78: whether to also force-present analog groups via a sentinel or validity bit. Out of scope here.*

**`ttn.js`**
- Emit explicit `true`/`false` for `boot`, machine-probe tilt, and hall/input `notify_act`/`notify_deact`/`is_active`, instead of true-only.

**Docs / proto**
- `doc/version 1.4.md` §2 and the `Telemetry` proto comment updated to describe the whole-group / always-present-system semantics.

## Tests

- New decoder test asserts a zero-valued system + hall group decodes to explicit `false`/`0`.
- `tools/test.sh` (node + pytest + clang-format + configen sync): **pass=4 fail=0** (build skipped locally; release build verified separately, FLASH 56.79% / RAM 65.66%).

## Not yet done

- [x] HW / TTN end-to-end verification of an on-air frame.
