### PR TITLE
configen: command-protocol codegen (Track B)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -114,12 +114,23 @@ var _ALM_TAGS = _invert(_ALM_NAMES);
 var _LRW_TAGS = _invert(_LRW_NAMES);
 
 // proto field tag -> command name in the DownlinkCommand body oneof.
+// BEGIN GENERATED COMMANDS
 var _CMD_NAMES = {
-  2: "set_param", 3: "get_param", 4: "get_info", 5: "get_config",
-  6: "settings_save", 7: "reboot", 8: "factory_reset", 9: "force_send",
-  10: "reset_counters", 11: "req_history", 12: "clock_sync", 13: "alarm_rule",
-  14: "w1_scan"
+  2: "set_param",
+  3: "get_param",
+  4: "get_info",
+  5: "get_config",
+  6: "settings_save",
+  7: "reboot",
+  8: "factory_reset",
+  9: "force_send",
+  10: "reset_counters",
+  11: "req_history",
+  12: "clock_sync",
+  13: "alarm_rule",
+  14: "w1_scan",
 };
+// END GENERATED COMMANDS
 var _CMD_TAGS = _invert(_CMD_NAMES);
 
 function _decodeLorawan(bytes, start, end) {

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -121,9 +121,15 @@ static void make_error(Response *resp, Response_Error_Code code, const char *det
 	}
 }
 
-static void handle_set_param(const Command_SetParam *sp, Response *resp,
-			     enum app_cmd_action *action)
+/* Command handlers share a uniform signature (transport, cmd, resp, action) so
+ * the generated app_cmd_dispatch() switch can call any of them the same way; a
+ * handler simply ignores the parameters it does not need. They fill `resp`
+ * (response body or error) and may set `*action` for deferred work. */
+static void app_cmd_handle_set_param(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				     enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
+	const Command_SetParam *sp = &cmd->body.set_param;
 	uint32_t fault = 0;
 	int rc = 0;
 
@@ -161,8 +167,13 @@ static void handle_set_param(const Command_SetParam *sp, Response *resp,
 	}
 }
 
-static void handle_get_param(const Command_GetParam *gp, Response *resp)
+static void app_cmd_handle_get_param(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				     enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
+	ARG_UNUSED(action);
+	const Command_GetParam *gp = &cmd->body.get_param;
+
 	resp->which_body = Response_config_dump_tag;
 	resp->body.config_dump.page_index = 0;
 	resp->body.config_dump.page_count = 1;
@@ -187,6 +198,17 @@ static void handle_get_param(const Command_GetParam *gp, Response *resp)
 		app_config_fill_alarms(&resp->body.config_dump.alarms, gp->alarms_field,
 				       gp->alarms_field_count);
 	}
+}
+
+static void app_cmd_handle_get_info(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				    enum app_cmd_action *action)
+{
+	ARG_UNUSED(tp);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(action);
+
+	resp->which_body = Response_info_tag;
+	fill_info(&resp->body.info);
 }
 
 /* Dumpable config fields in fixed order, each with a conservative upper bound
@@ -258,8 +280,12 @@ static const struct {
  * overflow (the largest single field is 18 B). */
 #define DUMP_PAGE_BUDGET 30
 
