### PR TITLE
Sensor robustness + NVS-load clamp (#94, #91)

### DIFF
--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -167,7 +167,9 @@ static void fill_snapshot(void)
 	}
 	if (!isnan(d.humidity)) {
 		t->has_humidity = true;
-		t->humidity = (uint32_t)(d.humidity * 2.0f);
+		/* Clamp before the unsigned cast: the SHT4x formula can yield a
+		 * slightly negative %RH, and a negative float->uint cast is UB. */
+		t->humidity = (uint32_t)CLAMP(d.humidity * 2.0f, 0.0f, 200.0f);
 	}
 
 	/* barometer */
@@ -175,7 +177,7 @@ static void fill_snapshot(void)
 		t->has_pressure = true;
 		/* d.pressure is kPa from the driver; the wire unit is hPa x10
 		 * (0.1 hPa resolution). hPa = kPa x10, so hPa x10 = kPa x100. */
-		t->pressure = (uint32_t)(d.pressure * 100.0f);
+		t->pressure = (uint32_t)CLAMP(d.pressure * 100.0f, 0.0f, 200000.0f);
 	}
 	if (g_app_config.cap_barometer && !isnan(d.altitude)) {
 		float a = CLAMP(d.altitude * 10.0f, (float)INT16_MIN, (float)INT16_MAX);
@@ -186,7 +188,7 @@ static void fill_snapshot(void)
 	/* light */
 	if (g_app_config.cap_light_sensor && !isnan(d.illuminance)) {
 		t->has_illuminance = true;
-		t->illuminance = (uint32_t)(d.illuminance / 2.0f);
+		t->illuminance = (uint32_t)CLAMP(d.illuminance / 2.0f, 0.0f, 1000000.0f);
 	}
 
 	/* accel (gated by the accelerometer capability) */

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -274,6 +274,161 @@ static int h_commit(void)
 		m_app_config_migrated = true;
 	}
 
