### PR TITLE
batch #55: small fixes — history hint, ats device info, payload version byte, post-join telemetry, SetParam save, enum hints, categorized config show

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -572,6 +572,9 @@ function encodeDownlinkCommand(cmd) {
   if (name === "set_param") {
     if (b.lorawan) body = body.concat(_encLenDelim(1, _encLorawan(b.lorawan)));
     if (b.application) body = body.concat(_encLenDelim(2, _encApplication(b.application)));
+    // save (field 3): persist + reboot after applying; set on the LAST message
+    // of a multi-downlink batch only.
+    if (b.save) body = body.concat(_encTag(3, 0)).concat(_encVarint(1));
   } else if (name === "get_param") {
     // proto3 repeated scalars are packed (length-delimited) by default.
     var lf = b.lorawan_field || [];
@@ -636,6 +639,9 @@ function decodeDownlinkCommand(bytes) {
             if (f2 === 1) sp.lorawan = _decodeLorawan(bytes, p, p + l2.value);
             else if (f2 === 2) sp.application = _decodeApplication(bytes, p, p + l2.value);
             p += l2.value;
+          } else if (w2 === 0) {
+            var sv = _pbReadVarint(bytes, p); p = sv.next;
+            if (f2 === 3) sp.save = sv.value !== 0; // persist + reboot after apply
           } else { break; }
         }
         cmd.set_param = sp;
@@ -780,14 +786,30 @@ function decodeAlarmBatch(bytes) {
   return out;
 }
 
+// 1-byte format version prefixed to application protobuf payloads (fPort 2
+// telemetry, fPort 85 response). Mirrors APP_PROTO_VERSION in app_cmd.h.
+var _PROTO_VERSION = 0x01;
+
+// Strip + validate the version prefix at byte[0]. Returns the protobuf bytes
+// (byte 1..end) and pushes a warning on an unexpected version (the remainder is
+// still decoded best-effort). fPort 1 (legacy bitmap) and fPort 3 are unversioned.
+function _stripProtoVersion(bytes, warnings) {
+  if (!bytes || bytes.length < 1) return bytes;
+  if (bytes[0] !== _PROTO_VERSION) {
+    warnings.push("unknown payload version 0x" + bytes[0].toString(16));
+  }
+  return bytes.slice(1);
+}
+
 function decodeUplink(input) {
 
   // fPort 85: DownlinkResponse (Ack / Info / Error from command dispatcher).
   if (input.fPort === 85) {
-
+    var w85 = [];
+    var b85 = _stripProtoVersion(input.bytes, w85);
     return {
-      data: decodeDownlinkResponse(input.bytes),
-      warnings: [],
+      data: decodeDownlinkResponse(b85),
+      warnings: w85,
       errors: []
     };
   }
@@ -799,9 +821,11 @@ function decodeUplink(input) {
 
   // fPort 2: protobuf Telemetry (new format). fPort 1 stays the legacy bitmap.
   if (input.fPort === 2) {
+    var w2 = [];
+    var b2 = _stripProtoVersion(input.bytes, w2);
     return {
-      data: decodeTelemetry(input.bytes),
-      warnings: [],
+      data: decodeTelemetry(b2),
+      warnings: w2,
       errors: []
     };
   }

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -49,6 +49,16 @@ const COMMANDS = [
     },
   },
   {
+    // #55: optional save flag (field 3) commits a multi-message SetParam batch.
+    name: "set_param (save flag only)",
+    hex: "080912021801",
+    data: {
+      seq: 9,
+      command: "set_param",
+      set_param: { save: true },
+    },
+  },
+  {
     name: "reset_counters (hall_left + input_a)",
     hex: "0807520408011801",
     data: {
@@ -97,7 +107,8 @@ test("decodeUplink decodes legacy bitmap (fPort 1)", () => {
 
 // --- Uplink: command response (fPort 85) ----------------------------------
 test("decodeUplink decodes an Ack response (fPort 85)", () => {
-  const got = codec.decodeUplink({ bytes: hex("08011200"), fPort: 85 });
+  // 01 = APP_PROTO_VERSION prefix, then Response{ seq=1, ack={} }.
+  const got = codec.decodeUplink({ bytes: hex("0108011200"), fPort: 85 });
   assert.equal(got.data.seq, 1);
   assert.deepEqual(got.data.ack, {});
 });
@@ -116,8 +127,9 @@ test("decodeUplink decodes an Ack response (fPort 85)", () => {
 //   90 01 00  hall_left_count=0          98 01 04  hall_left_flags=ACTIVE
 //   a0 01 00  hall_right_count=0         a8 01 04  hall_right_flags=ACTIVE
 test("decodeUplink fPort 2: real HW frame, system + enabled groups always present", () => {
+  // 01 = APP_PROTO_VERSION prefix (#55), then the captured Telemetry protobuf.
   const got = codec.decodeUplink({
-    bytes: hex("08a801100018fa24206c4002900100980104a00100a80104"),
+    bytes: hex("0108a801100018fa24206c4002900100980104a00100a80104"),
     fPort: 2,
   }).data;
   assert.equal(got.voltage, 3.36);
@@ -141,7 +153,7 @@ test("decodeUplink fPort 2: real HW frame, system + enabled groups always presen
 // frame: voltage=100 (field 1), system_flags=0 (field 2 -> boot=false),
 // hall_left_count=0 (field 18), hall_left_flags=0 (field 19 -> all false).
 test("decodeUplink fPort 2: zero-valued groups decode to explicit false/0", () => {
-  const got = codec.decodeUplink({ bytes: hex("08641000900100980100"), fPort: 2 }).data;
+  const got = codec.decodeUplink({ bytes: hex("0108641000900100980100"), fPort: 2 }).data;
   assert.equal(got.voltage, 2);
   assert.equal(got.boot, false);
   assert.equal(got.hall_left_count, 0);
@@ -151,9 +163,17 @@ test("decodeUplink fPort 2: zero-valued groups decode to explicit false/0", () =
 });
 
 test("fPort-2 telemetry decodes accel_motion_count (field 26)", () => {
-  // protobuf: tag (26 << 3 | varint) = 0xd0 0x01, value 3
-  const got = codec.decodeUplink({ bytes: hex("d00103"), fPort: 2 });
+  // 01 = version prefix, then tag (26 << 3 | varint) = 0xd0 0x01, value 3
+  const got = codec.decodeUplink({ bytes: hex("01d00103"), fPort: 2 });
   assert.equal(got.data.accel_motion_count, 3);
+});
+
+test("fPort 2: unknown payload version is flagged but still decodes", () => {
+  // version 0x02 (unknown) followed by voltage=100 (field 1) -> warn + decode
+  const r = codec.decodeUplink({ bytes: hex("020864"), fPort: 2 });
+  assert.equal(r.data.voltage, 2);
+  assert.ok(r.warnings.length >= 1, "expected a version warning");
+  assert.match(r.warnings[0], /version/);
 });
 
 // --- Uplink: history replay frames (fPort 85, device-driven multi-frame) ---
@@ -178,7 +198,8 @@ function buildHistoryFrame(seq, idx, count, t0, present, interval, samples) {
   let hf = idx ? pbTV(1, idx) : [];
   hf = hf.concat(pbTV(2, count)).concat(pbTV(3, t0))
     .concat(pbLD(4, samples)).concat(pbTV(5, present)).concat(pbTV(6, interval));
-  return [].concat(pbTV(1, seq)).concat(pbLD(5, hf)); // Response.history_frame = field 5
+  // 0x01 = APP_PROTO_VERSION prefix (#55); Response.history_frame = field 5.
+  return [0x01].concat(pbTV(1, seq)).concat(pbLD(5, hf));
 }
 
 test("decodeUplink decodes + reassembles multi-frame history (fPort 85)", () => {

--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -12,10 +12,7 @@
 #include "app_machine_probe.h"
 #include "app_sensor.h"
 #include "app_sht4x.h"
-
-#ifdef CONFIG_APP_CMD_DEBUG_SHELL
 #include "app_cmd.h"
-#endif
 
 /* Zephyr includes */
 #include <zephyr/init.h>
@@ -30,6 +27,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 LOG_MODULE_REGISTER(app_ats, LOG_LEVEL_DBG);
 
@@ -702,7 +700,50 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 #endif /* CONFIG_APP_CMD_DEBUG_SHELL */
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ats, SHELL_CMD(led, &sub_led, "LED commands.", NULL),
+/* Prints the same device info a GetInfo command returns over LoRaWAN, via the
+ * shared app_cmd_get_info() (single source of truth). */
+static int cmd_device_info(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	static const char *const build_type_name[] = {"main", "dev", "custom"};
+
+	struct app_cmd_info info;
+	app_cmd_get_info(&info);
+
+	const char *bt = info.build_type < ARRAY_SIZE(build_type_name)
+				 ? build_type_name[info.build_type]
+				 : "unknown";
+
+	shell_print(sh, "FW version:    %u.%u.%u", info.fw_major, info.fw_minor, info.fw_patch);
+	shell_print(sh, "Build type:    %s (%s)", bt, info.debug ? "debug" : "release");
+	shell_print(sh, "Serial number: %u", info.serial_number);
+	shell_print(sh, "Uptime:        %u s", info.uptime_s);
+
+	if (info.has_unix_time) {
+		time_t t = (time_t)info.unix_time;
+		struct tm tm;
+		gmtime_r(&t, &tm);
+		shell_print(sh, "Wall clock:    %04d-%02d-%02d %02d:%02d:%02d UTC",
+			    tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min,
+			    tm.tm_sec);
+	} else {
+		shell_print(sh, "Wall clock:    RTC not synced");
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_device,
+	SHELL_CMD_ARG(info, NULL,
+		      "Print device info (FW version, build type, serial, uptime, clock).",
+		      cmd_device_info, 1, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ats, SHELL_CMD(device, &sub_device, "Device info.", NULL),
+			       SHELL_CMD(led, &sub_led, "LED commands.", NULL),
 			       SHELL_CMD(sensors, &sub_sensors, "Sensor commands.", NULL),
 #if defined(CONFIG_LORAWAN)
 			       SHELL_CMD(lrw, &sub_lrw, "LoRaWAN commands.", NULL),

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -55,22 +55,47 @@ LOG_MODULE_REGISTER(app_cmd, LOG_LEVEL_DBG);
 #define APP_BUILD_TYPE    2
 #endif
 
-static void fill_info(Response_Info *info)
+void app_cmd_get_info(struct app_cmd_info *info)
 {
-	info->fw_major = APP_VERSION_MAJOR;
-	info->fw_minor = APP_VERSION_MINOR;
-	info->fw_patch = APP_VERSION_PATCH;
-	info->build_type = (Response_Info_BuildType)APP_BUILD_TYPE;
-	info->serial_number = g_app_config.serial_number;
-	info->uptime_s = (uint32_t)(k_uptime_get() / 1000);
-	info->debug = IS_ENABLED(CONFIG_FW_DEBUG);
+	if (!info) {
+		return;
+	}
+
+	*info = (struct app_cmd_info){
+		.fw_major = APP_VERSION_MAJOR,
+		.fw_minor = APP_VERSION_MINOR,
+		.fw_patch = APP_VERSION_PATCH,
+		.build_type = APP_BUILD_TYPE,
+		.debug = IS_ENABLED(CONFIG_FW_DEBUG),
+		.serial_number = g_app_config.serial_number,
+		.uptime_s = (uint32_t)(k_uptime_get() / 1000),
+	};
 
 #ifdef APP_CMD_HAVE_CLOCK
 	uint32_t unix_s;
 	if (app_clock_get_unix(&unix_s) == 0) {
+		info->has_unix_time = true;
 		info->unix_time = unix_s;
 	}
 #endif
+}
+
+/* Map the plain-C info snapshot onto the protobuf Response_Info. */
+static void fill_info(Response_Info *info)
+{
+	struct app_cmd_info i;
+	app_cmd_get_info(&i);
+
+	info->fw_major = i.fw_major;
+	info->fw_minor = i.fw_minor;
+	info->fw_patch = i.fw_patch;
+	info->build_type = (Response_Info_BuildType)i.build_type;
+	info->serial_number = i.serial_number;
+	info->uptime_s = i.uptime_s;
+	info->debug = i.debug;
+	if (i.has_unix_time) {
+		info->unix_time = i.unix_time;
+	}
 }
 
 static void make_error(Response *resp, Response_Error_Code code, const char *detail)
@@ -87,7 +112,8 @@ static void make_error(Response *resp, Response_Error_Code code, const char *det
 	}
 }
 
-static void handle_set_param(const Command_SetParam *sp, Response *resp)
+static void handle_set_param(const Command_SetParam *sp, Response *resp,
+			     enum app_cmd_action *action)
 {
 	uint32_t fault = 0;
 	int rc = 0;
@@ -104,6 +130,11 @@ static void handle_set_param(const Command_SetParam *sp, Response *resp)
 		resp->body.error.fault_field = fault;
 	} else {
 		resp->which_body = Response_ack_tag;
+		/* Optional one-shot commit: persist staged config + reboot, same path
+		 * as SettingsSave. Used as the last message of a multi-downlink batch. */
+		if (sp->has_save && sp->save) {
+			*action = APP_CMD_ACTION_SETTINGS_SAVE;
+		}
 	}
 }
 
@@ -308,7 +339,7 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 		break;
 
 	case Command_set_param_tag:
-		handle_set_param(&cmd->body.set_param, resp);
+		handle_set_param(&cmd->body.set_param, resp, action);
 		break;
 
 	case Command_get_param_tag:
@@ -363,6 +394,26 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 	}
 }
 
+/* Encode a Response into `out` with the 1-byte APP_PROTO_VERSION prefix at
+ * out[0] (fPort 85). Sets *out_len to the total length (version + protobuf). */
+static int encode_response(const Response *resp, uint8_t *out, size_t out_cap, size_t *out_len)
+{
+	if (out_cap < 1) {
+		return -EMSGSIZE;
+	}
+
+	out[0] = APP_PROTO_VERSION;
+
+	pb_ostream_t ostream = pb_ostream_from_buffer(out + 1, out_cap - 1);
+	if (!pb_encode(&ostream, Response_fields, resp)) {
+		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
+		return -EMSGSIZE;
+	}
+
+	*out_len = ostream.bytes_written + 1;
+	return 0;
+}
+
 int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t in_len, uint8_t *out,
 		   size_t out_cap, size_t *out_len, enum app_cmd_action *action)
 {
@@ -396,13 +447,11 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 		return 0;
 	}
 
-	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
-	if (!pb_encode(&ostream, Response_fields, &resp)) {
-		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
-		return -EMSGSIZE;
+	int ret = encode_response(&resp, out, out_cap, out_len);
+	if (ret) {
+		return ret;
 	}
 
-	*out_len = ostream.bytes_written;
 	if (action) {
 		*action = act;
 	}
@@ -420,14 +469,7 @@ int app_cmd_build_info(uint8_t *out, size_t out_cap, size_t *out_len)
 	resp.which_body = Response_info_tag;
 	fill_info(&resp.body.info);
 
-	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
-	if (!pb_encode(&ostream, Response_fields, &resp)) {
-		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
-		return -EMSGSIZE;
-	}
-
-	*out_len = ostream.bytes_written;
-	return 0;
+	return encode_response(&resp, out, out_cap, out_len);
 }
 
 #if defined(APP_CMD_HAVE_HISTORY)
@@ -456,14 +498,7 @@ int app_cmd_build_history_frame(uint32_t seq, uint32_t frame_index, uint32_t fra
 	memcpy(hf->samples.bytes, samples, samples_len);
 	hf->samples.size = samples_len;
 
-	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
-	if (!pb_encode(&ostream, Response_fields, &resp)) {
-		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
-		return -EMSGSIZE;
-	}
-
-	*out_len = ostream.bytes_written;
-	return 0;
+	return encode_response(&resp, out, out_cap, out_len);
 }
 #endif /* APP_CMD_HAVE_HISTORY */
 

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -16,6 +16,12 @@
 extern "C" {
 #endif
 
+/* 1-byte format version prefixed to application protobuf payloads so the
+ * encoding can change incompatibly in future while staying decodable (protobuf
+ * alone only handles additive field changes). Carried on fPort 2 (telemetry)
+ * and fPort 85 (command response). fPort 1 legacy bitmap stays unversioned. */
+#define APP_PROTO_VERSION 0x01
+
 enum app_cmd_transport {
 	APP_CMD_TRANSPORT_LRW,
 	APP_CMD_TRANSPORT_NFC,
@@ -30,6 +36,26 @@ enum app_cmd_action {
 	APP_CMD_ACTION_REBOOT,        /* reboot (discards staged edits) */
 	APP_CMD_ACTION_FACTORY_RESET, /* erase NVS + reboot */
 };
+
+/* Plain-C device info snapshot (no protobuf dependency), filled by
+ * app_cmd_get_info(). Single source of truth for both the GetInfo response and
+ * the `ats device info` shell command. build_type: 0=main, 1=dev, 2=custom. */
+struct app_cmd_info {
+	uint8_t fw_major;
+	uint8_t fw_minor;
+	uint8_t fw_patch;
+	uint8_t build_type; /* 0=main, 1=dev, 2=custom */
+	bool debug;         /* debug build (CONFIG_FW_DEBUG) */
+	uint32_t serial_number;
+	uint32_t uptime_s;
+	bool has_unix_time; /* unix_time valid (RTC synced) */
+	uint32_t unix_time; /* UTC seconds since epoch */
+};
+
+/* Fill `info` with the current device info: FW version, build type, serial,
+ * uptime, and wall-clock time (has_unix_time=false when the RTC is unsynced or
+ * the clock module is absent). Single source of truth for GetInfo + shell. */
+void app_cmd_get_info(struct app_cmd_info *info);
 
 /* Decode a serialized Command from `in`, dispatch it, encode the
  * resulting Response into `out`.

--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -5,6 +5,7 @@
  */
 
 #include "app_compose.h"
+#include "app_cmd.h"
 #include "app_config.h"
 #include "app_hall.h"
 #include "app_input.h"
@@ -346,7 +347,9 @@ int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more)
 		}
 	}
 
-	size_t cap = MIN(size, (size_t)budget);
+	/* Reserve 1 byte for the version prefix (buf[0]); the protobuf is encoded
+	 * from buf+1, so the group-packing budget loses that byte. */
+	size_t cap = MIN(size, (size_t)budget) - 1;
 
 	/* Greedily pack whole pending groups, highest priority first, that fit. */
 	Telemetry frame = Telemetry_init_zero;
@@ -380,7 +383,8 @@ int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more)
 		}
 	}
 
-	pb_ostream_t os = pb_ostream_from_buffer(buf, size);
+	buf[0] = APP_PROTO_VERSION;
+	pb_ostream_t os = pb_ostream_from_buffer(buf + 1, size - 1);
 	if (!pb_encode(&os, Telemetry_fields, &frame)) {
 		LOG_ERR("pb_encode failed: %s", PB_GET_ERROR(&os));
 		m_active = false;
@@ -388,7 +392,7 @@ int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more)
 	}
 
 	m_pending &= ~frame_groups;
-	*len = os.bytes_written;
+	*len = os.bytes_written + 1;
 	*more = (m_pending != 0);
 	if (!*more) {
 		m_active = false;

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -1007,24 +1007,23 @@ static void print_motion_sensitivity(const struct shell *shell)
 
 static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 {
+	shell_print(shell, "");
+	shell_print(shell, "General:");
 	print_secret_key(shell);
 	print_serial_number(shell);
 	print_nonce_counter(shell);
 	print_calibration(shell);
 	print_interval_sample(shell);
 	print_interval_report(shell);
-	print_lrw_region(shell);
-	print_lrw_sub_band(shell);
-	print_lrw_network(shell);
-	print_lrw_adr(shell);
-	print_lrw_activation(shell);
-	print_lrw_deveui(shell);
-	print_lrw_joineui(shell);
-	print_lrw_nwkkey(shell);
-	print_lrw_appkey(shell);
-	print_lrw_devaddr(shell);
-	print_lrw_nwkskey(shell);
-	print_lrw_appskey(shell);
+	print_corr_temperature(shell);
+	print_corr_t1_temperature(shell);
+	print_corr_t2_temperature(shell);
+	print_history_enable(shell);
+	print_history_sensors(shell);
+	print_alarm_limit(shell);
+	print_alarm_notif_time(shell);
+	shell_print(shell, "");
+	shell_print(shell, "Alarm thresholds:");
 	print_alarm_temperature_enabled(shell);
 	print_alarm_temperature_lo(shell);
 	print_alarm_temperature_hi(shell);
@@ -1045,6 +1044,8 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_alarm_t2_temperature_lo(shell);
 	print_alarm_t2_temperature_hi(shell);
 	print_alarm_t2_temperature_hst(shell);
+	shell_print(shell, "");
+	shell_print(shell, "Discrete inputs:");
 	print_hall_left_counter(shell);
 	print_hall_left_notify_act(shell);
 	print_hall_left_notify_deact(shell);
@@ -1057,9 +1058,12 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_input_b_counter(shell);
 	print_input_b_notify_act(shell);
 	print_input_b_notify_deact(shell);
-	print_corr_temperature(shell);
-	print_corr_t1_temperature(shell);
-	print_corr_t2_temperature(shell);
+	shell_print(shell, "");
+	shell_print(shell, "PIR / accel:");
+	print_pir_notify_act(shell);
+	print_motion_sensitivity(shell);
+	shell_print(shell, "");
+	shell_print(shell, "Capabilities:");
 	print_cap_hall_left(shell);
 	print_cap_hall_right(shell);
 	print_cap_input_a(shell);
@@ -1069,12 +1073,20 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_cap_pir_detector(shell);
 	print_cap_1w_thermometer(shell);
 	print_cap_1w_machine_probe(shell);
-	print_history_enable(shell);
-	print_history_sensors(shell);
-	print_alarm_limit(shell);
-	print_alarm_notif_time(shell);
-	print_pir_notify_act(shell);
-	print_motion_sensitivity(shell);
+	shell_print(shell, "");
+	shell_print(shell, "LoRaWAN:");
+	print_lrw_region(shell);
+	print_lrw_sub_band(shell);
+	print_lrw_network(shell);
+	print_lrw_adr(shell);
+	print_lrw_activation(shell);
+	print_lrw_deveui(shell);
+	print_lrw_joineui(shell);
+	print_lrw_nwkkey(shell);
+	print_lrw_appkey(shell);
+	print_lrw_devaddr(shell);
+	print_lrw_nwkskey(shell);
+	print_lrw_appskey(shell);
 
 	return 0;
 }
@@ -1236,6 +1248,12 @@ static int cmd_lrw_region(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	/* `help`/`?` lists the accepted tokens. */
+	if (!strcmp(argv[1], "help") || !strcmp(argv[1], "?")) {
+		shell_print(shell, "valid values: eu868, us915, au915");
+		return 0;
+	}
+
 	if (!strcmp(argv[1], "eu868")) {
 		m_app_config.lrw_region = APP_CONFIG_LRW_REGION_EU868;
 	} else if (!strcmp(argv[1], "us915")) {
@@ -1244,6 +1262,7 @@ static int cmd_lrw_region(const struct shell *shell, size_t argc, char **argv)
 		m_app_config.lrw_region = APP_CONFIG_LRW_REGION_AU915;
 	} else {
 		shell_error(shell, "%s", m_msg_invalid_value);
+		shell_print(shell, "valid values: eu868, us915, au915");
 		return -EINVAL;
 	}
 
@@ -1267,12 +1286,19 @@ static int cmd_lrw_network(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	/* `help`/`?` lists the accepted tokens. */
+	if (!strcmp(argv[1], "help") || !strcmp(argv[1], "?")) {
+		shell_print(shell, "valid values: public, private");
+		return 0;
+	}
+
 	if (!strcmp(argv[1], "public")) {
 		m_app_config.lrw_network = APP_CONFIG_LRW_NETWORK_PUBLIC;
 	} else if (!strcmp(argv[1], "private")) {
 		m_app_config.lrw_network = APP_CONFIG_LRW_NETWORK_PRIVATE;
 	} else {
 		shell_error(shell, "%s", m_msg_invalid_value);
+		shell_print(shell, "valid values: public, private");
 		return -EINVAL;
 	}
 
@@ -1296,12 +1322,19 @@ static int cmd_lrw_activation(const struct shell *shell, size_t argc, char **arg
 		return -EINVAL;
 	}
 
+	/* `help`/`?` lists the accepted tokens. */
+	if (!strcmp(argv[1], "help") || !strcmp(argv[1], "?")) {
+		shell_print(shell, "valid values: otaa, abp");
+		return 0;
+	}
+
 	if (!strcmp(argv[1], "otaa")) {
 		m_app_config.lrw_activation = APP_CONFIG_LRW_ACTIVATION_OTAA;
 	} else if (!strcmp(argv[1], "abp")) {
 		m_app_config.lrw_activation = APP_CONFIG_LRW_ACTIVATION_ABP;
 	} else {
 		shell_error(shell, "%s", m_msg_invalid_value);
+		shell_print(shell, "valid values: otaa, abp");
 		return -EINVAL;
 	}
 
@@ -1841,6 +1874,12 @@ static int cmd_motion_sensitivity(const struct shell *shell, size_t argc, char *
 		return -EINVAL;
 	}
 
+	/* `help`/`?` lists the accepted tokens. */
+	if (!strcmp(argv[1], "help") || !strcmp(argv[1], "?")) {
+		shell_print(shell, "valid values: off, low, medium, high");
+		return 0;
+	}
+
 	if (!strcmp(argv[1], "off")) {
 		m_app_config.motion_sensitivity = APP_CONFIG_MOTION_SENSITIVITY_OFF;
 	} else if (!strcmp(argv[1], "low")) {
@@ -1851,6 +1890,7 @@ static int cmd_motion_sensitivity(const struct shell *shell, size_t argc, char *
 		m_app_config.motion_sensitivity = APP_CONFIG_MOTION_SENSITIVITY_HIGH;
 	} else {
 		shell_error(shell, "%s", m_msg_invalid_value);
+		shell_print(shell, "valid values: off, low, medium, high");
 		return -EINVAL;
 	}
 

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -1007,23 +1007,24 @@ static void print_motion_sensitivity(const struct shell *shell)
 
 static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 {
-	shell_print(shell, "");
-	shell_print(shell, "General:");
 	print_secret_key(shell);
 	print_serial_number(shell);
 	print_nonce_counter(shell);
 	print_calibration(shell);
 	print_interval_sample(shell);
 	print_interval_report(shell);
-	print_corr_temperature(shell);
-	print_corr_t1_temperature(shell);
-	print_corr_t2_temperature(shell);
-	print_history_enable(shell);
-	print_history_sensors(shell);
-	print_alarm_limit(shell);
-	print_alarm_notif_time(shell);
-	shell_print(shell, "");
-	shell_print(shell, "Alarm thresholds:");
+	print_lrw_region(shell);
+	print_lrw_sub_band(shell);
+	print_lrw_network(shell);
+	print_lrw_adr(shell);
+	print_lrw_activation(shell);
+	print_lrw_deveui(shell);
+	print_lrw_joineui(shell);
+	print_lrw_nwkkey(shell);
+	print_lrw_appkey(shell);
+	print_lrw_devaddr(shell);
+	print_lrw_nwkskey(shell);
+	print_lrw_appskey(shell);
 	print_alarm_temperature_enabled(shell);
 	print_alarm_temperature_lo(shell);
 	print_alarm_temperature_hi(shell);
@@ -1044,8 +1045,6 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_alarm_t2_temperature_lo(shell);
 	print_alarm_t2_temperature_hi(shell);
 	print_alarm_t2_temperature_hst(shell);
-	shell_print(shell, "");
-	shell_print(shell, "Discrete inputs:");
 	print_hall_left_counter(shell);
 	print_hall_left_notify_act(shell);
 	print_hall_left_notify_deact(shell);
@@ -1058,12 +1057,9 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_input_b_counter(shell);
 	print_input_b_notify_act(shell);
 	print_input_b_notify_deact(shell);
-	shell_print(shell, "");
-	shell_print(shell, "PIR / accel:");
-	print_pir_notify_act(shell);
-	print_motion_sensitivity(shell);
-	shell_print(shell, "");
-	shell_print(shell, "Capabilities:");
+	print_corr_temperature(shell);
+	print_corr_t1_temperature(shell);
+	print_corr_t2_temperature(shell);
 	print_cap_hall_left(shell);
 	print_cap_hall_right(shell);
 	print_cap_input_a(shell);
@@ -1073,20 +1069,12 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_cap_pir_detector(shell);
 	print_cap_1w_thermometer(shell);
 	print_cap_1w_machine_probe(shell);
-	shell_print(shell, "");
-	shell_print(shell, "LoRaWAN:");
-	print_lrw_region(shell);
-	print_lrw_sub_band(shell);
-	print_lrw_network(shell);
-	print_lrw_adr(shell);
-	print_lrw_activation(shell);
-	print_lrw_deveui(shell);
-	print_lrw_joineui(shell);
-	print_lrw_nwkkey(shell);
-	print_lrw_appkey(shell);
-	print_lrw_devaddr(shell);
-	print_lrw_nwkskey(shell);
-	print_lrw_appskey(shell);
+	print_history_enable(shell);
+	print_history_sensors(shell);
+	print_alarm_limit(shell);
+	print_alarm_notif_time(shell);
+	print_pir_notify_act(shell);
+	print_motion_sensitivity(shell);
 
 	return 0;
 }

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -126,6 +126,10 @@ message Command {
     message SetParam {
         optional AppConfigMessage.Lorawan     lorawan     = 1;
         optional AppConfigMessage.Application application = 2;
+        // Persist + reboot after applying (same as SettingsSave). A large config
+        // is split across several SetParam downlinks that accumulate in staging;
+        // set save=true on the LAST one only to commit everything at once.
+        optional bool                         save        = 3;
     }
 
     message GetParam {

--- a/app/src/app_history.c
+++ b/app/src/app_history.c
@@ -803,8 +803,8 @@ static int cmd_history_enable(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 	app_history_set_enabled(en);
-	app_config()->history_enable = en; /* stage for `config save` */
-	shell_print(sh, "history %s (run `config save` to persist)", en ? "enabled" : "disabled");
+	app_config()->history_enable = en; /* staged; persisted on `settings save` */
+	shell_print(sh, "history %s", en ? "enabled" : "disabled");
 	return 0;
 }
 
@@ -845,9 +845,8 @@ static int cmd_history_sensors(const struct shell *sh, size_t argc, char **argv)
 	uint16_t mask = app_history_get_mask();
 	mask = on ? (mask | BIT(s)) : (mask & ~BIT(s));
 	app_history_set_mask(mask);
-	app_config()->history_sensors = app_history_get_mask(); /* stage */
-	shell_print(sh, "sensor `%s` %s; buffer cleared (run `config save` to persist)", argv[1],
-		    on ? "enabled" : "disabled");
+	app_config()->history_sensors = app_history_get_mask(); /* staged */
+	shell_print(sh, "sensor `%s` %s; buffer cleared", argv[1], on ? "enabled" : "disabled");
 	return 0;
 }
 

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -710,9 +710,9 @@ static void send_work_handler(struct k_work *work)
 		return;
 	}
 
-	/* Drain pending command response before composing telemetry. The
-	 * response leaves at the next jitter window; regular telemetry resumes
-	 * with the next periodic timer fire. */
+	/* Drain pending command response before composing telemetry. The response
+	 * leaves now; fresh telemetry follows shortly after (see below) instead of
+	 * waiting a full interval_report. */
 	k_mutex_lock(&m_pending_response_lock, K_FOREVER);
 	if (m_pending_response_len) {
 		uint8_t buf[APP_LRW_RESPONSE_BUF_SIZE];
@@ -728,12 +728,16 @@ static void send_work_handler(struct k_work *work)
 		} else {
 			LOG_INF("Response sent on port %u (%zu B)", port, len);
 		}
-		/* If an alarm batch is also queued, send it ASAP; else resume periodic. */
+		/* Follow the response with fresh telemetry instead of waiting a full
+		 * interval_report: an alarm batch (if queued) goes out ASAP, otherwise
+		 * schedule a telemetry send just after the RX windows (FRAME_GAP_SEC).
+		 * The next pass has an empty m_pending_response, so it composes and
+		 * sends fPort 2. This also lets the first report after join leave
+		 * promptly (restart_normal_operation intends "send immediately"). */
 		if (m_pending_alarm_len) {
 			k_work_submit_to_queue(&m_work_q, &m_send_work);
 		} else {
-			k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report),
-				      K_FOREVER);
+			k_timer_start(&m_send_timer, K_SECONDS(FRAME_GAP_SEC), K_FOREVER);
 		}
 		return;
 	}

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -608,30 +608,10 @@ static int cmd_float(const struct shell *shell, size_t argc, char **argv, float 
 {% for param in parameters %}
 {{ print_function(param, module, enums) }}
 {% endfor %}
-{# Derive a display section from the parameter name so `config show` can group
-   its output under headers without a per-parameter tag in app_config.yml. #}
-{% macro section_of(name) -%}
-{%- if name.startswith('lrw_') -%}LoRaWAN
-{%- elif name.startswith('cap_') -%}Capabilities
-{%- elif name.startswith('hall_') or name.startswith('input_') -%}Discrete inputs
-{%- elif name.startswith('pir_') or name == 'motion_sensitivity' -%}PIR / accel
-{%- elif name.startswith('alarm_temperature') or name.startswith('alarm_humidity') or name.startswith('alarm_pressure') or name.startswith('alarm_t1') or name.startswith('alarm_t2') -%}Alarm thresholds
-{%- else -%}General
-{%- endif -%}
-{%- endmacro %}
-{% set show_sections = ["General", "Alarm thresholds", "Discrete inputs", "PIR / accel", "Capabilities", "LoRaWAN"] %}
 static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 {
-{% for sec in show_sections %}
-{% set ns = namespace(first=true) %}
-{% for param in parameters if not param.hidden and section_of(param.name) | trim == sec %}
-{% if ns.first %}
-	shell_print(shell, "");
-	shell_print(shell, "{{ sec }}:");
-{% set ns.first = false %}
-{% endif %}
+{% for param in parameters if not param.hidden %}
 	print_{{ param.name | c_name }}(shell);
-{% endfor %}
 {% endfor %}
 
 	return 0;

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -286,6 +286,8 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 	return 0;
 {% elif param.type == 'enum' %}
 {% set enum_values = enums[param.enum] %}
+{% set ns = namespace(tokens=[]) %}
+{% for val in enum_values %}{% set ns.tokens = ns.tokens + [val.shell | default(val.name | lower)] %}{% endfor %}
 	if (argc == 1) {
 		print_{{ param.name | c_name }}(shell);
 		return 0;
@@ -294,6 +296,12 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 	if (argc != 2) {
 		shell_error(shell, "%s", m_msg_invalid_args);
 		return -EINVAL;
+	}
+
+	/* `help`/`?` lists the accepted tokens. */
+	if (!strcmp(argv[1], "help") || !strcmp(argv[1], "?")) {
+		shell_print(shell, "valid values: {{ ns.tokens | join(', ') }}");
+		return 0;
 	}
 
 {% for val in enum_values %}
@@ -306,6 +314,7 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 {% endfor %}
 	} else {
 		shell_error(shell, "%s", m_msg_invalid_value);
+		shell_print(shell, "valid values: {{ ns.tokens | join(', ') }}");
 		return -EINVAL;
 	}
 
@@ -599,10 +608,30 @@ static int cmd_float(const struct shell *shell, size_t argc, char **argv, float 
 {% for param in parameters %}
 {{ print_function(param, module, enums) }}
 {% endfor %}
+{# Derive a display section from the parameter name so `config show` can group
+   its output under headers without a per-parameter tag in app_config.yml. #}
+{% macro section_of(name) -%}
+{%- if name.startswith('lrw_') -%}LoRaWAN
+{%- elif name.startswith('cap_') -%}Capabilities
+{%- elif name.startswith('hall_') or name.startswith('input_') -%}Discrete inputs
+{%- elif name.startswith('pir_') or name == 'motion_sensitivity' -%}PIR / accel
+{%- elif name.startswith('alarm_temperature') or name.startswith('alarm_humidity') or name.startswith('alarm_pressure') or name.startswith('alarm_t1') or name.startswith('alarm_t2') -%}Alarm thresholds
+{%- else -%}General
+{%- endif -%}
+{%- endmacro %}
+{% set show_sections = ["General", "Alarm thresholds", "Discrete inputs", "PIR / accel", "Capabilities", "LoRaWAN"] %}
 static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 {
-{% for param in parameters if not param.hidden %}
+{% for sec in show_sections %}
+{% set ns = namespace(first=true) %}
+{% for param in parameters if not param.hidden and section_of(param.name) | trim == sec %}
+{% if ns.first %}
+	shell_print(shell, "");
+	shell_print(shell, "{{ sec }}:");
+{% set ns.first = false %}
+{% endif %}
 	print_{{ param.name | c_name }}(shell);
+{% endfor %}
 {% endfor %}
 
 	return 0;

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -43,8 +43,11 @@ static enum app_cmd_action handle(const char *hex, Response *resp)
 				 &action);
 	zassert_equal(ret, 0, "app_cmd_handle ret %d", ret);
 
+	/* out[0] is the APP_PROTO_VERSION prefix (#55); decode the protobuf after it. */
+	zassert_true(out_len >= 1, "missing version byte");
+	zassert_equal(out[0], APP_PROTO_VERSION, "bad version 0x%02x", out[0]);
 	*resp = (Response)Response_init_zero;
-	pb_istream_t is = pb_istream_from_buffer(out, out_len);
+	pb_istream_t is = pb_istream_from_buffer(out + 1, out_len - 1);
 	zassert_true(pb_decode(&is, Response_fields, resp), "Response decode failed");
 	return action;
 }
@@ -122,8 +125,10 @@ ZTEST(cmd, test_build_info)
 	int ret = app_cmd_build_info(out, sizeof(out), &out_len);
 	zassert_equal(ret, 0, "build_info ret %d", ret);
 
+	/* Skip the APP_PROTO_VERSION prefix (#55). */
+	zassert_equal(out[0], APP_PROTO_VERSION, "bad version 0x%02x", out[0]);
 	Response r = Response_init_zero;
-	pb_istream_t is = pb_istream_from_buffer(out, out_len);
+	pb_istream_t is = pb_istream_from_buffer(out + 1, out_len - 1);
 	zassert_true(pb_decode(&is, Response_fields, &r), "decode");
 	zassert_equal(r.which_body, Response_info_tag, "expected Info");
 	zassert_equal(r.body.info.serial_number, 1234567890, "serial");

--- a/tests/compose/src/main.c
+++ b/tests/compose/src/main.c
@@ -7,6 +7,7 @@
  */
 
 #include "app_compose.h"
+#include "app_cmd.h"
 #include "app_config.h"
 #include "app_sensor.h"
 #include "app_hall.h"
@@ -53,7 +54,11 @@ static void set_clean(void)
 static Telemetry decode(const uint8_t *buf, size_t len)
 {
 	Telemetry t = Telemetry_init_zero;
-	pb_istream_t is = pb_istream_from_buffer(buf, len);
+
+	/* buf[0] is the APP_PROTO_VERSION prefix (#55); decode the protobuf after it. */
+	zassert_true(len >= 1, "missing version byte");
+	zassert_equal(buf[0], APP_PROTO_VERSION, "bad version 0x%02x", buf[0]);
+	pb_istream_t is = pb_istream_from_buffer(buf + 1, len - 1);
 
 	zassert_true(pb_decode(&is, Telemetry_fields, &t), "pb_decode failed");
 	return t;
@@ -155,7 +160,8 @@ ZTEST(compose, test_counter_flags)
 			zassert_equal(fr[i].hall_left_count, 7, "hall count");
 			zassert_true(fr[i].has_hall_left_flags, "flags missing");
 			/* NOTIFY_ACT(bit0) | ACTIVE(bit2) = 0x5 */
-			zassert_equal(fr[i].hall_left_flags, 0x5, "flags %u", fr[i].hall_left_flags);
+			zassert_equal(fr[i].hall_left_flags, 0x5, "flags %u",
+				      fr[i].hall_left_flags);
 		}
 	}
 	zassert_true(seen, "hall_left missing");
@@ -216,7 +222,8 @@ ZTEST(compose, test_system_always_present)
 	zassert_true(fr[0].has_voltage, "system voltage must always be present");
 	zassert_equal(fr[0].voltage, 0, "absent voltage -> 0 sentinel, got %u", fr[0].voltage);
 	zassert_true(fr[0].has_system_flags, "system_flags must always be present");
-	zassert_equal(fr[0].system_flags, 0, "boot consumed -> flags 0, got %u", fr[0].system_flags);
+	zassert_equal(fr[0].system_flags, 0, "boot consumed -> flags 0, got %u",
+		      fr[0].system_flags);
 	/* No sensor groups leak in when nothing is available. */
 	zassert_false(fr[0].has_temperature, "temperature leaked");
 	zassert_false(fr[0].has_hall_left_count, "hall_left leaked");


### PR DESCRIPTION
Batch of small fixes & enhancements from #55. Lands the **non-renaming** items (1–5, 7, 8); the breaking config-key renames (#6 / #9) are deferred to a separate PR — see the note at the bottom. Does **not** close #55.

## Items

1. **history shell hint** — drop the wrong `(run \`config save\` to persist)` from `history enable` / `history sensors` (it's `settings save`, and the hint was noise). `app_history.c`.

2. **`ats device info`** — new shell command printing FW version, build type (main/dev/custom + debug/release), serial, uptime and wall-clock (or "RTC not synced"). `fill_info()` is refactored to a plain-C `app_cmd_get_info(struct app_cmd_info*)` so the GetInfo dispatch and the shell share one source of truth. `app_cmd.{h,c}`, `app_ats.c`.

3. **Payload version byte** — a 1-byte `APP_PROTO_VERSION` (0x01) is prefixed to **fPort-2 telemetry** and **fPort-85 responses** so the encoding can change incompatibly later. `app_compose` reserves 1 B of budget; `encode_response()` centralizes the prefix for Response/Info/HistoryFrame. Decoder `ttn.js` strips + validates `byte[0]` (warns on unknown version).
   - **Decision on the open question:** the **downlink command** (fPort 85 in) is left **unversioned** — each direction is independent and versioning the command would churn every downlink vector for no current benefit; it can be added later. fPort 1 (legacy bitmap) and fPort 3 (alarm) stay unversioned.

4. **First telemetry after join** — in `send_work_handler`, after draining a command response, schedule telemetry after `FRAME_GAP_SEC` instead of a full `interval_report`, so the first report after join (and after every command response) leaves promptly. `app_lrw.c`.

5. **`SetParam.save`** — optional `bool save = 3`; when set, the handler Acks and requests `SETTINGS_SAVE`, so the **last** message of a multi-downlink config batch commits everything at once (no separate `SettingsSave`). Caveat documented: `save=true` on the last message only. `app_config.proto`, `app_cmd.c`, `ttn.js`.

7. **Enum setters list valid values** — generated `config motion-sensitivity` / `lrw-region` / `lrw-network` / `lrw-activation` now print `valid values: <tokens>` on bad input and accept `help`/`?`. Fixed once in the configen template. Shell-only.

8. **Categorized `config show`** — output grouped under headers (General, Alarm thresholds, Discrete inputs, PIR / accel, Capabilities, LoRaWAN). Sections are derived from the parameter name in the template (no per-parameter yaml tag), keeping it decoupled from the #9 rename. Purely presentational, shell-only.

## Tests

- JS decoder (`ttn.test.js`): version-byte prefix on all fPort-2/85 vectors, an unknown-version warning case, and a `set_param save` round-trip. 16 pass.
- native_sim ztest: `cmd` + `compose` updated to skip the version byte; all suites pass (cmd 5 / compose 6 / history 4).
- configen pytest 11 pass; clang-format clean; configen output in sync.
- Builds: release flash unchanged (shell-only items don't affect it); **debug is tight at 99.41 %** of the 240 K region — watch this.

## Deferred (not in this PR)

- **#6 vs #9 config-key rename.** These two checklist items propose **conflicting** schemes. Decision taken: adopt the **sensor-centric** scheme (#9) — `hall-left-notify-act`, `temperature-alarm-hi`, with `alarm-*` reserved for global params only; **#6 (global `alarm-*`) is superseded.** This is a breaking NVS-key rename and will land in its own PR with the `doc/` update.

Refs #55.