-static void handle_get_config(const Command_GetConfig *gc, Response *resp)
+static void app_cmd_handle_get_config(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				      enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
+	ARG_UNUSED(action);
+	const Command_GetConfig *gc = &cmd->body.get_config;
 	uint32_t page = gc->has_page ? gc->page : 0;
 
 	/* One tag buffer per section, each sized to the whole table so any single
@@ -317,35 +343,42 @@ static void handle_get_config(const Command_GetConfig *gc, Response *resp)
 	}
 }
 
-static void handle_reset_counters(const Command_ResetCounters *rc, Response *resp)
+static void app_cmd_handle_reset_counters(enum app_cmd_transport tp, const Command *cmd,
+					  Response *resp, enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
+	ARG_UNUSED(action);
+	const Command_ResetCounters *rc = &cmd->body.reset_counters;
+
 	app_hall_reset_count(rc->has_hall_left && rc->hall_left,
 			     rc->has_hall_right && rc->hall_right);
 	app_input_reset_count(rc->has_input_a && rc->input_a, rc->has_input_b && rc->input_b);
 	resp->which_body = Response_ack_tag;
 }
 
-/* Some commands answer ONLY via a LoRaWAN uplink — triggered telemetry
- * (force_send), a HistoryFrame stream (req_history), or a deferred clock Info
- * (clock_sync). Over NFC the caller waits for a reply on the same transport and
- * would get nothing, so reject them with an error it can surface. Returns true
- * when the transport is LRW (proceed), false after filling an Error. */
-static bool require_lrw(enum app_cmd_transport transport, Response *resp)
+/* force_send / req_history / clock_sync are LRW-only (transports: [lrw] in the
+ * YAML); the generated dispatch enforces that before calling the handler, so
+ * the handlers below assume the LoRaWAN transport. */
+static void app_cmd_handle_force_send(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				      enum app_cmd_action *action)
 {
-	if (transport != APP_CMD_TRANSPORT_LRW) {
-		make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
-		return false;
-	}
-	return true;
+	ARG_UNUSED(tp);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(resp);
+	ARG_UNUSED(action);
+#if defined(CONFIG_LORAWAN)
+	app_lrw_send();
+#endif
+	/* No ack — the triggered telemetry uplink IS the answer; an extra ack
+	 * would just cost a second uplink. Leave which_body == 0 (emit nothing). */
 }
 
-static void handle_req_history(enum app_cmd_transport transport, const Command *cmd, Response *resp)
+static void app_cmd_handle_req_history(enum app_cmd_transport tp, const Command *cmd,
+				       Response *resp, enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
+	ARG_UNUSED(action);
 #if defined(APP_CMD_HAVE_HISTORY) && defined(CONFIG_LORAWAN)
-	if (!require_lrw(transport, resp)) {
-		return;
-	}
-
 	const Command_ReqHistory *rq = &cmd->body.req_history;
 	uint32_t from = rq->has_from_unix ? rq->from_unix : 0;
 	uint32_t to = rq->has_to_unix ? rq->to_unix : UINT32_MAX;
@@ -359,14 +392,15 @@ static void handle_req_history(enum app_cmd_transport transport, const Command *
 		make_error(resp, Response_Error_Code_HISTORY_UNAVAILABLE, "no records");
 	}
 #else
-	ARG_UNUSED(transport);
 	ARG_UNUSED(cmd);
 	make_error(resp, Response_Error_Code_HISTORY_UNAVAILABLE, "no history");
 #endif
 }
 
-static void handle_alarm_rule(const Command *cmd, Response *resp, enum app_cmd_action *action)
+static void app_cmd_handle_alarm_rule(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				      enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
 	const Command_AlarmRule *ar = &cmd->body.alarm_rule;
 	int ret;
 
@@ -431,8 +465,32 @@ static int w1_scan_cb(struct w1_rom rom, void *user_data)
 	return 0;
 }
 
-static void handle_w1_scan(Response *resp)
+#endif /* APP_CMD_HAVE_W1 */
+
+static void app_cmd_handle_clock_sync(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				      enum app_cmd_action *action)
 {
+	ARG_UNUSED(tp);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(action);
+#if defined(APP_CMD_HAVE_CLOCK) && defined(CONFIG_LORAWAN)
+	ARG_UNUSED(resp);
+	/* Re-sync, then answer with an Info uplink once the network time lands
+	 * (carries the synced unix_time). No ack — see app_lrw. */
+	app_clock_force_resync();
+	app_lrw_send_info_on_clock_sync();
+#else
+	resp->which_body = Response_ack_tag; /* no clock/LRW: just confirm */
+#endif
+}
+
+static void app_cmd_handle_w1_scan(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				   enum app_cmd_action *action)
+{
+	ARG_UNUSED(tp);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(action);
+#if defined(APP_CMD_HAVE_W1)
 	static const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ds2484));
 	struct app_w1 w1 = {0};
 	int ret;
@@ -457,97 +515,82 @@ static void handle_w1_scan(Response *resp)
 	if (ret < 0) {
 		make_error(resp, Response_Error_Code_NOT_READY, "1-wire scan");
 	}
+#else
+	make_error(resp, Response_Error_Code_NOT_READY, "no 1-wire");
+#endif
 }
-#endif /* APP_CMD_HAVE_W1 */
 