+	/* Clamp loaded values into their configured ranges so a corrupted or forged
+	 * NVS record can't leave the device in a broken state (e.g. interval=0 ->
+	 * K_SECONDS(0), or an out-of-range enum that no code path expects). */
+	if (m_app_config.interval_sample < 5 && m_app_config.interval_sample != 0) {
+		m_app_config.interval_sample = 5;
+	}
+	if (m_app_config.interval_sample > 3600) {
+		m_app_config.interval_sample = 3600;
+	}
+	if (m_app_config.interval_report < 60) {
+		m_app_config.interval_report = 60;
+	}
+	if (m_app_config.interval_report > 86400) {
+		m_app_config.interval_report = 86400;
+	}
+	if (m_app_config.alarm_limit < 0) {
+		m_app_config.alarm_limit = 0;
+	}
+	if (m_app_config.alarm_limit > 3600) {
+		m_app_config.alarm_limit = 3600;
+	}
+	if (m_app_config.alarm_notif_time < 1) {
+		m_app_config.alarm_notif_time = 1;
+	}
+	if (m_app_config.alarm_notif_time > 60) {
+		m_app_config.alarm_notif_time = 60;
+	}
+	if ((int)m_app_config.lrw_region < 0 || (int)m_app_config.lrw_region > 2) {
+		m_app_config.lrw_region = 0;
+	}
+	if (m_app_config.lrw_sub_band < 0) {
+		m_app_config.lrw_sub_band = 0;
+	}
+	if (m_app_config.lrw_sub_band > 8) {
+		m_app_config.lrw_sub_band = 8;
+	}
+	if ((int)m_app_config.lrw_network < 0 || (int)m_app_config.lrw_network > 1) {
+		m_app_config.lrw_network = 0;
+	}
+	if ((int)m_app_config.lrw_activation < 0 || (int)m_app_config.lrw_activation > 1) {
+		m_app_config.lrw_activation = 0;
+	}
+	if (m_app_config.temperature_alarm_lo < -30.0f) {
+		m_app_config.temperature_alarm_lo = -30.0f;
+	}
+	if (m_app_config.temperature_alarm_lo > 70.0f) {
+		m_app_config.temperature_alarm_lo = 70.0f;
+	}
+	if (m_app_config.temperature_alarm_hi < -30.0f) {
+		m_app_config.temperature_alarm_hi = -30.0f;
+	}
+	if (m_app_config.temperature_alarm_hi > 70.0f) {
+		m_app_config.temperature_alarm_hi = 70.0f;
+	}
+	if (m_app_config.temperature_alarm_hst < 0.0f) {
+		m_app_config.temperature_alarm_hst = 0.0f;
+	}
+	if (m_app_config.temperature_alarm_hst > 5.0f) {
+		m_app_config.temperature_alarm_hst = 5.0f;
+	}
+	if (m_app_config.humidity_alarm_lo < 0.0f) {
+		m_app_config.humidity_alarm_lo = 0.0f;
+	}
+	if (m_app_config.humidity_alarm_lo > 100.0f) {
+		m_app_config.humidity_alarm_lo = 100.0f;
+	}
+	if (m_app_config.humidity_alarm_hi < 0.0f) {
+		m_app_config.humidity_alarm_hi = 0.0f;
+	}
+	if (m_app_config.humidity_alarm_hi > 100.0f) {
+		m_app_config.humidity_alarm_hi = 100.0f;
+	}
+	if (m_app_config.humidity_alarm_hst < 0.0f) {
+		m_app_config.humidity_alarm_hst = 0.0f;
+	}
+	if (m_app_config.humidity_alarm_hst > 20.0f) {
+		m_app_config.humidity_alarm_hst = 20.0f;
+	}
+	if (m_app_config.pressure_alarm_lo < 500.0f) {
+		m_app_config.pressure_alarm_lo = 500.0f;
+	}
+	if (m_app_config.pressure_alarm_lo > 1200.0f) {
+		m_app_config.pressure_alarm_lo = 1200.0f;
+	}
+	if (m_app_config.pressure_alarm_hi < 500.0f) {
+		m_app_config.pressure_alarm_hi = 500.0f;
+	}
+	if (m_app_config.pressure_alarm_hi > 1200.0f) {
+		m_app_config.pressure_alarm_hi = 1200.0f;
+	}
+	if (m_app_config.pressure_alarm_hst < 0.0f) {
+		m_app_config.pressure_alarm_hst = 0.0f;
+	}
+	if (m_app_config.pressure_alarm_hst > 50.0f) {
+		m_app_config.pressure_alarm_hst = 50.0f;
+	}
+	if (m_app_config.t1_alarm_lo < -30.0f) {
+		m_app_config.t1_alarm_lo = -30.0f;
+	}
+	if (m_app_config.t1_alarm_lo > 70.0f) {
+		m_app_config.t1_alarm_lo = 70.0f;
+	}
+	if (m_app_config.t1_alarm_hi < -30.0f) {
+		m_app_config.t1_alarm_hi = -30.0f;
+	}
+	if (m_app_config.t1_alarm_hi > 70.0f) {
+		m_app_config.t1_alarm_hi = 70.0f;
+	}
+	if (m_app_config.t1_alarm_hst < 0.0f) {
+		m_app_config.t1_alarm_hst = 0.0f;
+	}
+	if (m_app_config.t1_alarm_hst > 5.0f) {
+		m_app_config.t1_alarm_hst = 5.0f;
+	}
+	if (m_app_config.t2_alarm_lo < -30.0f) {
+		m_app_config.t2_alarm_lo = -30.0f;
+	}
+	if (m_app_config.t2_alarm_lo > 70.0f) {
+		m_app_config.t2_alarm_lo = 70.0f;
+	}
+	if (m_app_config.t2_alarm_hi < -30.0f) {
+		m_app_config.t2_alarm_hi = -30.0f;
+	}
+	if (m_app_config.t2_alarm_hi > 70.0f) {
+		m_app_config.t2_alarm_hi = 70.0f;
+	}
+	if (m_app_config.t2_alarm_hst < 0.0f) {
+		m_app_config.t2_alarm_hst = 0.0f;
+	}
+	if (m_app_config.t2_alarm_hst > 5.0f) {
+		m_app_config.t2_alarm_hst = 5.0f;
+	}
+	if (m_app_config.temperature_corr < -5.0f) {
+		m_app_config.temperature_corr = -5.0f;
+	}
+	if (m_app_config.temperature_corr > 5.0f) {
+		m_app_config.temperature_corr = 5.0f;
+	}
+	if (m_app_config.t1_corr < -5.0f) {
+		m_app_config.t1_corr = -5.0f;
+	}
+	if (m_app_config.t1_corr > 5.0f) {
+		m_app_config.t1_corr = 5.0f;
+	}
+	if (m_app_config.t2_corr < -5.0f) {
+		m_app_config.t2_corr = -5.0f;
+	}
+	if (m_app_config.t2_corr > 5.0f) {
+		m_app_config.t2_corr = 5.0f;
+	}
+	if ((int)m_app_config.accel_motion_sensitivity < 0 ||
+	    (int)m_app_config.accel_motion_sensitivity > 3) {
+		m_app_config.accel_motion_sensitivity = APP_CONFIG_MOTION_SENSITIVITY_OFF;
+	}
+
 	memcpy(&g_app_config, &m_app_config, sizeof(g_app_config));
 	return 0;
 }

