### PR TITLE
ats: add 'ats device reboot' shell command

### DIFF
--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -735,14 +735,29 @@ static int cmd_device_info(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+/* App-level cold reboot from the shell. The same reboot is available remotely
+ * via the `reboot` command over LoRaWAN/NFC (app_cmd.c, APP_CMD_ACTION_REBOOT). */
+static int cmd_device_reboot(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "Rebooting...");
+	k_sleep(K_MSEC(200)); /* let the shell flush */
+	sys_reboot(SYS_REBOOT_COLD);
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_device,
 	SHELL_CMD_ARG(info, NULL,
 		      "Print device info (FW version, build type, serial, uptime, clock).",
 		      cmd_device_info, 1, 0),
+	SHELL_CMD_ARG(reboot, NULL, "Cold-reboot the device.", cmd_device_reboot, 1, 0),
 	SHELL_SUBCMD_SET_END);
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ats, SHELL_CMD(device, &sub_device, "Device info.", NULL),
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ats,
+			       SHELL_CMD(device, &sub_device, "Device info & control.", NULL),
 			       SHELL_CMD(led, &sub_led, "LED commands.", NULL),
 			       SHELL_CMD(sensors, &sub_sensors, "Sensor commands.", NULL),
 #if defined(CONFIG_LORAWAN)


### PR DESCRIPTION
Adds an app-level **`ats device reboot`** shell command (cold reboot), under the existing `ats device` subshell.

Context: the user wanted a shell reboot that doesn't depend on the Zephyr `kernel reboot` command. We considered disabling `CONFIG_KERNEL_SHELL` to save debug flash, but decided to **keep the kernel shell** — this just adds a convenient app-level reboot alongside it.

The same reboot is already available **remotely**:
- **LoRaWAN:** the `reboot` downlink command (`Command.Reboot` → `APP_CMD_ACTION_REBOOT` → `sys_reboot`), encoded by `ttn.js` (hex `08083a00`).
- **NFC:** the command dispatcher (`app_cmd_handle`) is transport-agnostic, so `reboot` will execute over NFC once that transport lands (#68); testable today via `ats cmd nfc 08083a00`.

No config change. clang-format clean; debug build fits (99.38 % of the 240 K region). Refs the shell-commands discussion under v1.4.0.