-static void dispatch(enum app_cmd_transport transport, const Command *cmd, Response *resp,
-		     enum app_cmd_action *action)
+// BEGIN GENERATED DISPATCH
+static void app_cmd_dispatch(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+			     enum app_cmd_action *action)
 {
 	resp->seq = cmd->seq;
 
 	switch (cmd->which_body) {
-	case Command_get_info_tag:
-		resp->which_body = Response_info_tag;
-		fill_info(&resp->body.info);
-		break;
-
 	case Command_set_param_tag:
-		handle_set_param(&cmd->body.set_param, resp, action);
+		app_cmd_handle_set_param(tp, cmd, resp, action);
 		break;
-
 	case Command_get_param_tag:
-		handle_get_param(&cmd->body.get_param, resp);
+		app_cmd_handle_get_param(tp, cmd, resp, action);
 		break;
-
+	case Command_get_info_tag:
+		app_cmd_handle_get_info(tp, cmd, resp, action);
+		break;
 	case Command_get_config_tag:
-		handle_get_config(&cmd->body.get_config, resp);
+		app_cmd_handle_get_config(tp, cmd, resp, action);
 		break;
-
 	case Command_settings_save_tag:
-		resp->which_body = Response_ack_tag;
 		*action = APP_CMD_ACTION_SETTINGS_SAVE;
+		resp->which_body = Response_ack_tag;
 		break;
-
 	case Command_reboot_tag:
-		resp->which_body = Response_ack_tag;
 		*action = APP_CMD_ACTION_REBOOT;
-		break;
-
-	case Command_factory_reset_tag:
 		resp->which_body = Response_ack_tag;
+		break;
+	case Command_factory_reset_tag:
 		*action = APP_CMD_ACTION_FACTORY_RESET;
+		resp->which_body = Response_ack_tag;
 		break;
-
 	case Command_force_send_tag:
-		if (!require_lrw(transport, resp)) {
+		/* transports: [lrw] — the answer is an uplink, meaningless over NFC */
+		if (tp != APP_CMD_TRANSPORT_LRW) {
+			make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
 			break;
 		}
-#if defined(CONFIG_LORAWAN)
-		app_lrw_send();
-#endif
-		/* No ack — the triggered telemetry uplink IS the answer; an extra ack
-		 * would just cost a second uplink. Leave which_body == 0 (emit nothing). */
+		app_cmd_handle_force_send(tp, cmd, resp, action);
 		break;
-
 	case Command_reset_counters_tag:
-		handle_reset_counters(&cmd->body.reset_counters, resp);
-		break;
-
-	case Command_clock_sync_tag:
-		if (!require_lrw(transport, resp)) {
-			break;
-		}
-#if defined(APP_CMD_HAVE_CLOCK) && defined(CONFIG_LORAWAN)
-		/* Re-sync, then answer with an Info uplink once the network time lands
-		 * (carries the synced unix_time). No ack — see app_lrw. */
-		app_clock_force_resync();
-		app_lrw_send_info_on_clock_sync();
-#else
-		resp->which_body = Response_ack_tag; /* no clock/LRW: just confirm */
-#endif
-		break;
-
-	case Command_alarm_rule_tag:
-		handle_alarm_rule(cmd, resp, action);
+		app_cmd_handle_reset_counters(tp, cmd, resp, action);
 		break;
 	case Command_req_history_tag:
-		handle_req_history(transport, cmd, resp);
+		/* transports: [lrw] — the answer is an uplink, meaningless over NFC */
+		if (tp != APP_CMD_TRANSPORT_LRW) {
+			make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
+			break;
+		}
+		app_cmd_handle_req_history(tp, cmd, resp, action);
 		break;
-
+	case Command_clock_sync_tag:
+		/* transports: [lrw] — the answer is an uplink, meaningless over NFC */
+		if (tp != APP_CMD_TRANSPORT_LRW) {
+			make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
+			break;
+		}
+		app_cmd_handle_clock_sync(tp, cmd, resp, action);
+		break;
+	case Command_alarm_rule_tag:
+		app_cmd_handle_alarm_rule(tp, cmd, resp, action);
+		break;
 	case Command_w1_scan_tag:
-#if defined(APP_CMD_HAVE_W1)
-		handle_w1_scan(resp);
-#else
-		make_error(resp, Response_Error_Code_NOT_READY, "no 1-wire");
-#endif
+		app_cmd_handle_w1_scan(tp, cmd, resp, action);
 		break;
-
 	default:
 		LOG_WRN("Command tag %u not implemented", cmd->which_body);
 		make_error(resp, Response_Error_Code_UNKNOWN, "not implemented");
 		break;
 	}
 }
+// END GENERATED DISPATCH
 
 /* Encode a Response into `out` with the 1-byte APP_PROTO_VERSION prefix at
  * out[0] (fPort 85). Sets *out_len to the total length (version + protobuf). */
@@ -588,7 +631,7 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 		resp.seq = 0;
 		make_error(&resp, Response_Error_Code_BAD_REQUEST, PB_GET_ERROR(&istream));
 	} else {
-		dispatch(transport, &cmd, &resp, &act);
+		app_cmd_dispatch(transport, &cmd, &resp, &act);
 	}
 
 	/* A handler may opt out of an immediate response by leaving the oneof unset

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -123,21 +123,23 @@ message AppConfigMessage {
 message Command {
     uint32 seq = 1;
 
+    // BEGIN GENERATED COMMANDS
     oneof body {
-        SetParam        set_param        = 2;
-        GetParam        get_param        = 3;
-        GetInfo         get_info         = 4;
-        GetConfig       get_config       = 5;
-        SettingsSave    settings_save    = 6;
-        Reboot          reboot           = 7;
-        FactoryReset    factory_reset    = 8;
-        ForceSend       force_send       = 9;
-        ResetCounters   reset_counters   = 10;
-        ReqHistory      req_history      = 11;
-        ClockSync       clock_sync       = 12;
-        AlarmRule       alarm_rule       = 13;
-        W1Scan          w1_scan          = 14;
+        SetParam      set_param      = 2;
+        GetParam      get_param      = 3;
+        GetInfo       get_info       = 4;
+        GetConfig     get_config     = 5;
+        SettingsSave  settings_save  = 6;
+        Reboot        reboot         = 7;
+        FactoryReset  factory_reset  = 8;
+        ForceSend     force_send     = 9;
+        ResetCounters reset_counters = 10;
+        ReqHistory    req_history    = 11;
+        ClockSync     clock_sync     = 12;
+        AlarmRule     alarm_rule     = 13;
+        W1Scan        w1_scan        = 14;
     }
+// END GENERATED COMMANDS
 
     message SetParam {
         optional AppConfigMessage.Lorawan     lorawan     = 1;

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -110,6 +110,38 @@ proto:
         - 35
         - 36
         - 53
+
+# Command protocol (LoRaWAN fPort 85 downlink + NFC). The single source of truth
+# for which commands exist, their wire id, dispatch routing and availability.
+# configen generates from `list`: the proto `Command` oneof, the decoder
+# _CMD_NAMES/_CMD_TAGS maps, and the app_cmd_dispatch() switch. The per-command
+# body sub-messages and handler bodies stay hand-written (see configen-commands
+# design). Per-entry fields:
+#   name/proto_id : wire identity (append-only; reserved on removal).
+#   body          : protobuf sub-message type (hand-written in the proto).
+#   kind          : handler (calls app_cmd_handle_<name>) | action (sets *action).
+#   action        : APP_CMD_ACTION_* to set (action kind, or a handler that defers).
+#   transports    : optional allow-list (lrw/nfc/shell); omitted = all.
+#   response      : success body — ack | info | config_dump | none | info_deferred |
+#                   w1_scan (drives the decoder/docs; the FW emits it in the handler).
+commands:
+  message: Command
+  response: Response
+  reserved: []
+  list:
+    - {name: set_param,      proto_id: 2,  body: SetParam,      kind: handler, response: ack}
+    - {name: get_param,      proto_id: 3,  body: GetParam,      kind: handler, response: config_dump}
+    - {name: get_info,       proto_id: 4,  body: GetInfo,       kind: handler, response: info}
+    - {name: get_config,     proto_id: 5,  body: GetConfig,     kind: handler, response: config_dump}
+    - {name: settings_save,  proto_id: 6,  body: SettingsSave,  kind: action,  action: SETTINGS_SAVE, response: ack}
+    - {name: reboot,         proto_id: 7,  body: Reboot,        kind: action,  action: REBOOT, response: ack}
+    - {name: factory_reset,  proto_id: 8,  body: FactoryReset,  kind: action,  action: FACTORY_RESET, response: ack}
+    - {name: force_send,     proto_id: 9,  body: ForceSend,     kind: handler, response: none, transports: [lrw]}
+    - {name: reset_counters, proto_id: 10, body: ResetCounters, kind: handler, response: ack}
+    - {name: req_history,    proto_id: 11, body: ReqHistory,    kind: handler, response: none, transports: [lrw]}
+    - {name: clock_sync,     proto_id: 12, body: ClockSync,     kind: handler, response: info_deferred, transports: [lrw]}
+    - {name: alarm_rule,     proto_id: 13, body: AlarmRule,     kind: handler, response: ack}
+    - {name: w1_scan,        proto_id: 14, body: W1Scan,        kind: handler, response: w1_scan}
 parameters:
   - name: secret_key
     proto_group: root

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -614,21 +614,91 @@ def build_options_lines(config):
     return lines
 
 
-def rewrite_marked_region(path, body, comment):
+def rewrite_marked_region(path, body, comment,
+                          begin_label=PROTO_BEGIN, end_label=PROTO_END):
     """Replace the text between the BEGIN/END markers in `path` with `body`,
-    keeping everything outside (hand-written messages / options)."""
+    keeping everything outside (hand-written messages / options). `begin_label`
+    / `end_label` select which marker pair (a file may hold several, e.g. the
+    config region and the Command-oneof region in the .proto)."""
     if not path.exists():
         log.die(f"target {path} not found — seed it with the "
-                f"'{comment} {PROTO_BEGIN}' / '{comment} {PROTO_END}' markers first")
+                f"'{comment} {begin_label}' / '{comment} {end_label}' markers first")
     text = path.read_text()
-    begin = f"{comment} {PROTO_BEGIN}"
-    end = f"{comment} {PROTO_END}"
+    begin = f"{comment} {begin_label}"
+    end = f"{comment} {end_label}"
     if begin not in text or end not in text:
         log.die(f"{path} is missing the generated-region markers "
                 f"({begin} / {end})")
     head, rest = text.split(begin, 1)
     _, tail = rest.split(end, 1)
     return f"{head}{begin}\n{body}\n{end}{tail}"
+
+
+# Marker labels for the command-codegen regions (each lives in its own file:
+# the Command oneof in the .proto, the dispatch switch in app_cmd.c, the
+# name<->tag maps in ttn.js). All use line comments so one rewrite helper fits.
+COMMANDS_BEGIN = "BEGIN GENERATED COMMANDS"
+COMMANDS_END = "END GENERATED COMMANDS"
+DISPATCH_BEGIN = "BEGIN GENERATED DISPATCH"
+DISPATCH_END = "END GENERATED DISPATCH"
+
+# Response-body kinds whose dispatch emits no immediate Response (the command's
+# effect — telemetry, history frames, a deferred Info — is the answer).
+COMMAND_RESPONSE_NONE = {"none", "info_deferred"}
+
+
+def build_commands_model(config):
+    """jinja context for the command codegen (proto Command oneof, decoder
+    _CMD_NAMES/_CMD_TAGS, app_cmd_dispatch switch) from the YAML `commands:`
+    section. Returns None when the YAML has no command list."""
+    commands = config.get("commands")
+    if not commands:
+        return None
+
+    msg = commands["message"]
+    seen_ids, seen_names = {}, set()
+    cmds = []
+    for c in commands["list"]:
+        name = c["name"]
+        pid = c["proto_id"]
+        if name in seen_names:
+            log.die(f"duplicate command name '{name}'")
+        if pid in seen_ids:
+            log.die(f"duplicate command proto_id {pid} "
+                    f"('{name}' vs '{seen_ids[pid]}')")
+        seen_names.add(name)
+        seen_ids[pid] = name
+
+        kind = c["kind"]
+        if kind not in ("handler", "action"):
+            log.die(f"command '{name}' has invalid kind '{kind}' "
+                    f"(expected handler|action)")
+        if kind == "action" and not c.get("action"):
+            log.die(f"action command '{name}' must set 'action'")
+
+        transports = c.get("transports")
+        cmds.append({
+            "name": name,
+            "proto_id": pid,
+            "body": c["body"],
+            "kind": kind,
+            "action": c.get("action"),
+            "response": c.get("response", "ack"),
+            "transports": transports,
+            "lrw_only": transports == ["lrw"],
+            "emits_response": c.get("response", "ack") not in COMMAND_RESPONSE_NONE,
+            "tag": f"{msg}_{name}_tag",
+            "handler": f"app_cmd_handle_{name}",
+        })
+
+    by_id = sorted(cmds, key=lambda c: c["proto_id"])
+    return {
+        "message": msg,
+        "response_message": commands["response"],
+        "reserved": list(commands.get("reserved", [])),
+        "commands": cmds,        # YAML order (decoder/dispatch)
+        "commands_by_id": by_id, # proto_id order (proto oneof)
+    }
 
 
 class Configen(WestCommand):
@@ -686,6 +756,22 @@ class Configen(WestCommand):
             action="store_true",
             help="skip proto/options generation even if the YAML has a "
             "'proto:' block",
+        )
+        parser.add_argument(
+            "--decoder",
+            type=Path,
+            default=None,
+            help="path to the JS decoder whose _CMD_NAMES/_CMD_TAGS region is "
+            "rewritten from the YAML 'commands:' list "
+            "(default: <output-dir>/../decoder/ttn.js)",
+        )
+        parser.add_argument(
+            "--app-cmd",
+            type=Path,
+            default=None,
+            help="path to the C command file whose app_cmd_dispatch() region is "
+            "rewritten from the YAML 'commands:' list "
+            "(default: <output-dir>/app_cmd.c)",
         )
         parser.add_argument(
             "--dry-run",
@@ -840,6 +926,13 @@ class Configen(WestCommand):
             self._generate_proto(env, config, yaml_path, proto_path.resolve(),
                                  options_path.resolve(), args.dry_run)
 
+        # Command protocol codegen (decoder maps, dispatch switch, Command oneof)
+        # from the YAML `commands:` section — keeps the wire id / routing /
+        # availability of every command in one place (configen-commands design).
+        commands_model = build_commands_model(config)
+        if commands_model:
+            self._generate_commands(env, commands_model, output_dir, args)
+
     def _generate_proto(self, env, config, yaml_path, proto_path, options_path,
                         dry_run):
         """Generate the .proto config region + nanopb options from the YAML,
@@ -885,6 +978,47 @@ class Configen(WestCommand):
         log.inf(f"Generated: {proto_path}")
         options_path.write_text(options_text)
         log.inf(f"Generated: {options_path}")
+
+    def _generate_commands(self, env, model, output_dir, args):
+        """Rewrite the command-codegen regions from the YAML `commands:` list:
+        the decoder _CMD_NAMES map (ttn.js) and the app_cmd_dispatch() switch
+        (app_cmd.c). The proto Command oneof is rewritten by _generate_proto."""
+        # Decoder: _CMD_NAMES / _CMD_TAGS region in ttn.js.
+        decoder_path = args.decoder or (output_dir.parent / "decoder" / "ttn.js")
+        decoder_path = decoder_path.resolve()
+        if decoder_path.exists():
+            body = env.get_template("commands_decoder.js.j2").render(**model)
+            body = body.rstrip("\n")
+            text = rewrite_marked_region(decoder_path, body, "//",
+                                         COMMANDS_BEGIN, COMMANDS_END)
+            if args.dry_run:
+                log.inf(f"Would generate decoder region in: {decoder_path}")
+                print(body)
+            else:
+                decoder_path.write_text(text)
+                log.inf(f"Generated decoder command region: {decoder_path}")
+        else:
+            log.wrn(f"decoder not found ({decoder_path}); "
+                    "skipping _CMD_NAMES region")
+
+        # Firmware: app_cmd_dispatch() switch region in app_cmd.c. Only rewritten
+        # once the file carries the markers (seeded when the dispatch codegen
+        # lands); skipped gracefully otherwise so the decoder region can ship
+        # ahead of it.
+        app_cmd_path = args.app_cmd or (output_dir / "app_cmd.c")
+        app_cmd_path = app_cmd_path.resolve()
+        if app_cmd_path.exists() and f"// {DISPATCH_BEGIN}" in app_cmd_path.read_text():
+            body = env.get_template("commands_dispatch.c.j2").render(**model)
+            body = body.rstrip("\n")
+            text = rewrite_marked_region(app_cmd_path, body, "//",
+                                         DISPATCH_BEGIN, DISPATCH_END)
+            if args.dry_run:
+                log.inf(f"Would generate dispatch region in: {app_cmd_path}")
+                print(body)
+            else:
+                app_cmd_path.write_text(text)
+                log.inf(f"Generated dispatch region: {app_cmd_path}")
+                self._clang_format([app_cmd_path])
 
     def _clang_format(self, paths):
         """Run clang-format on generated files if available."""

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -614,6 +614,18 @@ def build_options_lines(config):
     return lines
 
 
+def rewrite_marked_text(text, body, comment, begin_label, end_label, where=""):
+    """Replace the text between the BEGIN/END markers in `text` with `body`."""
+    begin = f"{comment} {begin_label}"
+    end = f"{comment} {end_label}"
+    if begin not in text or end not in text:
+        log.die(f"{where or 'input'} is missing the generated-region markers "
+                f"({begin} / {end})")
+    head, rest = text.split(begin, 1)
+    _, tail = rest.split(end, 1)
+    return f"{head}{begin}\n{body}\n{end}{tail}"
+
+
 def rewrite_marked_region(path, body, comment,
                           begin_label=PROTO_BEGIN, end_label=PROTO_END):
     """Replace the text between the BEGIN/END markers in `path` with `body`,
@@ -623,15 +635,8 @@ def rewrite_marked_region(path, body, comment,
     if not path.exists():
         log.die(f"target {path} not found — seed it with the "
                 f"'{comment} {begin_label}' / '{comment} {end_label}' markers first")
-    text = path.read_text()
-    begin = f"{comment} {begin_label}"
-    end = f"{comment} {end_label}"
-    if begin not in text or end not in text:
-        log.die(f"{path} is missing the generated-region markers "
-                f"({begin} / {end})")
-    head, rest = text.split(begin, 1)
-    _, tail = rest.split(end, 1)
-    return f"{head}{begin}\n{body}\n{end}{tail}"
+    return rewrite_marked_text(path.read_text(), body, comment,
+                               begin_label, end_label, str(path))
 
 
 # Marker labels for the command-codegen regions (each lives in its own file:
@@ -645,6 +650,28 @@ DISPATCH_END = "END GENERATED DISPATCH"
 # Response-body kinds whose dispatch emits no immediate Response (the command's
 # effect — telemetry, history frames, a deferred Info — is the answer).
 COMMAND_RESPONSE_NONE = {"none", "info_deferred"}
+
+
+def guard_no_renumber_commands(model, proto_path):
+    """Fail the run if a command's proto_id differs from the one already in the
+    Command oneof region of the target .proto (a deployed downlink / NFC tag
+    encodes the tag, so renumbering silently breaks the field protocol)."""
+    if not proto_path.exists():
+        return
+    text = proto_path.read_text()
+    begin = f"// {COMMANDS_BEGIN}"
+    end = f"// {COMMANDS_END}"
+    if begin not in text or end not in text:
+        return
+    region = text.split(begin, 1)[1].split(end, 1)[0]
+    old = {}
+    for m in re.finditer(r"^\s*\w+\s+(\w+)\s*=\s*(\d+)\s*;", region, re.MULTILINE):
+        old[m.group(1)] = int(m.group(2))
+    for c in model["commands"]:
+        if c["name"] in old and old[c["name"]] != c["proto_id"]:
+            log.die(f"command proto_id for '{c['name']}' changed "
+                    f"{old[c['name']]} -> {c['proto_id']} — renumbering is "
+                    f"forbidden (downlinks / NFC tags already deployed)")
 
 
 def build_commands_model(config):
@@ -698,6 +725,9 @@ def build_commands_model(config):
         "reserved": list(commands.get("reserved", [])),
         "commands": cmds,        # YAML order (decoder/dispatch)
         "commands_by_id": by_id, # proto_id order (proto oneof)
+        # Column widths so the generated .proto oneof aligns like the rest.
+        "type_width": max(len(c["body"]) for c in cmds),
+        "name_width": max(len(c["name"]) for c in cmds),
     }
 
 
@@ -953,6 +983,19 @@ class Configen(WestCommand):
         model = build_proto_model(config)
         body = env.get_template("config.proto.j2").render(proto=model).rstrip("\n")
         proto_text = rewrite_marked_region(proto_path, body, "//")
+
+        # Command oneof: a second generated region in the same .proto (the body
+        # sub-messages + Response stay hand-written). Rewritten in-memory on top
+        # of the config region, when the YAML has a commands list and the file
+        # carries the markers.
+        commands_model = build_commands_model(config)
+        if commands_model and f"// {COMMANDS_BEGIN}" in proto_text:
+            guard_no_renumber_commands(commands_model, proto_path)
+            cmd_body = env.get_template("commands_proto.j2").render(
+                **commands_model).rstrip("\n")
+            proto_text = rewrite_marked_text(proto_text, cmd_body, "//",
+                                             COMMANDS_BEGIN, COMMANDS_END,
+                                             str(proto_path))
 
         options_body = "\n".join(build_options_lines(config))
         options_text = rewrite_marked_region(options_path, options_body, "#")

--- a/scripts/west_commands/templates/commands_decoder.js.j2
+++ b/scripts/west_commands/templates/commands_decoder.js.j2
@@ -1,0 +1,5 @@
+var _CMD_NAMES = {
+{% for c in commands_by_id %}
+  {{ c.proto_id }}: "{{ c.name }}",
+{% endfor %}
+};

--- a/scripts/west_commands/templates/commands_dispatch.c.j2
+++ b/scripts/west_commands/templates/commands_dispatch.c.j2
@@ -1,0 +1,29 @@
+static void app_cmd_dispatch(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+			     enum app_cmd_action *action)
+{
+	resp->seq = cmd->seq;
+
+	switch (cmd->which_body) {
+{% for c in commands %}
+	case {{ c.tag }}:
+{% if c.lrw_only %}
+		/* transports: [lrw] — the answer is an uplink, meaningless over NFC */
+		if (tp != APP_CMD_TRANSPORT_LRW) {
+			make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
+			break;
+		}
+{% endif %}
+{% if c.kind == 'action' %}
+		*action = APP_CMD_ACTION_{{ c.action }};
+		resp->which_body = Response_ack_tag;
+{% else %}
+		{{ c.handler }}(tp, cmd, resp, action);
+{% endif %}
+		break;
+{% endfor %}
+	default:
+		LOG_WRN("Command tag %u not implemented", cmd->which_body);
+		make_error(resp, Response_Error_Code_UNKNOWN, "not implemented");
+		break;
+	}
+}