--- a/app/src/app_hall.c
+++ b/app/src/app_hall.c
@@ -69,7 +69,9 @@ static int poll(void)
 		}
 	}
 
-	k_busy_wait(2);
+	/* Let the pull-up settle before sampling. 2 us is borderline for the pin
+	 * RC; 10 us costs nothing and is safely above it. */
+	k_busy_wait(10);
 
 	if (g_app_config.cap_hall_left) {
 		int val = gpio_pin_get_dt(&m_hall_left);

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -5,6 +5,7 @@
  */
 
 #include "app_alarm.h"
+#include "app_battery.h"
 #include "app_calibration.h"
 #include "app_clock.h"
 #include "app_cmd.h"
@@ -285,10 +286,25 @@ static void downlink_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t 
 	k_work_submit_to_queue(&m_work_q, &m_downlink_success_work);
 }
 
+/* Approximate operational cell window for the DevStatusAns battery level.
+ * Tune to the actual cell; values outside are clamped. */
+#define BATTERY_EMPTY_V 2.4f
+#define BATTERY_FULL_V  3.6f
+
 static uint8_t battery_level_callback(void)
 {
-	/* TODO Implement */
-	return 255;
+	/* LoRaWAN DevStatusAns battery level: 0 = external power, 1..254 = battery
+	 * (1 ~ empty, 254 ~ full), 255 = unable to measure. Map the measured cell
+	 * voltage linearly over the operational window. */
+	float v;
+
+	if (app_battery_measure(&v) != 0) {
+		return 255; /* can't measure */
+	}
+
+	float frac = CLAMP((v - BATTERY_EMPTY_V) / (BATTERY_FULL_V - BATTERY_EMPTY_V), 0.0f, 1.0f);
+
+	return (uint8_t)(1 + (int)(frac * 253.0f + 0.5f)); /* 1..254 */
 }
 
 static void datarate_changed_callback(enum lorawan_datarate dr)

--- a/app/src/app_pyq1648.c
+++ b/app/src/app_pyq1648.c
@@ -113,7 +113,9 @@ static int clear_event(void)
 {
 	int ret;
 
-	ret = gpio_pin_configure_dt(&m_dl_spec, GPIO_OUTPUT);
+	/* Drive DL low (defined initial level) to clear the event, not an
+	 * undefined GPIO_OUTPUT level. */
+	ret = gpio_pin_configure_dt(&m_dl_spec, GPIO_OUTPUT_INACTIVE);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("gpio_pin_configure_dt", ret);
 		return ret;
@@ -191,7 +193,8 @@ int app_pyq1648_init(void)
 		return -ENODEV;
 	}
 
-	ret = gpio_pin_configure_dt(&m_si_spec, GPIO_OUTPUT);
+	/* SI idles low; configure with a defined initial level. */
+	ret = gpio_pin_configure_dt(&m_si_spec, GPIO_OUTPUT_INACTIVE);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("gpio_pin_configure_dt", ret);
 		return ret;

--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -23,6 +23,7 @@
 /* Zephyr includes */
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
@@ -38,6 +39,13 @@ LOG_MODULE_REGISTER(app_sensor, LOG_LEVEL_DBG);
 
 #define TILT_THRESHOLD 7
 #define TILT_DURATION  1
