### PR TITLE
config: unify alarm cross-validation + atomic SetParam (#91)

### DIFF
--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -118,14 +118,23 @@ static void handle_set_param(const Command_SetParam *sp, Response *resp,
 	uint32_t fault = 0;
 	int rc = 0;
 
+	/* Apply atomically: snapshot the staging config, apply both sections, then
+	 * cross-validate. On any fault, restore the snapshot so a rejected batch
+	 * leaves nothing partially staged for a later SettingsSave to persist. */
+	struct app_config snapshot = *app_config();
+
 	if (sp->has_lorawan) {
 		rc = app_config_apply_lorawan(&sp->lorawan, &fault);
 	}
 	if (rc == 0 && sp->has_application) {
 		rc = app_config_apply_application(&sp->application, &fault);
 	}
+	if (rc == 0) {
+		rc = app_config_validate_alarm_pairs(app_config(), &fault);
+	}
 
 	if (rc) {
+		*app_config() = snapshot; /* roll back the whole batch */
 		make_error(resp, Response_Error_Code_OUT_OF_RANGE, "invalid value");
 		resp->body.error.fault_field = fault;
 	} else {

--- a/app/src/app_config_ingest.c
+++ b/app/src/app_config_ingest.c
@@ -266,24 +266,47 @@ int app_config_apply_application(const AppConfigMessage_Application *src, uint32
 		}
 	}
 
-	/* Cross-validate alarm lo/hi pairs — disable the alarm if lo >= hi */
-	if (config->temperature_alarm_lo >= config->temperature_alarm_hi) {
-		config->temperature_alarm_enabled = false;
-	}
-	if (config->humidity_alarm_lo >= config->humidity_alarm_hi) {
-		config->humidity_alarm_enabled = false;
-	}
-	if (config->pressure_alarm_lo >= config->pressure_alarm_hi) {
-		config->pressure_alarm_enabled = false;
-	}
-	if (config->t1_alarm_lo >= config->t1_alarm_hi) {
-		config->t1_alarm_enabled = false;
-	}
-	if (config->t2_alarm_lo >= config->t2_alarm_hi) {
-		config->t2_alarm_enabled = false;
+	/* Cross-validation (lo/hi/hst) is no longer done here: mutating *_enabled
+	 * over the whole staging after every apply silently disabled alarms from
+	 * unrelated edits. It now lives in app_config_validate_alarm_pairs(), called
+	 * at the commit points (SetParam pre-stage, save()) where it can report a
+	 * fault / reject instead of silently changing the user's config. */
+	return ret;
+}
+
+int app_config_validate_alarm_pairs(const struct app_config *cfg, uint32_t *fault_field)
+{
+	if (fault_field) {
+		*fault_field = 0;
 	}
 
-	return ret;
+	const struct {
+		bool enabled;
+		float lo, hi, hst;
+		uint32_t tag; /* proto `lo` tag, reported as the fault field */
+	} pairs[] = {
+		{cfg->temperature_alarm_enabled, cfg->temperature_alarm_lo,
+		 cfg->temperature_alarm_hi, cfg->temperature_alarm_hst, 6},
+		{cfg->humidity_alarm_enabled, cfg->humidity_alarm_lo, cfg->humidity_alarm_hi,
+		 cfg->humidity_alarm_hst, 10},
+		{cfg->pressure_alarm_enabled, cfg->pressure_alarm_lo, cfg->pressure_alarm_hi,
+		 cfg->pressure_alarm_hst, 14},
+		{cfg->t1_alarm_enabled, cfg->t1_alarm_lo, cfg->t1_alarm_hi, cfg->t1_alarm_hst, 18},
+		{cfg->t2_alarm_enabled, cfg->t2_alarm_lo, cfg->t2_alarm_hi, cfg->t2_alarm_hst, 22},
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(pairs); i++) {
+		/* Empty deactivation band: lo + 2*hst >= hi (also catches lo >= hi). */
+		if (pairs[i].enabled && pairs[i].lo + 2.0f * pairs[i].hst >= pairs[i].hi) {
+			LOG_WRN("Alarm pair (tag %u) has an empty deactivation band", pairs[i].tag);
+			if (fault_field) {
+				*fault_field = pairs[i].tag;
+			}
+			return -EINVAL;
+		}
+	}
+
+	return 0;
 }
 
 static bool requested(const uint32_t *ids, size_t n, uint32_t tag)

--- a/app/src/app_config_ingest.h
+++ b/app/src/app_config_ingest.h
@@ -30,6 +30,16 @@ int app_config_apply_application(const AppConfigMessage_Application *src, uint32
 void app_config_fill_lorawan(AppConfigMessage_Lorawan *dst, const uint32_t *ids, size_t n);
 void app_config_fill_application(AppConfigMessage_Application *dst, const uint32_t *ids, size_t n);
 
+/* Cross-validate the alarm threshold pairs on `cfg`. An enabled threshold alarm
+ * can only deactivate inside lo+hst < v < hi-hst; that band is empty when
+ * lo + 2*hst >= hi (which also covers lo >= hi), so an activated alarm would
+ * latch until NaN/reboot and hold the alarm LED. Sets *fault_field (if non-NULL)
+ * to the offending alarm's `lo` proto tag and returns -EINVAL on the first bad
+ * enabled pair; returns 0 if all enabled pairs are valid. Does not mutate cfg.
+ * One source of truth shared by the shell/SetParam/NFC commit paths. */
+struct app_config;
+int app_config_validate_alarm_pairs(const struct app_config *cfg, uint32_t *fault_field);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/app_settings.c
+++ b/app/src/app_settings.c
@@ -5,6 +5,8 @@
  */
 
 #include "app_settings.h"
+#include "app_config.h"
+#include "app_config_ingest.h"
 
 /* Zephyr includes */
 #include <zephyr/fs/fs.h>
@@ -27,6 +29,16 @@ static const char m_shell_msg_error[] = "command failed";
 static int save(bool reboot)
 {
 	int ret;
+
+	/* Refuse to persist a degenerate alarm configuration from any path (shell
+	 * `settings save`, NFC, or a downlink SettingsSave all reach here). An
+	 * enabled alarm with an empty deactivation band would latch forever. */
+	uint32_t fault = 0;
+	if (app_config_validate_alarm_pairs(app_config(), &fault)) {
+		LOG_ERR("Refusing to save: alarm pair (tag %u) has an empty deactivation band",
+			fault);
+		return -EINVAL;
+	}
 
 	ret = settings_save();
 	if (ret) {

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -8,12 +8,14 @@
 
 #include "app_cmd.h"
 #include "app_config.h"
+#include "app_config_ingest.h"
 
 #include <pb_decode.h>
 #include "src/app_config.pb.h"
 
 #include <zephyr/ztest.h>
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -90,6 +92,37 @@ ZTEST(cmd, test_set_param_out_of_range)
 	zassert_equal(r.body.error.fault_field, 4, "fault_field %u", r.body.error.fault_field);
 	/* invalid value must NOT be applied */
 	zassert_not_equal(g_app_config.interval_report, 10, "out-of-range value leaked");
+}
+
+/* #91: cross-validation is one shared function reporting a FAULT, no longer a
+ * silent *_enabled mutation. An enabled alarm needs lo + 2*hst < hi. */
+ZTEST(cmd, test_validate_alarm_pairs)
+{
+	struct app_config c;
+	uint32_t fault = 0xFFFF;
+
+	memset(&c, 0, sizeof(c));
+	/* All alarms disabled (lo==hi==0) must still pass — only enabled pairs count. */
+	zassert_equal(app_config_validate_alarm_pairs(&c, &fault), 0, "disabled pairs must pass");
+	zassert_equal(fault, 0, "no fault expected");
+
+	/* Enabled with a valid band. */
+	c.temperature_alarm_enabled = true;
+	c.temperature_alarm_lo = 15.0f;
+	c.temperature_alarm_hi = 25.0f;
+	c.temperature_alarm_hst = 0.5f;
+	zassert_equal(app_config_validate_alarm_pairs(&c, &fault), 0, "valid band must pass");
+
+	/* hst too large -> empty deactivation band (15 + 2*5 = 25 >= 25). */
+	c.temperature_alarm_hst = 5.0f;
+	zassert_equal(app_config_validate_alarm_pairs(&c, &fault), -EINVAL,
+		      "empty band must fault");
+	zassert_equal(fault, 6, "temperature lo tag expected, got %u", fault);
+
+	/* lo >= hi is also caught. */
+	c.temperature_alarm_hst = 0.5f;
+	c.temperature_alarm_lo = 30.0f;
+	zassert_equal(app_config_validate_alarm_pairs(&c, &fault), -EINVAL, "lo>=hi must fault");
 }
 
 ZTEST(cmd, test_get_param_config_dump)


### PR DESCRIPTION
Unifies alarm threshold cross-validation and makes SetParam atomic. Single-commit follow-up to #91 (and closes the empty-hysteresis gap from #94.3). Targets `v1.4.0`.

## Problem

Cross-validation of alarm `lo`/`hi`/`hst` pairs ran **inside** `apply_application`, over the whole staging config after *every* message, and it **silently flipped `*_enabled` off**. Consequences:
- an unrelated SetParam (or a value left in staging by the shell) could silently disable an alarm with no signal to the operator;
- it never ran on the shell path at all;
- SetParam was best-effort with **no rollback** — a partial/invalid batch stayed staged and a later SettingsSave would persist the fragment.

It also only checked `lo >= hi`, missing the **empty deactivation band** case (#94.3): a valid-per-field config like `lo=15, hi=25, hst=5` makes `lo+hst < v < hi-hst` empty, so an activated alarm can never deactivate and holds the alarm LED.

## Change

- **`app_config_validate_alarm_pairs()`** — one source of truth. An enabled threshold alarm requires `lo + 2*hst < hi` (non-empty deactivation band; also catches `lo >= hi`). Reports the offending alarm's `lo` proto tag as a FAULT and **does not mutate** the config.
- **SetParam is now atomic** — snapshot the staging config, apply both sections, cross-validate, and **roll back the whole batch** on any fault. Nothing partial is left staged.
- **`save()` validates before persisting** — the shell `settings save`, NFC, and downlink SettingsSave paths all reject a degenerate config at the one shared commit point, instead of silently disabling.
- ztest: enabled empty-band and `lo >= hi` fault on the `lo` tag; disabled pairs pass.

## Issues

- Refs #91 — cross-validation unify + SetParam rollback (two #91 leftovers remain: codegen of ingest/`DUMP_FIELDS` from YAML; validate-and-clamp of NVS on load).
- Refs #94 — resolves §3 empty-hysteresis validation.

## Verification
- Release build green (FLASH 94.93 %); native_sim ztest cmd 8 / compose 8 / history 4; clang-format clean.