--- a/scripts/west_commands/templates/commands_proto.j2
+++ b/scripts/west_commands/templates/commands_proto.j2
@@ -1,0 +1,5 @@
+    oneof body {
+{% for c in commands_by_id %}
+        {{ "%-*s"|format(type_width, c.body) }} {{ "%-*s"|format(name_width, c.name) }} = {{ c.proto_id }};
+{% endfor %}
+    }

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -358,6 +358,30 @@ def test_generated_dispatch_region_matches_committed(workdir):
     assert (workdir / "app_cmd.c").read_text() == (APP_SRC / "app_cmd.c").read_text()
 
 
+def test_generated_proto_command_oneof_matches_committed(workdir):
+    """The generated Command oneof region must equal what is committed in the
+    .proto (locks the command wire ids alongside the config region)."""
+    _run_configen(workdir)
+    assert (workdir / "app_config.proto").read_text() == PROTO.read_text()
+
+
+def test_command_renumber_is_rejected(workdir):
+    """Changing a command's proto_id away from the committed .proto fails the run
+    (deployed downlinks / NFC tags encode the tag)."""
+    _run_configen(workdir)  # seed the committed ids into workdir proto
+    import ruamel.yaml
+    rt = ruamel.yaml.YAML()
+    with open(workdir / "app_config.yml") as f:
+        doc = rt.load(f)
+    for c in doc["commands"]["list"]:
+        if c["name"] == "w1_scan":
+            c["proto_id"] = 20  # was 14
+    with open(workdir / "app_config.yml", "w") as f:
+        rt.dump(doc, f)
+    with pytest.raises(SystemExit):
+        _run_configen(workdir)
+
+
 def test_dispatch_template_routes_every_command():
     """Every command in the model appears in the rendered dispatch switch, with
     LRW-only commands guarded and action commands setting their action."""

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -42,6 +42,8 @@ def _run_configen(out_dir):
         proto=None,
         options=None,
         no_proto=False,