+
+/* I2C bus recovery: if every I2C sensor read in a sweep fails for this many
+ * consecutive sweeps, the bus is likely wedged (a slave holding SDA low after a
+ * brown-out/EMI glitch). i2c_recover_bus() bit-bangs 9 clocks to free it. */
+#define I2C_RECOVER_FAIL_THRESHOLD 3
+static const struct device *const m_i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c1));
+static int m_i2c_fail_streak;
 
 struct app_sensor_data g_app_sensor_data = {
 	.orientation = INT_MAX,
@@ -315,6 +323,9 @@ void app_sensor_sample(void)
 	struct app_hall_data hall_data = {0};
 	struct app_input_data input_data = {0};
 
+	/* Track I2C sensor reads this sweep to detect a wedged bus. */
+	int i2c_tried = 0, i2c_failed = 0;
+
 	struct app_w1_slot_reading w1[APP_W1_SLOT_COUNT];
 	for (int s = 0; s < APP_W1_SLOT_COUNT; s++) {
 		w1[s] = (struct app_w1_slot_reading){.temperature = NAN,
@@ -333,7 +344,9 @@ void app_sensor_sample(void)
 #if defined(CONFIG_LIS2DH)
 	if (g_app_config.cap_accelerometer) {
 		ret = app_accel_read(NULL, NULL, NULL, &orientation);
+		i2c_tried++;
 		if (ret) {
+			i2c_failed++;
 			LOG_ERR_CALL_FAILED_INT("app_accel_read", ret);
 		}
 	}
@@ -342,21 +355,27 @@ void app_sensor_sample(void)
 
 #if defined(CONFIG_SHT4X)
 	ret = app_sht4x_read(&temperature, &humidity);
+	i2c_tried++;
 	if (ret) {
+		i2c_failed++;
 		LOG_ERR_CALL_FAILED_INT("app_sht4x_read", ret);
 	}
 #endif /* defined(CONFIG_SHT4X) */
 
 	if (g_app_config.cap_light_sensor) {
 		ret = app_opt3001_read(&illuminance);
+		i2c_tried++;
 		if (ret) {
+			i2c_failed++;
 			LOG_ERR_CALL_FAILED_INT("app_opt3001_read", ret);
 		}
 	}
 
 	if (g_app_config.cap_barometer) {
 		ret = app_mpl3115a2_read(&altitude, &pressure, NULL);
+		i2c_tried++;
 		if (ret) {
+			i2c_failed++;
 			LOG_ERR_CALL_FAILED_INT("app_mpl3115a2_read", ret);
 		}
 	}
@@ -393,6 +412,25 @@ void app_sensor_sample(void)
 					w1[s].is_tilt_alert ? "" : "not ");
 			}
 		}
+	}
+
+	/* A whole sweep where every attempted I2C read failed points at a wedged
+	 * bus (slave holding SDA low). After a few such sweeps, bit-bang it free —
+	 * otherwise every I2C sensor stays dead until a reboot that may never come. */
+	if (i2c_tried > 0 && i2c_failed == i2c_tried) {
+		if (++m_i2c_fail_streak >= I2C_RECOVER_FAIL_THRESHOLD) {
+			LOG_WRN("All %d I2C reads failed for %d sweeps; recovering bus", i2c_tried,
+				m_i2c_fail_streak);
+			if (device_is_ready(m_i2c_dev)) {
+				ret = i2c_recover_bus(m_i2c_dev);
+				if (ret) {
+					LOG_ERR_CALL_FAILED_INT("i2c_recover_bus", ret);
+				}
+			}
+			m_i2c_fail_streak = 0;
+		}
+	} else {
+		m_i2c_fail_streak = 0;
 	}
 
 	k_mutex_lock(&g_app_sensor_data_lock, K_FOREVER);

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -459,6 +459,26 @@ static int h_commit(void)
 	}
 
 {% endif %}
