### PR TITLE
ats: onboard accelerometer x/y/z in 'sensors sample' (#83)

### DIFF
--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "app_accel.h"
 #include "app_ds18b20.h"
 #include "app_hall.h"
 #include "app_input.h"
@@ -470,11 +471,18 @@ static int cmd_print_sample(const struct shell *shell, size_t argc, char **argv)
 	print_float(shell, "pressure:", d->pressure, "Pa");
 	print_float(shell, "altitude:", d->altitude, "m");
 	print_float(shell, "illuminance:", d->illuminance, "lux");
-	/* orientation is meaningful only with the accelerometer enabled. */
+	/* orientation + raw axes are meaningful only with the accelerometer enabled;
+	 * read live (the onboard accel x/y/z are not cached in g_app_sensor_data). */
 	if (g_app_config.cap_accelerometer) {
-		shell_print(shell, "  %-16s %d", "orientation:", d->orientation);
+		float ax = NAN, ay = NAN, az = NAN;
+		int ori = d->orientation;
+		(void)app_accel_read(&ax, &ay, &az, &ori);
+		shell_print(shell, "  %-16s %d", "orientation:", ori);
+		shell_print(shell, "  %-16s x=%.2f y=%.2f z=%.2f m/s^2", "accel:", (double)ax,
+			    (double)ay, (double)az);
 	} else {
 		shell_print(shell, "  %-16s nan", "orientation:");
+		shell_print(shell, "  %-16s nan", "accel:");
 	}
 	shell_print(shell, "  %-16s %u", "motion-count:", d->motion_count);
 	shell_print(shell, "  %-16s %u", "accel-motion:", d->accel_motion_count);


### PR DESCRIPTION
Completes **#83**.

Items 1 (refreshed sensor list) and 2 (NaN `orientation` when `cap_accelerometer` is off) — plus the per-slot machine-probe accel x/y/z readout — were already delivered in #104. This PR adds the one remaining task: the **device's own (onboard LIS2DH) accelerometer axes** in `ats sensors sample`.

- Read live via `app_accel_read()` in the `== Device ==` section (the onboard axes are not cached in `g_app_sensor_data`).
- Gated on `cap_accelerometer`: prints `accel: x=.. y=.. z=.. m/s^2` when enabled, `nan` when off — consistent with `orientation`.
- The machine-probe slot's own accel cluster (`== s1 ==` …) is unchanged.

## Test

HW-verified on `sticker-2162165131`:
- `cap-accelerometer` off → Device `orientation: nan`, `accel: nan`.
- `cap-accelerometer` on (after `settings save`) → Device `orientation: 2`, `accel: x=-0.61 y=-0.31 z=9.50 m/s^2` (z ≈ g, board flat); the s1 machine-probe accel reads independently.

Builds debug 93.05% FLASH; display-only change to `app_ats.c`.

Closes #83.
