### PR TITLE
1-Wire: rebind after scan, re-arm tilt per scan, harden readbacks (#95)

### DIFF
--- a/app/src/app_machine_probe.c
+++ b/app/src/app_machine_probe.c
@@ -82,6 +82,11 @@ static uint8_t sht_crc8(const uint8_t *data, size_t len)
 #define LIS2DH12_INT1_THS      0x32
 #define LIS2DH12_INT1_DURATION 0x33
 
+/* Tilt-alert defaults — armed per probe inside the bus scan (see scan_callback)
+ * so the alert survives runtime re-scans, not just the boot scan. */
+#define MP_TILT_THRESHOLD 7
+#define MP_TILT_DURATION  1
+
 enum sht_type {
 	SHT_TYPE_UNKNOWN = 0,
 	SHT_TYPE_SHT30,
@@ -339,7 +344,11 @@ static int sht_read_serial(const struct device *dev, uint32_t *serial_number,
 	write_buf[0] = 0x37;
 	write_buf[1] = 0x80;
 	ret = ds28e17_i2c_write_read(dev, SHT33_I2C_ADDR, write_buf, 2, read_buf, 6);
-	if (ret == 0) {
+	if (ret == 0 && sht_crc8(&read_buf[0], 2) == read_buf[2] &&
+	    sht_crc8(&read_buf[3], 2) == read_buf[5]) {
+		/* CRC-check the serial read (same as the SHT43 branch) — addr 0x45 can
+		 * collide with an OPT3001 on some probes, so an un-validated response
+		 * must not be accepted as an SHT. */
 		LOG_DBG("SHT33 detected");
 		if (detected_type) {
 			*detected_type = SHT_TYPE_SHT30;
@@ -656,6 +665,17 @@ static int lis2dh12_get_interrupt(const struct device *dev, bool *is_active)
 		return ret;
 	}
 
+	/* The DS28E17 1-Wire data readback is not CRC-protected and tilt is a single
+	 * bit, so a flipped bit on a long cable would inject a false tilt alert.
+	 * INT1_SRC bit 7 is reserved-zero: a set bit 7 means the byte was corrupted
+	 * on the wire — discard it rather than trust the IA bit. (A true double-read
+	 * can't help here: INT1_SRC is latched and clears on read.) */
+	if (read_buf[0] & BIT(7)) {
+		LOG_WRN("LIS2DH INT1_SRC readback corrupt (0x%02x), ignoring", read_buf[0]);
+		*is_active = false;
+		return 0;
+	}
+
 	*is_active = read_buf[0] & BIT(6) ? true : false;
 
 	return 0;
@@ -698,6 +718,15 @@ static int scan_callback(struct w1_rom rom, void *user_data)
 	if (ret) {
 		LOG_DBG("Skipping serial number: %llu", serial_number);
 		return 0;
+	}
+
+	/* Arm tilt detection here, on every scan (incl. runtime re-scan/enroll).
+	 * lis2dh12_init just BOOTed CTRL_REG5 and wiped the INT1 config, so arming
+	 * only from app_sensor_init would silently disable tilt after any later
+	 * `w1 scan`. Non-fatal: register the probe even if arming fails. */
+	ret = lis2dh12_enable_alert(m_sensors[m_count].dev, MP_TILT_THRESHOLD, MP_TILT_DURATION);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("lis2dh12_enable_alert", ret);
 	}
 
 	m_sensors[m_count++].serial_number = serial_number;

--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -37,9 +37,6 @@
 
 LOG_MODULE_REGISTER(app_sensor, LOG_LEVEL_DBG);
 
-#define TILT_THRESHOLD 7
-#define TILT_DURATION  1
-
 /* I2C bus recovery: if every I2C sensor read in a sweep fails for this many
  * consecutive sweeps, the bus is likely wedged (a slave holding SDA low after a
  * brown-out/EMI glitch). i2c_recover_bus() bit-bangs 9 clocks to free it. */
@@ -271,17 +268,9 @@ int app_sensor_init(void)
 			res = res ? res : ret;
 		}
 
-		int count = app_machine_probe_get_count();
-
-		for (int i = 0; i < count; i++) {
-			uint64_t serial_number;
-			ret = app_machine_probe_enable_tilt_alert(i, &serial_number, TILT_THRESHOLD,
-								  TILT_DURATION);
-			if (ret) {
-				LOG_ERR_CALL_FAILED_INT("app_machine_probe_enable_tilt_alert", ret);
-				res = res ? res : ret;
-			}
-		}
+		/* Tilt alert is armed per probe inside app_machine_probe_scan() (see
+		 * scan_callback), so it survives runtime re-scans too — no separate
+		 * arming pass is needed here. */
 	}
 
 	/* Bind discovered 1-Wire devices to logical slots by their persisted ROM

--- a/app/src/app_w1_slots.c
+++ b/app/src/app_w1_slots.c
@@ -539,6 +539,12 @@ int app_w1_slots_scan(struct app_w1_scan_entry *out, int max)
 		out[n].bound_slot = slot_of_rom(dev[d].serial);
 		n++;
 	}
+
+	/* The per-type driver scans above reshuffle driver indices, so re-bind
+	 * ROM->slot here — otherwise a bare `w1 scan` (no teach/enroll) leaves
+	 * m_slots[].driver_index pointing at a stale physical sensor until the next
+	 * teach or reboot. Idempotent; teach/assign rebind again after writing ROM. */
+	(void)app_w1_slots_rebind();
 	return n;
 }
 

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -92,6 +92,8 @@ message SensorReading {
 
 `ttn.js` decodes this into `w1_sensors[]`, each `{ slot, type, type_name, temperature?, humidity?, tilt_alert }`. A slot keeps its identity across reboots/rescans (ROM-bound), so `slot 2` is always the same physical sensor — not a function of bus enumeration order.
 
+A runtime `w1_scan` / enroll re-binds the slots and re-arms machine-probe tilt detection on the spot — **no reboot is needed** for either the slot→sensor mapping or tilt alerts to stay correct after a rescan. Machine-probe readbacks are integrity-checked (SHT serial CRC; the tilt status bit is rejected if the 1-Wire readback is corrupt) so a noisy bus can't bind the wrong sensor or raise a false tilt.
+
 ---
 
 ## 3. Alarm-detail batch on fPort 3 (NEW)


### PR DESCRIPTION
Addresses **#95** — 1-Wire slot framework robustness.

## Items

- **#95.1 (slots not wired into telemetry/alarms)** — already resolved by #85/#86 (per-slot sampling via `app_w1_slots_read`) + the dynamic-alarms rework (per-slot alarms). Verified in current code; no change needed here.
- **#95.2 — stale `driver_index` after `w1 scan`**: `app_w1_slots_scan()` re-runs the per-type driver scans (which reshuffle driver indices) but never rebound, so a bare `w1 scan` (no teach) left `m_slots[].driver_index` pointing at the wrong physical sensor until the next teach/reboot. Now calls `app_w1_slots_rebind()` at the end of the scan (idempotent; teach/assign already rebind after writing the ROM).
- **#95.3 — runtime rescan disabled the tilt alert**: `lis2dh12_init()` (run from `scan_callback`) BOOTs `CTRL_REG5` and wipes the INT1 config; tilt was only armed from `app_sensor_init`, so any runtime `w1 scan`/`enroll` silently killed tilt detection until reboot. Tilt is now armed per probe inside `scan_callback` (covers boot **and** runtime); the redundant arming pass in `app_sensor_init` is removed.
- **#95.4 — unprotected DS28E17 readbacks**:
  - CRC-check the **SHT33** serial read (addr `0x45` can collide with an OPT3001; only the CRC distinguishes them — now matches the SHT43 branch).
  - Guard the **LIS2DH `INT1_SRC`** tilt readback: bit 7 is reserved-zero, so a wire-corrupted byte (the 1-Wire readback is not CRC-protected and tilt is a single bit) can't inject a false tilt. A literal double-read isn't applicable — `INT1_SRC` is latched and clears on read — so the reserved-bit guard is used instead.

## Test

HW-verified on `sticker-2162165131` (machine probe, slot 1):
- `w1 scan` → `w1 list` still shows the slot bound with a live reading (23.0 °C / 44.8 %) — rebind works.
- tilt/accel read correctly after a scan; no `enable_alert` errors in the log.

Builds: release 92.26% / debug 93.02% FLASH. Tests: pytest 20, decoder node 23, native_sim cmd/compose/history all pass.

Closes #95.