+	/* Clamp loaded values into their configured ranges so a corrupted or forged
+	 * NVS record can't leave the device in a broken state (e.g. interval=0 ->
+	 * K_SECONDS(0), or an out-of-range enum that no code path expects). */
+{% for param in parameters %}
+{% if param.type == 'enum' %}
+	if ((int)m_{{ module.name }}.{{ param.name | c_name }} < 0 ||
+	    (int)m_{{ module.name }}.{{ param.name | c_name }} > {{ (enums[param.enum] | length) - 1 }}) {
+		m_{{ module.name }}.{{ param.name | c_name }} = {{ param | default_value(module.name) or 0 }};
+	}
+{% elif (param.min is defined or param.max is defined) and (param | is_numeric) %}
+{% set sfx = 'f' if (param | is_float) else '' %}
+	if (m_{{ module.name }}.{{ param.name | c_name }} < {{ param | min_value }}{{ sfx }}{% if param.extras and param.extras.zero_allowed %} && m_{{ module.name }}.{{ param.name | c_name }} != 0{% endif %}) {
+		m_{{ module.name }}.{{ param.name | c_name }} = {{ param | min_value }}{{ sfx }};
+	}
+	if (m_{{ module.name }}.{{ param.name | c_name }} > {{ param | max_value }}{{ sfx }}) {
+		m_{{ module.name }}.{{ param.name | c_name }} = {{ param | max_value }}{{ sfx }};
+	}
+{% endif %}
+{% endfor %}
+
 	memcpy(&g_{{ module.name }}, &m_{{ module.name }}, sizeof(g_{{ module.name }}));
 	return 0;
 }

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -222,6 +222,24 @@ def test_migration_preserves_factory_fields(workdir):
     assert generated.count("m_app_config_migrated = true") == 1
 
 
+def test_h_commit_clamps_loaded_values(workdir):
+    """Issue #91: h_commit must clamp out-of-range NVS values so a corrupted
+    record can't break the device (interval=0 hang, out-of-range enum)."""
+    _run_configen(workdir)
+    generated = (workdir / "app_config.c").read_text()
+
+    # interval_report (min 60, max 86400) clamps both ways.
+    assert "if (m_app_config.interval_report < 60) {" in generated
+    assert "if (m_app_config.interval_report > 86400) {" in generated
+    # interval_sample is zero_allowed: the low clamp must spare 0.
+    assert ("if (m_app_config.interval_sample < 5 && "
+            "m_app_config.interval_sample != 0) {") in generated
+    # enums clamp to their valid range (lrw_activation 0..1).
+    assert "(int)m_app_config.lrw_activation > 1) {" in generated
+    # float ranges keep the f suffix.
+    assert "if (m_app_config.temperature_alarm_hst > 5.0f) {" in generated
+
+
 # --- proto <-> decoder cross-check ---------------------------------------
 
 COMMAND_VECTORS = {


### PR DESCRIPTION
Sensor robustness (#94) and NVS-load hardening (#91) follow-ups. Targets `v1.4.0`. 4 commits.

## Done

### Sensors — Refs #94
- **§4 battery level** — `battery_level_callback` returned a hardcoded 255; now wired to `app_battery_measure()` and mapped to the LoRaWAN 1..254 range over an approximate operational window (2.4–3.6 V, tunable), 255 only on measurement failure.
- **§2 I2C bus recovery** — `i2c_recover_bus()` had no call sites; a slave holding SDA low (brown-out/EMI) left every I2C sensor dead until a reboot that (#88) may never come. Each sweep now counts its I2C reads (accel/SHT4x/OPT3001/MPL3115A2); 3 consecutive all-failed sweeps bit-bang the bus free on `i2c1`.
- **§5 low-risk hardening** — PIR DL/SI lines configured `GPIO_OUTPUT_INACTIVE` (defined level, not an undefined output); hall pull-up settle 2 µs → 10 µs; `CLAMP` on humidity/pressure/illuminance before the unsigned cast (the SHT4x formula can go slightly negative → float→uint UB).

### Config — Refs #91
- **NVS clamp on load** — `h_set` only checked record length, so a corrupted/forged value passed through (`interval_report=0` → `K_SECONDS(0)` hang; out-of-range enum → join never starts). configen now emits a clamp pass in `h_commit` from the YAML: numeric min/max (honouring `zero_allowed`), enums reset to default, floats keep the `f` suffix. pytest locks the generated shape.

## Remaining (separate follow-ups, not in this PR)
- **#91 §8** — generate `app_config_ingest` apply/fill + `DUMP_FIELDS` from the YAML (own PR; touches the NFC/downlink config path).
- **#94 §3** — "bound sensor missing/replaced" alarm; needs the slot `replaced` flag and overlaps the 1-Wire framework (#95).

## Verification
- Release build green (FLASH 95.71 %); configen output in sync; pytest 13/13; native_sim ztest cmd 8 / compose 8 / history 4; clang-format clean.
- HW test recommended for the I2C-recovery path and the battery-level mapping.
