### PR TITLE
Commands: YAML-driven schema + behaviour refinements (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .venv/
 /app/deploy/
 build/
+twister-out/

--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -117,7 +117,8 @@ var _LRW_TAGS = _invert(_LRW_NAMES);
 var _CMD_NAMES = {
   2: "set_param", 3: "get_param", 4: "get_info", 5: "get_config",
   6: "settings_save", 7: "reboot", 8: "factory_reset", 9: "force_send",
-  10: "reset_counters", 11: "req_history", 12: "clock_sync", 13: "alarm_rule"
+  10: "reset_counters", 11: "req_history", 12: "clock_sync", 13: "alarm_rule",
+  14: "w1_scan"
 };
 var _CMD_TAGS = _invert(_CMD_NAMES);
 
@@ -241,6 +242,27 @@ function _decodeError(bytes, start, end) {
   return err;
 }
 
+// W1Scan response (fPort 85): repeated `rom` (field 1), each 8 bytes
+// (family + 6-byte serial + CRC). Returned as hex strings; the host picks one
+// and teaches a slot via SetParam sensorN_rom.
+function _decodeW1Scan(bytes, start, end) {
+  var roms = [];
+  var pos = start;
+  while (pos < end) {
+    var tag = _pbReadVarint(bytes, pos); pos = tag.next;
+    var field = tag.value >>> 3;
+    var wire = tag.value & 0x7;
+    if (wire === 2) {
+      var len = _pbReadVarint(bytes, pos); pos = len.next;
+      if (field === 1) roms.push(_pbBytesToHex(bytes.slice(pos, pos + len.value)));
+      pos += len.value;
+    } else {
+      break;
+    }
+  }
+  return { rom: roms };
+}
+
 // app_history_sensor enum order → name + encoding (mirrors app_history.c).
 var _HIST_SENSORS = [
   { name: "temperature", enc: "temp" },
@@ -351,6 +373,7 @@ function decodeDownlinkResponse(bytes) {
       else if (field === 4) resp.config_dump = _decodeConfigDump(bytes, pos, end);
       else if (field === 5) resp.history_frame = _decodeHistoryFrame(bytes, pos, end);
       else if (field === 6) resp.error = _decodeError(bytes, pos, end);
+      else if (field === 7) resp.w1_scan = _decodeW1Scan(bytes, pos, end);
       pos = end;
     } else {
       break;
@@ -672,7 +695,8 @@ function encodeDownlinkCommand(cmd) {
     if (b.from_state) body = body.concat(_encTag(8, 0)).concat(_encVarint(b.from_state));
     if (b.to_state) body = body.concat(_encTag(9, 0)).concat(_encVarint(b.to_state));
   }
-  // get_info / settings_save / reboot / factory_reset / force_send / clock_sync: empty body.
+  // get_info / settings_save / reboot / factory_reset / force_send / clock_sync /
+  // w1_scan: empty body.
 
   out = out.concat(_encLenDelim(tag, body));
   return { bytes: out, error: null };

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -73,6 +73,7 @@ const COMMANDS = [
   { name: "clock_sync", hex: "08056200", data: { seq: 5, command: "clock_sync" } },
   { name: "force_send", hex: "08064a00", data: { seq: 6, command: "force_send" } },
   { name: "reboot", hex: "08083a00", data: { seq: 8, command: "reboot" } },
+  { name: "w1_scan", hex: "08097200", data: { seq: 9, command: "w1_scan" } },
 ];
 
 test("decodeDownlink decodes command frames", () => {
@@ -150,6 +151,22 @@ test("decodeUplink decodes an Ack response (fPort 85)", () => {
   const got = codec.decodeUplink({ bytes: hex("0108011200"), fPort: 85 });
   assert.equal(got.data.seq, 1);
   assert.deepEqual(got.data.ack, {});
+});
+
+// W1Scan response (field 7): the discovered 1-Wire ROMs come back as hex
+// strings so the host can teach a slot via SetParam sensorN_rom.
+//   01           APP_PROTO_VERSION prefix
+//   08 02        seq=2
+//   3a 14        w1_scan, len=20
+//     0a 08 28000011223344a5   rom[0] (8 B: family 0x28 + serial + crc)
+//     0a 08 28abcdef010203b7   rom[1]
+test("decodeUplink decodes a W1Scan response (fPort 85)", () => {
+  const got = codec.decodeUplink({
+    bytes: hex("0108023a140a0828000011223344a50a0828abcdef010203b7"),
+    fPort: 85,
+  }).data;
+  assert.equal(got.seq, 2);
+  assert.deepEqual(got.w1_scan.rom, ["28000011223344a5", "28abcdef010203b7"]);
 });
 
 // --- Uplink: protobuf telemetry (fPort 2) ---------------------------------

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -325,12 +325,24 @@ static void handle_reset_counters(const Command_ResetCounters *rc, Response *res
 	resp->which_body = Response_ack_tag;
 }
 
+/* Some commands answer ONLY via a LoRaWAN uplink — triggered telemetry
+ * (force_send), a HistoryFrame stream (req_history), or a deferred clock Info
+ * (clock_sync). Over NFC the caller waits for a reply on the same transport and
+ * would get nothing, so reject them with an error it can surface. Returns true
+ * when the transport is LRW (proceed), false after filling an Error. */
+static bool require_lrw(enum app_cmd_transport transport, Response *resp)
+{
+	if (transport != APP_CMD_TRANSPORT_LRW) {
+		make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
+		return false;
+	}
+	return true;
+}
+
 static void handle_req_history(enum app_cmd_transport transport, const Command *cmd, Response *resp)
 {
 #if defined(APP_CMD_HAVE_HISTORY) && defined(CONFIG_LORAWAN)
-	if (transport != APP_CMD_TRANSPORT_LRW) {
-		/* Replay is inherently a stream of LoRaWAN uplinks. */
-		make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
+	if (!require_lrw(transport, resp)) {
 		return;
 	}
 
@@ -451,8 +463,6 @@ static void handle_w1_scan(Response *resp)
 static void dispatch(enum app_cmd_transport transport, const Command *cmd, Response *resp,
 		     enum app_cmd_action *action)
 {
-	ARG_UNUSED(transport);
-
 	resp->seq = cmd->seq;
 
 	switch (cmd->which_body) {
@@ -489,6 +499,9 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 		break;
 
 	case Command_force_send_tag:
+		if (!require_lrw(transport, resp)) {
+			break;
+		}
 #if defined(CONFIG_LORAWAN)
 		app_lrw_send();
 #endif
@@ -501,6 +514,9 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 		break;
 
 	case Command_clock_sync_tag:
+		if (!require_lrw(transport, resp)) {
+			break;
+		}
 #if defined(APP_CMD_HAVE_CLOCK) && defined(CONFIG_LORAWAN)
 		/* Re-sync, then answer with an Info uplink once the network time lands
 		 * (carries the synced unix_time). No ack — see app_lrw. */

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -445,10 +445,14 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 		break;
 
 	case Command_clock_sync_tag:
-#ifdef APP_CMD_HAVE_CLOCK
+#if defined(APP_CMD_HAVE_CLOCK) && defined(CONFIG_LORAWAN)
+		/* Re-sync, then answer with an Info uplink once the network time lands
+		 * (carries the synced unix_time). No ack — see app_lrw. */
 		app_clock_force_resync();
+		app_lrw_send_info_on_clock_sync();
+#else
+		resp->which_body = Response_ack_tag; /* no clock/LRW: just confirm */
 #endif
-		resp->which_body = Response_ack_tag;
 		break;
 
 	case Command_alarm_rule_tag:

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -436,7 +436,8 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 #if defined(CONFIG_LORAWAN)
 		app_lrw_send();
 #endif
-		resp->which_body = Response_ack_tag;
+		/* No ack — the triggered telemetry uplink IS the answer; an extra ack
+		 * would just cost a second uplink. Leave which_body == 0 (emit nothing). */
 		break;
 
 	case Command_reset_counters_tag:

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -28,6 +28,14 @@
 #define APP_CMD_HAVE_HISTORY 1
 #endif
 
+/* 1-Wire bus enumeration (W1Scan command). Present only when the DS2484 bridge
+ * is configured; the response returns the discovered ROMs so the host can teach
+ * a slot via SetParam sensorN_rom. */
+#if defined(CONFIG_W1)
+#include "app_w1.h"
+#define APP_CMD_HAVE_W1 1
+#endif
+
 /* Nanopb includes */
 #include <pb_decode.h>
 #include <pb_encode.h>
@@ -392,6 +400,54 @@ static void handle_alarm_rule(const Command *cmd, Response *resp, enum app_cmd_a
 	}
 }
 
+#if defined(APP_CMD_HAVE_W1)
+/* w1_scan ROM-discovery callback: append each ROM (8 bytes: family + 6-byte
+ * serial + CRC) to the response, capped at the field's max_count. */
+static int w1_scan_cb(struct w1_rom rom, void *user_data)
+{
+	Response_W1Scan *w1 = user_data;
+
+	if (w1->rom_count >= ARRAY_SIZE(w1->rom)) {
+		return 0; /* response is full; ignore the rest */
+	}
+
+	BUILD_ASSERT(sizeof(rom) == 8, "w1_rom must be 8 bytes");
+	w1->rom[w1->rom_count].size = sizeof(rom);
+	memcpy(w1->rom[w1->rom_count].bytes, &rom, sizeof(rom));
+	w1->rom_count++;
+
+	return 0;
+}
+
+static void handle_w1_scan(Response *resp)
+{
+	static const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ds2484));
+	struct app_w1 w1 = {0};
+	int ret;
+
+	if (!device_is_ready(dev)) {
+		make_error(resp, Response_Error_Code_NOT_READY, "1-wire bus");
+		return;
+	}
+
+	ret = app_w1_acquire(&w1, dev);
+	if (ret) {
+		make_error(resp, Response_Error_Code_NOT_READY, "1-wire acquire");
+		return;
+	}
+
+	resp->which_body = Response_w1_scan_tag;
+	resp->body.w1_scan.rom_count = 0;
+	ret = app_w1_scan(&w1, dev, w1_scan_cb, &resp->body.w1_scan);
+
+	(void)app_w1_release(&w1, dev);
+
+	if (ret < 0) {
+		make_error(resp, Response_Error_Code_NOT_READY, "1-wire scan");
+	}
+}
+#endif /* APP_CMD_HAVE_W1 */
+
 static void dispatch(enum app_cmd_transport transport, const Command *cmd, Response *resp,
 		     enum app_cmd_action *action)
 {
@@ -460,6 +516,14 @@ static void dispatch(enum app_cmd_transport transport, const Command *cmd, Respo
 		break;
 	case Command_req_history_tag:
 		handle_req_history(transport, cmd, resp);
+		break;
+
+	case Command_w1_scan_tag:
+#if defined(APP_CMD_HAVE_W1)
+		handle_w1_scan(resp);
+#else
+		make_error(resp, Response_Error_Code_NOT_READY, "no 1-wire");
+#endif
 		break;
 
 	default:

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -34,7 +34,7 @@ enum app_cmd_action {
 	APP_CMD_ACTION_NONE = 0,
 	APP_CMD_ACTION_SETTINGS_SAVE,    /* persist staged config + reboot */
 	APP_CMD_ACTION_REBOOT,           /* reboot (discards staged edits) */
-	APP_CMD_ACTION_FACTORY_RESET,    /* erase NVS + reboot */
+	APP_CMD_ACTION_FACTORY_RESET,    /* defaults (keep identity+LoRaWAN) + reboot */
 	APP_CMD_ACTION_ALARM_RULES_SAVE, /* persist alarm-rule blob (no reboot) */
 };
 

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -1836,6 +1836,46 @@ struct app_config *app_config(void)
 	return &m_app_config;
 }
 
+int app_config_factory_reset(void)
+{
+	int ret;
+
+	/* Reset every parameter to its compiled-in default, but carry over the
+	 * factory identity and network credentials (preserve_on_migration in the
+	 * YAML) so the reset never un-provisions the device or drops it off the
+	 * LoRaWAN network. A full wipe (incl. identity) stays shell-only via
+	 * `settings reset`. Mirrors the migration restore in h_commit. */
+	struct app_config preserved = m_app_config;
+
+	m_app_config = m_app_config_defaults;
+	memcpy(m_app_config.secret_key, preserved.secret_key, sizeof(m_app_config.secret_key));
+	m_app_config.serial_number = preserved.serial_number;
+	m_app_config.nonce_counter = preserved.nonce_counter;
+	m_app_config.lrw_region = preserved.lrw_region;
+	m_app_config.lrw_sub_band = preserved.lrw_sub_band;
+	m_app_config.lrw_network = preserved.lrw_network;
+	m_app_config.lrw_adr = preserved.lrw_adr;
+	m_app_config.lrw_activation = preserved.lrw_activation;
+	memcpy(m_app_config.lrw_deveui, preserved.lrw_deveui, sizeof(m_app_config.lrw_deveui));
+	memcpy(m_app_config.lrw_joineui, preserved.lrw_joineui, sizeof(m_app_config.lrw_joineui));
+	memcpy(m_app_config.lrw_nwkkey, preserved.lrw_nwkkey, sizeof(m_app_config.lrw_nwkkey));
+	memcpy(m_app_config.lrw_appkey, preserved.lrw_appkey, sizeof(m_app_config.lrw_appkey));
+	memcpy(m_app_config.lrw_devaddr, preserved.lrw_devaddr, sizeof(m_app_config.lrw_devaddr));
+	memcpy(m_app_config.lrw_nwkskey, preserved.lrw_nwkskey, sizeof(m_app_config.lrw_nwkskey));
+	memcpy(m_app_config.lrw_appskey, preserved.lrw_appskey, sizeof(m_app_config.lrw_appskey));
+
+	memcpy(&g_app_config, &m_app_config, sizeof(g_app_config));
+
+	ret = settings_save_subtree(SETTINGS_PFX);
+	if (ret) {
+		LOG_ERR("Call `settings_save_subtree` failed: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("Factory reset: config restored to defaults (identity + LoRaWAN kept)");
+	return 0;
+}
+
 static int app_config_init(void)
 {
 	int ret;

--- a/app/src/app_config.h
+++ b/app/src/app_config.h
@@ -90,6 +90,13 @@ extern struct app_config g_app_config;
 
 struct app_config *app_config(void);
 
+/* Reset every parameter to its compiled-in default EXCEPT the factory identity
+ * and network credentials (preserve_on_migration), then persist. Backs the
+ * factory_reset command so the device keeps its LoRaWAN session; the shell
+ * `settings reset` still does a full NVS wipe. Returns 0 or a negative errno.
+ * The caller reboots so every module re-reads the restored config. */
+int app_config_factory_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/app_config.options.in
+++ b/app/src/app_config.options.in
@@ -29,3 +29,7 @@ Command.GetParam.lorawan_field     max_count:16
 Command.GetParam.application_field max_count:16
 Command.GetParam.sensors_field     max_count:16
 Command.GetParam.alarms_field      max_count:16
+
+# W1Scan response: discovered 1-Wire ROMs (8 B each). Capped to the slot count;
+# the encoded reply must fit the fPort-85 response buffer (64 B).
+Response.W1Scan.rom max_count:4 max_size:8

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -136,6 +136,7 @@ message Command {
         ReqHistory      req_history      = 11;
         ClockSync       clock_sync       = 12;
         AlarmRule       alarm_rule       = 13;
+        W1Scan          w1_scan          = 14;
     }
 
     message SetParam {
@@ -186,6 +187,10 @@ message Command {
         optional uint32 from_state = 8;
         optional uint32 to_state   = 9;
     }
+
+    // Enumerate the 1-Wire bus; the response (Response.W1Scan) returns the
+    // discovered ROMs so the host can teach a slot via SetParam sensorN_rom.
+    message W1Scan { }
 }
 
 message Response {
@@ -197,6 +202,7 @@ message Response {
         ConfigDump   config_dump   = 4;
         HistoryFrame history_frame = 5;
         Error        error         = 6;
+        W1Scan       w1_scan       = 7;
     }
 
     message Ack { }
@@ -254,6 +260,13 @@ message Response {
         Code   code         = 1;
         uint32 fault_field  = 2;
         string detail       = 3;
+    }
+
+    // Answer to a W1Scan command: the ROMs discovered on the 1-Wire bus (8 bytes
+    // each: family + 6-byte serial + CRC). The host teaches a slot by writing a
+    // chosen ROM to sensorN_rom via SetParam.
+    message W1Scan {
+        repeated bytes rom = 1;
     }
 }
 

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -167,6 +167,10 @@ static struct k_work m_dl_request_work;
 static struct k_work_delayable m_post_cmd_work;
 static enum app_cmd_action m_post_cmd_action;
 
+/* Set by a ClockSync command; the next network time-update sends an Info uplink
+ * (with the synced unix_time) instead of the command acking immediately. */
+static bool m_clock_sync_info_pending;
+
 static uint32_t calculate_rejoin_backoff(int attempt)
 {
 	uint32_t backoff = REJOIN_BACKOFF_BASE_SEC;
@@ -279,6 +283,19 @@ static void downlink_callback(uint8_t port, uint8_t flags, int16_t rssi, int8_t 
 
 	/* Set the RTC from the network if this downlink carried a DeviceTimeAns. */
 	app_clock_handle_downlink(flags);
+
+	/* Deferred answer to a ClockSync command: once the network time actually
+	 * lands, send an Info uplink carrying the freshly-synced unix_time (the
+	 * command itself does not ack — saves an uplink, and a bare ack couldn't
+	 * carry the synced time yet). */
+	if (m_clock_sync_info_pending && (flags & LORAWAN_TIME_UPDATED)) {
+		m_clock_sync_info_pending = false;
+		uint8_t info_buf[APP_LRW_RESPONSE_BUF_SIZE];
+		size_t info_len;
+		if (app_cmd_build_info(info_buf, sizeof(info_buf), &info_len) == 0) {
+			(void)app_lrw_queue_response(APP_LRW_DOWNLINK_CMD_PORT, info_buf, info_len);
+		}
+	}
 
 	if (port == APP_LRW_DOWNLINK_CMD_PORT && data && len > 0) {
 		if (len <= sizeof(m_dl_request_buf)) {
@@ -1300,6 +1317,13 @@ int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len)
 	 * instead of waiting for the periodic timer. */
 	k_work_submit_to_queue(&m_work_q, &m_send_work);
 	return 0;
+}
+
+void app_lrw_send_info_on_clock_sync(void)
+{
+	/* Arm the deferred Info; downlink_callback sends it once LORAWAN_TIME_UPDATED
+	 * arrives (the ClockSync command answer). */
+	m_clock_sync_info_pending = true;
 }
 
 int app_lrw_send_alarm(const uint8_t *buf, size_t len)

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -210,8 +210,8 @@ static void post_cmd_work_handler(struct k_work *work)
 		app_settings_save(true);
 		break;
 	case APP_CMD_ACTION_FACTORY_RESET:
-		LOG_INF("Command: factory reset + reboot");
-		app_settings_reset();
+		LOG_INF("Command: factory reset (keep identity + LoRaWAN) + reboot");
+		app_settings_factory_reset();
 		break;
 	case APP_CMD_ACTION_REBOOT:
 		LOG_INF("Command: reboot");

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -64,6 +64,11 @@ uint8_t app_lrw_get_max_payload(void);
  * a warning if a prior response hasn't been transmitted yet. */
 int app_lrw_queue_response(uint8_t port, const uint8_t *buf, size_t len);
 
+/* Arm a deferred GetInfo uplink to answer a ClockSync command: the next network
+ * time-update (DeviceTimeAns) sends an Info carrying the synced unix_time. The
+ * command itself does not ack (saves an uplink; a bare ack can't carry the time). */
+void app_lrw_send_info_on_clock_sync(void);
+
 /* Stage an alarm-detail batch (issue #27) for the next uplink on fPort 3. Own
  * slot, drained after the command response and before telemetry, so it never
  * collides with app_lrw_queue_response(). Returns 0, -EINVAL, or -EMSGSIZE. */

--- a/app/src/app_settings.c
+++ b/app/src/app_settings.c
@@ -5,6 +5,7 @@
  */
 
 #include "app_settings.h"
+#include "app_alarm_rules.h"
 #include "app_config.h"
 #include "app_config_ingest.h"
 
@@ -170,4 +171,30 @@ int app_settings_save(bool reboot)
 int app_settings_reset(void)
 {
 	return reset(true);
+}
+
+int app_settings_factory_reset(void)
+{
+	int ret;
+
+	/* Config: defaults for everything except the preserved identity + LoRaWAN
+	 * fields (see app_config_factory_reset). */
+	ret = app_config_factory_reset();
+	if (ret) {
+		LOG_ERR("Call `app_config_factory_reset` failed: %d", ret);
+		return ret;
+	}
+
+	/* Dynamic alarm rules live outside the config blob; clear them too so a
+	 * factory reset returns the full application state to defaults. */
+	app_alarm_rules_clear_all();
+	ret = app_alarm_rules_save();
+	if (ret) {
+		LOG_ERR("Call `app_alarm_rules_save` failed: %d", ret);
+		return ret;
+	}
+
+	sys_reboot(SYS_REBOOT_COLD);
+
+	return 0;
 }

--- a/app/src/app_settings.h
+++ b/app/src/app_settings.h
@@ -17,6 +17,13 @@ extern "C" {
 int app_settings_save(bool reboot);
 int app_settings_reset(void);
 
+/* Factory reset for the factory_reset command: restore every config parameter
+ * (and clear all dynamic alarm rules) to defaults but KEEP the device identity
+ * and LoRaWAN credentials, then reboot, so the device stays provisioned and on
+ * the network. Differs from app_settings_reset(), which wipes the whole NVS
+ * partition (identity included) and is reserved for the shell. */
+int app_settings_factory_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -718,6 +718,39 @@ struct {{ module.name }} *{{ module.name }}(void)
 	return &m_{{ module.name }};
 }
 
+int {{ module.name }}_factory_reset(void)
+{
+	int ret;
+
+	/* Reset every parameter to its compiled-in default, but carry over the
+	 * factory identity and network credentials (preserve_on_migration in the
+	 * YAML) so the reset never un-provisions the device or drops it off the
+	 * LoRaWAN network. A full wipe (incl. identity) stays shell-only via
+	 * `settings reset`. Mirrors the migration restore in h_commit. */
+	struct {{ module.name }} preserved = m_{{ module.name }};
+
+	m_{{ module.name }} = m_{{ module.name }}_defaults;
+{% for param in parameters if param.preserve_on_migration | default(false) %}
+{% if param.type == 'bytes' or param.type == 'string' %}
+	memcpy(m_{{ module.name }}.{{ param.name | c_name }}, preserved.{{ param.name | c_name }},
+	       sizeof(m_{{ module.name }}.{{ param.name | c_name }}));
+{% else %}
+	m_{{ module.name }}.{{ param.name | c_name }} = preserved.{{ param.name | c_name }};
+{% endif %}
+{% endfor %}
+
+	memcpy(&g_{{ module.name }}, &m_{{ module.name }}, sizeof(g_{{ module.name }}));
+
+	ret = settings_save_subtree(SETTINGS_PFX);
+	if (ret) {
+		LOG_ERR("Call `settings_save_subtree` failed: %d", ret);
+		return ret;
+	}
+
+	LOG_INF("Factory reset: config restored to defaults (identity + LoRaWAN kept)");
+	return 0;
+}
+
 static int {{ module.name }}_init(void)
 {
 	int ret;

--- a/scripts/west_commands/templates/config.h.j2
+++ b/scripts/west_commands/templates/config.h.j2
@@ -42,6 +42,13 @@ extern struct {{ module.name }} g_{{ module.name }};
 
 struct {{ module.name }} *{{ module.name }}(void);
 
+/* Reset every parameter to its compiled-in default EXCEPT the factory identity
+ * and network credentials (preserve_on_migration), then persist. Backs the
+ * factory_reset command so the device keeps its LoRaWAN session; the shell
+ * `settings reset` still does a full NVS wipe. Returns 0 or a negative errno.
+ * The caller reboots so every module re-reads the restored config. */
+int {{ module.name }}_factory_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -33,16 +33,16 @@ static size_t unhex(const char *hex, uint8_t *out, size_t cap)
 	return n;
 }
 
-/* Run app_cmd_handle on a hex command; decode the Response into `resp`. */
-static enum app_cmd_action handle(const char *hex, Response *resp)
+/* Run app_cmd_handle on a hex command over `transport`; decode the Response. */
+static enum app_cmd_action handle_via(enum app_cmd_transport transport, const char *hex,
+				      Response *resp)
 {
 	uint8_t in[64], out[128];
 	size_t in_len = unhex(hex, in, sizeof(in));
 	size_t out_len = 0;
 	enum app_cmd_action action = APP_CMD_ACTION_NONE;
 
-	int ret = app_cmd_handle(APP_CMD_TRANSPORT_LRW, in, in_len, out, sizeof(out), &out_len,
-				 &action);
+	int ret = app_cmd_handle(transport, in, in_len, out, sizeof(out), &out_len, &action);
 	zassert_equal(ret, 0, "app_cmd_handle ret %d", ret);
 
 	/* out[0] is the APP_PROTO_VERSION prefix (#55); decode the protobuf after it. */
@@ -52,6 +52,12 @@ static enum app_cmd_action handle(const char *hex, Response *resp)
 	pb_istream_t is = pb_istream_from_buffer(out + 1, out_len - 1);
 	zassert_true(pb_decode(&is, Response_fields, resp), "Response decode failed");
 	return action;
+}
+
+/* Most tests exercise the LoRaWAN transport. */
+static enum app_cmd_action handle(const char *hex, Response *resp)
+{
+	return handle_via(APP_CMD_TRANSPORT_LRW, hex, resp);
 }
 
 static void reset_cfg(void)
@@ -147,6 +153,34 @@ ZTEST(cmd, test_deferred_actions)
 
 	zassert_equal(handle("08083a00", &r), APP_CMD_ACTION_REBOOT, "reboot");
 	zassert_equal(handle("08094200", &r), APP_CMD_ACTION_FACTORY_RESET, "factory");
+}
+
+/* force_send / clock_sync / req_history answer only via a LoRaWAN uplink, so
+ * over NFC they must be rejected with an Error (NOT_READY) rather than firing a
+ * side effect the NFC caller can never observe. */
+ZTEST(cmd, test_lrw_only_commands_rejected_over_nfc)
+{
+	Response r;
+
+	/* force_send (field 9, empty body) — seq=6. */
+	reset_cfg();
+	handle_via(APP_CMD_TRANSPORT_NFC, "08064a00", &r);
+	zassert_equal(r.which_body, Response_error_tag, "force_send/NFC should error (which=%d)",
+		      r.which_body);
+	zassert_equal(r.body.error.code, Response_Error_Code_NOT_READY, "code %d",
+		      r.body.error.code);
+
+	/* clock_sync (field 12, empty body) — seq=5. */
+	reset_cfg();
+	handle_via(APP_CMD_TRANSPORT_NFC, "08056200", &r);
+	zassert_equal(r.which_body, Response_error_tag, "clock_sync/NFC should error (which=%d)",
+		      r.which_body);
+
+	/* req_history (field 11) — seq=7, empty window. */
+	reset_cfg();
+	handle_via(APP_CMD_TRANSPORT_NFC, "08075a00", &r);
+	zassert_equal(r.which_body, Response_error_tag, "req_history/NFC should error (which=%d)",
+		      r.which_body);
 }
 
 /* #89: a fully-populated history frame (48 samples, synced 5-byte t0) must fit


### PR DESCRIPTION
**WIP / draft.** Implements the YAML-driven command-schema plan (design note:
`doc/configen-commands-design.md`, project-level). Stacked on #105 (config regroup +
ingest codegen) — base will be retargeted to `v1.4.0` once #105 merges.

## Goal
Move the command protocol to a `commands:` section in `app_config.yml` so the `Command`
oneof + decoder maps + the `app_cmd.c` dispatch are **generated** (kill the proto↔app_cmd↔
ttn.js drift), plus the agreed behaviour refinements.

## Phases (checklist)
**Track A — behaviour (no codegen, shippable independently):**
- [x] `force_send` → no ack (the telemetry IS the answer)
- [x] `clock_sync` → no ack; deferred **Info** uplink once the DeviceTime sync lands (app_clock hook)
- [x] `factory_reset` → reset application/sensors/alarms to defaults but **keep device + lorawan** (reuse the `preserve_on_migration` whitelist); full wipe stays shell-only
- [x] `w1_scan` (new cmd, proto_id 14) + `Response.W1Scan{repeated bytes rom}` + DS2484 ROM search; app teaches via `set_param sensorN_rom`
- [x] transport gating: LRW-only for `force_send`/`req_history`/`clock_sync`

**Track B — codegen (configen `commands:`):**
- [ ] `commands:` YAML section + `build_commands_model()`
- [ ] generate `_CMD_NAMES`/`_CMD_TAGS` (decoder) + verify no behaviour change
- [ ] generate the `app_cmd_dispatch()` **switch** into an `app_cmd.c` marked region; adversarially verify it routes identically to the current hand switch; ztest per command kind
- [ ] generate the proto `Command` oneof (append-only guard, reserved on removal)

**Out of scope (separate):** NFC response path (#69) + NFC inbound transport gating (#68) — design context already posted there.

## Verification per phase
release build, native_sim ztest (cmd/compose/history), configen pytest, node decoder.
HW test recommended. manager-app must mirror the new schema.