+        decoder=out_dir / "ttn.js",
+        app_cmd=out_dir / "app_cmd.c",
         dry_run=False,
     )
     configen.Configen().do_run(args, [])
@@ -51,6 +53,9 @@ def _run_configen(out_dir):
 def workdir(tmp_path):
     for name in ["app_config.yml", "app_config.proto", "app_config.options.in"]:
         shutil.copy(APP_SRC / name, tmp_path / name)
+    # The decoder's command-map region is rewritten in place; copy it so the run
+    # has a marked region to edit (app_cmd.c is intentionally absent → skipped).
+    shutil.copy(DECODER, tmp_path / "ttn.js")
     # Carry the project clang-format style so generated C matches the committed
     # files (clang-format searches upward from the file for .clang-format).
     if (REPO / ".clang-format").exists():
@@ -299,3 +304,45 @@ def test_proto_and_decoder_agree(tmp_path):
     js = _decode_with_node(COMMAND_VECTORS["get_param"])
     assert js["get_param"]["lorawan_field"] == [3]
     assert js["get_param"]["application_field"] == [4, 7]
+
+
+# --- commands codegen -----------------------------------------------------
+
+def test_build_commands_model_shape():
+    model = configen.build_commands_model(_load_config())
+    assert model["message"] == "Command"
+    assert model["response_message"] == "Response"
+    by_name = {c["name"]: c for c in model["commands"]}
+    # wire identity + routing carried from the YAML
+    assert by_name["w1_scan"]["proto_id"] == 14
+    assert by_name["w1_scan"]["tag"] == "Command_w1_scan_tag"
+    assert by_name["w1_scan"]["handler"] == "app_cmd_handle_w1_scan"
+    # action vs handler kinds
+    assert by_name["reboot"]["kind"] == "action"
+    assert by_name["reboot"]["action"] == "REBOOT"
+    assert by_name["set_param"]["kind"] == "handler"
+    # transport gating + no-immediate-response flags
+    assert by_name["force_send"]["lrw_only"] is True
+    assert by_name["force_send"]["emits_response"] is False
+    assert by_name["clock_sync"]["emits_response"] is False  # info_deferred
+    assert by_name["set_param"]["lrw_only"] is False
+    assert by_name["set_param"]["emits_response"] is True
+    # proto-id order for the oneof
+    assert [c["proto_id"] for c in model["commands_by_id"]] == \
+        sorted(c["proto_id"] for c in model["commands"])
+
+
+def test_build_commands_model_rejects_duplicates():
+    cfg = _load_config()
+    cfg["commands"]["list"].append(
+        {"name": "dupe", "proto_id": 14, "body": "X", "kind": "action",
+         "action": "REBOOT", "response": "ack"})
+    with pytest.raises(SystemExit):
+        configen.build_commands_model(cfg)
+
+
+def test_generated_decoder_command_region_matches_committed(workdir):
+    """The _CMD_NAMES region the generator emits must equal what is committed in
+    ttn.js (locks the name<->tag map against hand-edits / YAML drift)."""
+    _run_configen(workdir)
+    assert (workdir / "ttn.js").read_text() == DECODER.read_text()

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -53,9 +53,10 @@ def _run_configen(out_dir):
 def workdir(tmp_path):
     for name in ["app_config.yml", "app_config.proto", "app_config.options.in"]:
         shutil.copy(APP_SRC / name, tmp_path / name)
-    # The decoder's command-map region is rewritten in place; copy it so the run
-    # has a marked region to edit (app_cmd.c is intentionally absent → skipped).
+    # The decoder's command-map region and app_cmd.c's dispatch region are
+    # rewritten in place; copy them so the run has marked regions to edit.
     shutil.copy(DECODER, tmp_path / "ttn.js")
+    shutil.copy(APP_SRC / "app_cmd.c", tmp_path / "app_cmd.c")
     # Carry the project clang-format style so generated C matches the committed
     # files (clang-format searches upward from the file for .clang-format).
     if (REPO / ".clang-format").exists():
@@ -346,3 +347,33 @@ def test_generated_decoder_command_region_matches_committed(workdir):
     ttn.js (locks the name<->tag map against hand-edits / YAML drift)."""
     _run_configen(workdir)
     assert (workdir / "ttn.js").read_text() == DECODER.read_text()
+
+
+@pytest.mark.skipif(shutil.which("clang-format") is None,
+                    reason="clang-format not available")
+def test_generated_dispatch_region_matches_committed(workdir):
+    """The app_cmd_dispatch() switch the generator emits must equal what is
+    committed in app_cmd.c (locks routing against YAML drift)."""
+    _run_configen(workdir)
+    assert (workdir / "app_cmd.c").read_text() == (APP_SRC / "app_cmd.c").read_text()
+
+
+def test_dispatch_template_routes_every_command():
+    """Every command in the model appears in the rendered dispatch switch, with
+    LRW-only commands guarded and action commands setting their action."""
+    import jinja2
+    model = configen.build_commands_model(_load_config())
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(configen.TEMPLATES_DIR),
+        trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True)
+    out = env.get_template("commands_dispatch.c.j2").render(**model)
+    for c in model["commands"]:
+        assert f"case {c['tag']}:" in out, c["name"]
+        if c["kind"] == "action":
+            assert f"APP_CMD_ACTION_{c['action']}" in out, c["name"]
+        else:
+            assert f"{c['handler']}(tp, cmd, resp, action);" in out, c["name"]
+        if c["lrw_only"]:
+            # the guard precedes this command's handler/action body
+            head = out.split(f"case {c['tag']}:", 1)[1]
+            assert "tp != APP_CMD_TRANSPORT_LRW" in head.split("break;", 1)[0]


### PR DESCRIPTION
Generate the command protocol from the `commands:` section of `app_config.yml` so the command list / wire identity / dispatch routing / availability stop drifting across the proto, firmware and decoder — the same single-source-of-truth treatment the config params got in #105. Follows the behaviour changes in #106 (Track A).

Design: `doc/configen-commands-design.md` (project note, not in repo).

### Phases
- [x] **B0/B1** — `commands:` YAML section + `build_commands_model()`; generate the decoder `_CMD_NAMES`/`_CMD_TAGS` map (no behaviour change; locks name↔tag)
- [x] **B2** — generate the `app_cmd_dispatch()` **switch** into a `BEGIN/END GENERATED DISPATCH` region of `app_cmd.c` (handler→call, action→set+ack, transports→guard). Adversarially verify identical routing to the current hand switch; ztest per kind
- [x] **B3** — generate the proto `Command` oneof from `commands.list` (append-only guard, reserved on removal); sub-message bodies + `Response` stay hand-written

### What stays hand-written
Sub-message bodies (`SetParam{…}`, `W1Scan{…}`), the `Response` oneof, and the `handle_*` logic. configen owns only the **list / wire identity / routing / availability**.

### Notes
- `rewrite_marked_region()` generalized to take BEGIN/END labels so multiple generated regions coexist in one file.
- manager-app (Flutter) regenerates Dart from the proto; its command list could also be YAML-driven later.
