### PR TITLE
NFC: nfc shell command + info NDEF on tag (SN/FW/config version)

### DIFF
--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -5,9 +5,11 @@
  */
 
 #include "app_nfc.h"
+#include "app_cmd.h"
 #include "app_config_ingest.h"
 #include "app_config.h"
 #include "app_ndef_parser.h"
+#include "app_version.h"
 #include "app_log.h"
 
 /* Nanopb includes */
@@ -22,6 +24,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+#if defined(CONFIG_SHELL)
+#include <zephyr/shell/shell.h>
+#endif
 
 /* PSA Crypto includes */
 #include <psa/crypto.h>
@@ -30,6 +37,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
@@ -41,10 +49,41 @@ LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
 #define ST25DV_INT_PAGE_BYTES      4
 #define ST25DV_TW_MS_PER_PAGE      5
 
+#define ST25DV_USER_MEM_SIZE 512
+
 #define NDEF_TNF_MIME       0x02
 #define NDEF_SUPPORTED_TYPE "application/vnd.hardwario.sticker-config.v1"
 
-typedef void (*ndef_text_callback_t)(const char *text, size_t len);
+/* Plaintext info record the firmware keeps on the tag so a phone learns the
+ * sticker identity and schema version the moment it taps, without decrypting
+ * anything. Payload layout (11 bytes):
+ *   [0]    format version (NDEF_INFO_FORMAT)
+ *   [1..4] serial number (big-endian uint32)
+ *   [5]    fw major   [6] fw minor   [7] fw patch
+ *   [8]    build type (0=main, 1=dev, 2=custom)
+ *   [9]    config/schema version (APP_CONFIG_VERSION)
+ *   [10]   flags: bit0 = debug build
+ */
+#define NDEF_INFO_TYPE   "application/vnd.hardwario.sticker-info.v1"
+#define NDEF_INFO_FORMAT 0x01
+
+/* NFC Forum Type 5 Capability Container (4-byte form) for ST25DV04K:
+ *   [0] 0xE1 magic, [1] 0x40 mapping v1.0 + read/write,
+ *   [2] MLEN = user_memory / 8 = 512/8 = 0x40, [3] 0x01 (MBREAD feature).
+ * A phone's Web NFC (Type 5) reader requires a valid CC at offset 0 before the
+ * NDEF TLV; without it the tag reads as unformatted/empty over RF. */
+#define ST25DV_CC0 0xE1
+#define ST25DV_CC1 0x40
+#define ST25DV_CC2 (ST25DV_USER_MEM_SIZE / 8)
+#define ST25DV_CC3 0x01
+
+/* Single shared 512-byte scratch buffer for all ST25DV memory access. Always
+ * used while holding m_lock, which serialises app_nfc_check() (main loop) and
+ * the `nfc` shell commands against each other on the I2C bus and LPD pin. */
+static uint8_t m_buf[ST25DV_USER_MEM_SIZE];
+static K_MUTEX_DEFINE(m_lock);
+
+static const struct gpio_dt_spec m_lpd = GPIO_DT_SPEC_GET(DT_NODELABEL(lpd), gpios);
 
 static int read_mem(uint16_t reg, void *buf, size_t len)
 {
@@ -123,6 +162,93 @@ static int write_mem(uint16_t reg, const void *buf, size_t len)
 	return 0;
 }
 
+/* Power the ST25DV up for I2C access (LPD low) and take the access lock. On
+ * success the caller must pair this with nfc_access_end(). */
+static int nfc_access_begin(void)
+{
+	int ret;
+
+	k_mutex_lock(&m_lock, K_FOREVER);
+
+	if (!gpio_is_ready_dt(&m_lpd)) {
+		LOG_ERR("GPIO device not ready (LPD)");
+		k_mutex_unlock(&m_lock);
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_set_dt(&m_lpd, 0);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("gpio_pin_set_dt", ret);
+		k_mutex_unlock(&m_lock);
+		return ret;
+	}
+
+	k_sleep(K_MSEC(150));
+
+	return 0;
+}
+
+/* Power the ST25DV back down (LPD high) and release the access lock. */
+static void nfc_access_end(void)
+{
+	int ret = gpio_pin_set_dt(&m_lpd, 1);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("gpio_pin_set_dt", ret);
+	}
+
+	k_mutex_unlock(&m_lock);
+}
+
+/* Build the plaintext info NDEF (TLV + single MIME record + terminator) into
+ * `out`. Returns the byte length, or 0 if it would not fit. Deterministic for a
+ * given firmware/config (no uptime/clock), so app_nfc_check() can compare it to
+ * the tag content and skip rewriting when already present. */
+static size_t build_info_ndef(uint8_t *out, size_t out_size)
+{
+	struct app_cmd_info info;
+	app_cmd_get_info(&info);
+
+	uint8_t payload[11];
+	payload[0] = NDEF_INFO_FORMAT;
+	sys_put_be32(info.serial_number, &payload[1]);
+	payload[5] = info.fw_major;
+	payload[6] = info.fw_minor;
+	payload[7] = info.fw_patch;
+	payload[8] = info.build_type;
+	payload[9] = (uint8_t)g_app_config.config_version;
+	payload[10] = info.debug ? 0x01 : 0x00;
+
+	size_t type_len = strlen(NDEF_INFO_TYPE);
+	size_t payload_len = sizeof(payload);
+
+	/* NDEF record: header + type_len + payload_len + type + payload */
+	size_t msg_len = 1 + 1 + 1 + type_len + payload_len;
+
+	/* Tag content: CC (4) + NDEF Message TLV (0x03, len) + message + Terminator (0xFE) */
+	size_t total = 4 + 2 + msg_len + 1;
+	if (total > out_size || msg_len > 0xFE) {
+		return 0;
+	}
+
+	size_t i = 0;
+	out[i++] = ST25DV_CC0; /* Type 5 Capability Container */
+	out[i++] = ST25DV_CC1;
+	out[i++] = ST25DV_CC2;
+	out[i++] = ST25DV_CC3;
+	out[i++] = 0x03;             /* NDEF Message TLV type */
+	out[i++] = (uint8_t)msg_len; /* TLV length (single-byte form) */
+	out[i++] = 0xD2;             /* MB | ME | SR | TNF=MIME(0x02) */
+	out[i++] = (uint8_t)type_len;
+	out[i++] = (uint8_t)payload_len;
+	memcpy(&out[i], NDEF_INFO_TYPE, type_len);
+	i += type_len;
+	memcpy(&out[i], payload, payload_len);
+	i += payload_len;
+	out[i++] = 0xFE; /* Terminator TLV */
+
+	return i;
+}
+
 static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_size, size_t *out_len)
 {
 	int res = 0;
@@ -169,7 +295,7 @@ static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_si
 
 	psa_key_id_t key_id;
 	status = psa_import_key(&key_attributes, g_app_config.secret_key,
-				sizeof(g_app_config.secret_key), &key_id);
+			       sizeof(g_app_config.secret_key), &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_ERR_CALL_FAILED_INT("psa_import_key", status);
 		return -EIO;
@@ -260,14 +386,12 @@ int app_nfc_init(void)
 {
 	int ret;
 
-	const struct gpio_dt_spec lpd_spec = GPIO_DT_SPEC_GET(DT_NODELABEL(lpd), gpios);
-
-	if (!gpio_is_ready_dt(&lpd_spec)) {
+	if (!gpio_is_ready_dt(&m_lpd)) {
 		LOG_ERR("GPIO device not ready (LPD)");
 		return -ENODEV;
 	}
 
-	ret = gpio_pin_configure_dt(&lpd_spec, GPIO_OUTPUT_ACTIVE);
+	ret = gpio_pin_configure_dt(&m_lpd, GPIO_OUTPUT_ACTIVE);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("gpio_pin_configure_dt", ret);
 		return ret;
@@ -283,67 +407,195 @@ int app_nfc_check(enum app_nfc_action *action)
 
 	*action = APP_NFC_ACTION_NONE;
 
-	const struct gpio_dt_spec lpd_spec = GPIO_DT_SPEC_GET(DT_NODELABEL(lpd), gpios);
+	/* Build the expected info record up front (no I2C); used both to detect
+	 * "tag already holds our info" and to (re)write it. */
+	uint8_t info[80];
+	size_t info_len = build_info_ndef(info, sizeof(info));
 
-	if (!gpio_is_ready_dt(&lpd_spec)) {
-		LOG_ERR("GPIO device not ready (LPD)");
-		return -ENODEV;
-	}
-
-	ret = gpio_pin_set_dt(&lpd_spec, 0);
+	ret = nfc_access_begin();
 	if (ret) {
-		LOG_ERR_CALL_FAILED_INT("gpio_pin_set_dt", ret);
 		return ret;
 	}
 
-	k_sleep(K_MSEC(150));
-
-	static uint8_t buf[512];
-	ret = read_mem(0, buf, sizeof(buf));
+	ret = read_mem(0, m_buf, ST25DV_USER_MEM_SIZE);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("read_mem", ret);
 		res = ret;
-
-		ret = gpio_pin_set_dt(&lpd_spec, 1);
-		if (ret) {
-			LOG_ERR_CALL_FAILED_INT("gpio_pin_set_dt", ret);
-			return ret;
-		}
-
-		return res;
+		goto out;
 	}
 
-	if (is_buffer_zero(buf, sizeof(buf))) {
-		ret = gpio_pin_set_dt(&lpd_spec, 1);
-		if (ret) {
-			LOG_ERR_CALL_FAILED_INT("gpio_pin_set_dt", ret);
-			return ret;
+	/* Empty tag: lay down the info record so a phone always finds metadata. */
+	if (is_buffer_zero(m_buf, ST25DV_USER_MEM_SIZE)) {
+		if (info_len) {
+			ret = write_mem(0, info, info_len);
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("write_mem", ret);
+				res = ret;
+			}
 		}
-
-		return 0;
+		goto out;
 	}
 
-	ret = app_ndef_parser_run(buf, sizeof(buf), parser_callback, action);
+	/* Tag already holds exactly our info record: nothing pending, leave it
+	 * (avoids rewriting the EEPROM on every periodic check). */
+	if (info_len && memcmp(m_buf, info, info_len) == 0) {
+		goto out;
+	}
+
+	/* Pending data written by a phone: parse it (config ingest sets *action). */
+	ret = app_ndef_parser_run(m_buf, ST25DV_USER_MEM_SIZE, parser_callback, action);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("app_ndef_parser_run", ret);
 		res = ret;
 	}
 
-	LOG_INF("Clearing memory...");
-
-	memset(buf, 0, sizeof(buf));
-
-	ret = write_mem(0, buf, sizeof(buf));
-	if (ret) {
-		LOG_ERR_CALL_FAILED_INT("write_mem", ret);
-		res = ret;
+	/* Replace the tag content with the info record. This clears the consumed
+	 * config (anti-replay) and restores the metadata a phone expects to read. */
+	LOG_INF("Writing info record to NFC...");
+	if (info_len) {
+		ret = write_mem(0, info, info_len);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("write_mem", ret);
+			res = ret;
+		}
 	}
 
-	ret = gpio_pin_set_dt(&lpd_spec, 1);
-	if (ret) {
-		LOG_ERR_CALL_FAILED_INT("gpio_pin_set_dt", ret);
-		res = ret;
-	}
-
+out:
+	nfc_access_end();
 	return res;
 }
+
+#if defined(CONFIG_SHELL)
+
+static int cmd_nfc_dump(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		shell_error(sh, "nfc access failed: %d", ret);
+		return ret;
+	}
+
+	ret = read_mem(0, m_buf, ST25DV_USER_MEM_SIZE);
+	if (ret == 0) {
+		shell_hexdump(sh, m_buf, ST25DV_USER_MEM_SIZE);
+	}
+
+	nfc_access_end();
+
+	if (ret) {
+		shell_error(sh, "read failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int cmd_nfc_read(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	unsigned long off = strtoul(argv[1], NULL, 0);
+	unsigned long len = strtoul(argv[2], NULL, 0);
+
+	if (len == 0 || off >= ST25DV_USER_MEM_SIZE || off + len > ST25DV_USER_MEM_SIZE) {
+		shell_error(sh, "range out of 0..%d", ST25DV_USER_MEM_SIZE);
+		return -EINVAL;
+	}
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		shell_error(sh, "nfc access failed: %d", ret);
+		return ret;
+	}
+
+	ret = read_mem((uint16_t)off, m_buf, len);
+	if (ret == 0) {
+		shell_hexdump(sh, m_buf, len);
+	}
+
+	nfc_access_end();
+
+	if (ret) {
+		shell_error(sh, "read failed: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int cmd_nfc_write(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	unsigned long off = strtoul(argv[1], NULL, 0);
+
+	size_t n = hex2bin(argv[2], strlen(argv[2]), m_buf, ST25DV_USER_MEM_SIZE);
+	if (n == 0) {
+		shell_error(sh, "bad hex (or empty)");
+		return -EINVAL;
+	}
+
+	if (off >= ST25DV_USER_MEM_SIZE || off + n > ST25DV_USER_MEM_SIZE) {
+		shell_error(sh, "range out of 0..%d", ST25DV_USER_MEM_SIZE);
+		return -EINVAL;
+	}
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		shell_error(sh, "nfc access failed: %d", ret);
+		return ret;
+	}
+
+	ret = write_mem((uint16_t)off, m_buf, n);
+
+	nfc_access_end();
+
+	if (ret) {
+		shell_error(sh, "write failed: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "wrote %zu byte(s) at offset %lu", n, off);
+	return 0;
+}
+
+static int cmd_nfc_clear(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	memset(m_buf, 0, ST25DV_USER_MEM_SIZE);
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		shell_error(sh, "nfc access failed: %d", ret);
+		return ret;
+	}
+
+	ret = write_mem(0, m_buf, ST25DV_USER_MEM_SIZE);
+
+	nfc_access_end();
+
+	if (ret) {
+		shell_error(sh, "clear failed: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "cleared %d bytes", ST25DV_USER_MEM_SIZE);
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_nfc, SHELL_CMD_ARG(dump, NULL, "Hex dump all 512 B of NFC memory.", cmd_nfc_dump, 1, 0),
+	SHELL_CMD_ARG(read, NULL, "Read a range. Usage: read <offset> <len>", cmd_nfc_read, 3, 0),
+	SHELL_CMD_ARG(write, NULL, "Write hex bytes. Usage: write <offset> <hexbytes>", cmd_nfc_write,
+		      3, 0),
+	SHELL_CMD_ARG(clear, NULL, "Zero all 512 B of NFC memory.", cmd_nfc_clear, 1, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(nfc, &sub_nfc, "ST25DV NFC memory access (debug).", NULL);
+
+#endif /* CONFIG_SHELL */

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -43,6 +43,46 @@
 
 LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
 
+#if defined(CONFIG_SHELL)
+/* When set (by `nfc check`), nfc_check_locked()/parser_callback emit a human-
+ * readable trace to this shell: what was read & decoded off the tag, how the
+ * firmware reacted, and what it wrote back. NULL for boot/poll-thread checks
+ * (those only log over RTT). Set/cleared around the app_nfc_check() call. */
+static const struct shell *m_report_sh;
+#define NFC_REPORT(...)                                                                            \
+	do {                                                                                       \
+		if (m_report_sh) {                                                                 \
+			shell_print(m_report_sh, __VA_ARGS__);                                     \
+		}                                                                                  \
+	} while (0)
+#define NFC_REPORT_HEX(label, data, len)                                                           \
+	do {                                                                                       \
+		if (m_report_sh) {                                                                 \
+			shell_print(m_report_sh, label);                                           \
+			shell_hexdump(m_report_sh, (data), (len));                                 \
+		}                                                                                  \
+	} while (0)
+
+static const char *cmd_action_str(enum app_cmd_action a)
+{
+	switch (a) {
+	case APP_CMD_ACTION_NONE:
+		return "none";
+	case APP_CMD_ACTION_SETTINGS_SAVE:
+		return "save+reboot";
+	case APP_CMD_ACTION_REBOOT:
+		return "reboot";
+	case APP_CMD_ACTION_FACTORY_RESET:
+		return "factory-reset";
+	default:
+		return "?";
+	}
+}
+#else
+#define NFC_REPORT(...)                  ((void)0)
+#define NFC_REPORT_HEX(label, data, len) ((void)0)
+#endif
+
 #define ST25DV_I2C_ADDR_E0 0x53
 /* System/dynamic register device address. With user memory at 0x53 (E2=1),
  * the system area is at 0x57 (the prior 0x55 was the E2=0 value and NACKed). */
@@ -67,8 +107,12 @@ LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
 #define ST25DV_GPO_RF_WRITE_EN 0x40
 #define ST25DV_I2C_PWD_REG     0x0900
 
-#define NDEF_TNF_MIME       0x02
-#define NDEF_SUPPORTED_TYPE "application/com.hardwario.sticker.config"
+/* NFC Forum external type (TNF=0x04, urn:nfc:ext:) records. Short type names
+ * ("hio.stck:<kind>") instead of full MIME media-types save ST25DV user memory
+ * (512 B total) — leaving more room for the encrypted config payload — while
+ * staying typed/filterable: Web NFC exposes them as record.recordType. */
+#define NDEF_TNF_EXT        0x04
+#define NDEF_SUPPORTED_TYPE "hio.stck:cfg"
 
 /* Plaintext info record the firmware keeps on the tag so a phone learns the
  * sticker identity and schema version the moment it taps, without decrypting
@@ -80,14 +124,14 @@ LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
  *   [9]    config/schema version (APP_CONFIG_VERSION)
  *   [10]   flags: bit0 = debug build
  */
-#define NDEF_INFO_TYPE   "application/com.hardwario.sticker.info"
+#define NDEF_INFO_TYPE   "hio.stck:inf"
 #define NDEF_INFO_FORMAT 0x01
 
 /* Command/response over NDEF. The phone writes a command record (raw protobuf
  * Command, like a LoRaWAN downlink); the firmware processes it via app_cmd and
  * replaces it with a response record (0x01 version + protobuf Response). */
-#define NDEF_COMMAND_TYPE  "application/com.hardwario.sticker.command"
-#define NDEF_RESPONSE_TYPE "application/com.hardwario.sticker.response"
+#define NDEF_COMMAND_TYPE  "hio.stck:cmd"
+#define NDEF_RESPONSE_TYPE "hio.stck:rsp"
 
 /* NFC Forum Type 5 Capability Container (4-byte form) for ST25DV04K:
  *   [0] 0xE1 magic, [1] 0x40 mapping v1.0 + read/write,
@@ -120,8 +164,8 @@ static bool m_rf_write_gate;
  * is found and consumed by nfc_check_locked (writes the response to the tag). */
 static uint8_t m_resp_buf[256];
 static size_t m_resp_len;
-static bool m_have_resp;    /* a command was processed; m_resp_buf holds the reply to write */
-static bool m_seen_resp;    /* tag already holds a response record; leave it for the phone */
+static bool m_have_resp; /* a command was processed; m_resp_buf holds the reply to write */
+static bool m_seen_resp; /* tag already holds a response record; leave it for the phone */
 static enum app_cmd_action m_cmd_action; /* deferred action from app_cmd_handle */
 
 /* Take (and clear) the deferred action from the last processed NFC command, so
@@ -375,13 +419,14 @@ static void nfc_access_end(void)
 	k_mutex_unlock(&m_lock);
 }
 
-/* Build CC + NDEF Message TLV + a single short MIME record + terminator into
- * `out`. Returns the byte length, or 0 if it would not fit (short record, so
- * payload <= 255 B). Shared by the info and command-response writers. */
-static size_t build_ndef_mime(uint8_t *out, size_t out_size, const char *mime,
-			      const uint8_t *payload, size_t payload_len)
+/* Build CC + NDEF Message TLV + a single short NFC-Forum-external-type record +
+ * terminator into `out`. Returns the byte length, or 0 if it would not fit
+ * (short record, so payload <= 255 B). Shared by the info and command-response
+ * writers. */
+static size_t build_ndef_record(uint8_t *out, size_t out_size, const char *type,
+				const uint8_t *payload, size_t payload_len)
 {
-	size_t type_len = strlen(mime);
+	size_t type_len = strlen(type);
 
 	/* NDEF record: header + type_len + payload_len + type + payload */
 	size_t msg_len = 1 + 1 + 1 + type_len + payload_len;
@@ -399,10 +444,10 @@ static size_t build_ndef_mime(uint8_t *out, size_t out_size, const char *mime,
 	out[i++] = ST25DV_CC3;
 	out[i++] = 0x03;             /* NDEF Message TLV type */
 	out[i++] = (uint8_t)msg_len; /* TLV length (single-byte form) */
-	out[i++] = 0xD2;             /* MB | ME | SR | TNF=MIME(0x02) */
+	out[i++] = 0xD4;             /* MB | ME | SR | TNF=NFC Forum external(0x04) */
 	out[i++] = (uint8_t)type_len;
 	out[i++] = (uint8_t)payload_len;
-	memcpy(&out[i], mime, type_len);
+	memcpy(&out[i], type, type_len);
 	i += type_len;
 	memcpy(&out[i], payload, payload_len);
 	i += payload_len;
@@ -429,7 +474,7 @@ static size_t build_info_ndef(uint8_t *out, size_t out_size)
 	payload[9] = (uint8_t)g_app_config.config_version;
 	payload[10] = info.debug ? 0x01 : 0x00;
 
-	return build_ndef_mime(out, out_size, NDEF_INFO_TYPE, payload, sizeof(payload));
+	return build_ndef_record(out, out_size, NDEF_INFO_TYPE, payload, sizeof(payload));
 }
 
 static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_size, size_t *out_len)
@@ -444,6 +489,7 @@ static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_si
 	/* Verify serial number (part of nonce) */
 	uint32_t serial_number = sys_get_be32(&in[0]);
 	LOG_INF("Serial number: %u", serial_number);
+	NFC_REPORT("  serial: %u (expected %u)", serial_number, g_app_config.serial_number);
 
 	if (g_app_config.serial_number != serial_number) {
 		LOG_ERR("Serial number does not match: %u != %u", serial_number,
@@ -454,6 +500,7 @@ static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_si
 	/* Verify nonce counter (part of nonce) */
 	uint32_t nonce_counter = sys_get_be32(&in[4]);
 	LOG_INF("Nonce counter: %u", nonce_counter);
+	NFC_REPORT("  nonce: %u (last used %u)", nonce_counter, g_app_config.nonce_counter);
 
 	if (g_app_config.nonce_counter >= nonce_counter) {
 		LOG_ERR("Nonce counter is not greater than the last used nonce: %u >= %u",
@@ -478,7 +525,7 @@ static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_si
 
 	psa_key_id_t key_id;
 	status = psa_import_key(&key_attributes, g_app_config.secret_key,
-			       sizeof(g_app_config.secret_key), &key_id);
+				sizeof(g_app_config.secret_key), &key_id);
 	if (status != PSA_SUCCESS) {
 		LOG_ERR_CALL_FAILED_INT("psa_import_key", status);
 		return -EIO;
@@ -514,8 +561,8 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 
 	enum app_nfc_action *action = (enum app_nfc_action *)user_data;
 
-	/* Check if TNF type is MIME */
-	if (record_info->tnf != NDEF_TNF_MIME) {
+	/* Only our NFC Forum external-type records carry sticker payloads. */
+	if (record_info->tnf != NDEF_TNF_EXT) {
 		return 0;
 	}
 
@@ -525,6 +572,9 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 	if (record_info->type_len == cmd_type_len &&
 	    strncmp((const char *)record_info->type, NDEF_COMMAND_TYPE, cmd_type_len) == 0) {
 		LOG_INF("Found command record - length: %u byte(s)", record_info->payload_len);
+		NFC_REPORT("NFC read: command record (%u B)", record_info->payload_len);
+		NFC_REPORT_HEX("  command (protobuf):", record_info->payload,
+			       record_info->payload_len);
 
 		enum app_cmd_action cmd_action = APP_CMD_ACTION_NONE;
 		ret = app_cmd_handle(APP_CMD_TRANSPORT_NFC, record_info->payload,
@@ -532,12 +582,15 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 				     &m_resp_len, &cmd_action);
 		if (ret) {
 			LOG_ERR_CALL_FAILED_INT("app_cmd_handle", ret);
+			NFC_REPORT("  -> app_cmd_handle failed: %d", ret);
 			m_resp_len = 0;
 			return ret;
 		}
 
 		m_have_resp = (m_resp_len > 0);
 		m_cmd_action = cmd_action;
+		NFC_REPORT("  -> handled, response %zu B, deferred action: %s", m_resp_len,
+			   cmd_action_str(cmd_action));
 		return 0;
 	}
 
@@ -547,6 +600,9 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 	if (record_info->type_len == resp_type_len &&
 	    strncmp((const char *)record_info->type, NDEF_RESPONSE_TYPE, resp_type_len) == 0) {
 		m_seen_resp = true;
+		NFC_REPORT("NFC read: our response record still on tag (%u B) - leaving it for "
+			   "the phone",
+			   record_info->payload_len);
 		return 0;
 	}
 
@@ -559,12 +615,14 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 	}
 
 	LOG_INF("Found supported MIME record - length: %u byte(s)", record_info->payload_len);
+	NFC_REPORT("NFC read: config record (%u B encrypted)", record_info->payload_len);
 
 	static uint8_t buf[448];
 	size_t len;
 	ret = decrypt(record_info->payload, record_info->payload_len, buf, sizeof(buf), &len);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("decrypt", ret);
+		NFC_REPORT("  -> decrypt failed: %d (rejected, tag left untouched)", ret);
 		return ret;
 	}
 
@@ -578,8 +636,10 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 
 	if (app_config_ingest(&message)) {
 		*action = APP_NFC_ACTION_RESET;
+		NFC_REPORT("  -> config decoded & ingested, action: factory reset");
 	} else {
 		*action = APP_NFC_ACTION_SAVE;
+		NFC_REPORT("  -> config decoded & ingested, action: apply + save");
 	}
 
 	return 0;
@@ -650,6 +710,7 @@ static int nfc_check_locked(enum app_nfc_action *action)
 
 	/* Empty tag: lay down the info record so a phone always finds metadata. */
 	if (is_buffer_zero(m_buf, ST25DV_USER_MEM_SIZE)) {
+		NFC_REPORT("NFC tag empty -> writing info record (%zu B)", info_len);
 		if (info_len) {
 			ret = write_mem(0, info, info_len);
 			if (ret) {
@@ -663,6 +724,7 @@ static int nfc_check_locked(enum app_nfc_action *action)
 	/* Tag already holds exactly our info record: nothing pending, leave it
 	 * (avoids rewriting the EEPROM on every check). */
 	if (info_len && memcmp(m_buf, info, info_len) == 0) {
+		NFC_REPORT("NFC tag holds our info record (nothing pending) -> no action");
 		return 0;
 	}
 
@@ -679,9 +741,13 @@ static int nfc_check_locked(enum app_nfc_action *action)
 	 * as the output buffer (its parsed contents are no longer needed; the reply
 	 * is already copied into m_resp_buf) to keep this off the thread stack. */
 	if (m_have_resp) {
-		size_t out_len = build_ndef_mime(m_buf, ST25DV_USER_MEM_SIZE, NDEF_RESPONSE_TYPE,
-						 m_resp_buf, m_resp_len);
+		size_t out_len = build_ndef_record(m_buf, ST25DV_USER_MEM_SIZE, NDEF_RESPONSE_TYPE,
+						   m_resp_buf, m_resp_len);
 		LOG_INF("Writing command response to NFC (%zu B)...", m_resp_len);
+		NFC_REPORT("NFC wrote: response record (%zu B NDEF, %zu B payload)", out_len,
+			   m_resp_len);
+		NFC_REPORT_HEX("  response (0x01 ver + protobuf Response):", m_resp_buf,
+			       m_resp_len);
 		if (out_len) {
 			ret = write_mem(0, m_buf, out_len);
 			if (ret) {
@@ -700,6 +766,9 @@ static int nfc_check_locked(enum app_nfc_action *action)
 	/* Config consumed (or unrecognized data): (re)write the info record. This
 	 * clears the consumed config (anti-replay) and restores the metadata. */
 	LOG_INF("Writing info record to NFC...");
+	NFC_REPORT("NFC wrote: info record (%zu B) - cleared consumed/unknown data, restored "
+		   "metadata",
+		   info_len);
 	if (info_len) {
 		ret = write_mem(0, info, info_len);
 		if (ret) {
@@ -904,7 +973,11 @@ static int cmd_nfc_check(const struct shell *sh, size_t argc, char **argv)
 	ARG_UNUSED(argv);
 
 	enum app_nfc_action action;
+
+	/* Route the check's read/decode/react/write trace to this shell. */
+	m_report_sh = sh;
 	int ret = app_nfc_check(&action);
+	m_report_sh = NULL;
 	if (ret) {
 		shell_error(sh, "nfc check failed: %d", ret);
 		return ret;
@@ -986,13 +1059,13 @@ static int cmd_nfc_regw(const struct shell *sh, size_t argc, char **argv)
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_nfc, SHELL_CMD_ARG(dump, NULL, "Hex dump all 512 B of NFC memory.", cmd_nfc_dump, 1, 0),
 	SHELL_CMD_ARG(read, NULL, "Read a range. Usage: read <offset> <len>", cmd_nfc_read, 3, 0),
-	SHELL_CMD_ARG(write, NULL, "Write hex bytes. Usage: write <offset> <hexbytes>", cmd_nfc_write,
-		      3, 0),
+	SHELL_CMD_ARG(write, NULL, "Write hex bytes. Usage: write <offset> <hexbytes>",
+		      cmd_nfc_write, 3, 0),
 	SHELL_CMD_ARG(clear, NULL, "Zero all 512 B of NFC memory.", cmd_nfc_clear, 1, 0),
 	SHELL_CMD_ARG(autocheck, NULL, "Enable/disable periodic check. Usage: autocheck on|off",
 		      cmd_nfc_autocheck, 2, 0),
-	SHELL_CMD_ARG(check, NULL, "Run the NFC check now (parse + apply config).", cmd_nfc_check, 1,
-		      0),
+	SHELL_CMD_ARG(check, NULL, "Run the NFC check now (parse + apply config).", cmd_nfc_check,
+		      1, 0),
 	SHELL_CMD_ARG(reg, NULL, "Read system/dynamic register (E1). Usage: reg <addr> [count]",
 		      cmd_nfc_reg, 2, 1),
 	SHELL_CMD_ARG(regw, NULL, "Write system/dynamic register (E1). Usage: regw <addr> <hex>",

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -83,6 +83,12 @@ LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
 #define NDEF_INFO_TYPE   "application/com.hardwario.sticker.info"
 #define NDEF_INFO_FORMAT 0x01
 
+/* Command/response over NDEF. The phone writes a command record (raw protobuf
+ * Command, like a LoRaWAN downlink); the firmware processes it via app_cmd and
+ * replaces it with a response record (0x01 version + protobuf Response). */
+#define NDEF_COMMAND_TYPE  "application/com.hardwario.sticker.command"
+#define NDEF_RESPONSE_TYPE "application/com.hardwario.sticker.response"
+
 /* NFC Forum Type 5 Capability Container (4-byte form) for ST25DV04K:
  *   [0] 0xE1 magic, [1] 0x40 mapping v1.0 + read/write,
  *   [2] MLEN = user_memory / 8 = 512/8 = 0x40, [3] 0x01 (MBREAD feature).
@@ -109,6 +115,23 @@ static bool m_periodic = true;
 /* True when GPO RF_WRITE_EN was successfully enabled, so the poll can gate on
  * the RF_WRITE bit specifically. False => gate on any RF activity (fallback). */
 static bool m_rf_write_gate;
+
+/* Command/response state, filled by parser_callback when an NDEF command record
+ * is found and consumed by nfc_check_locked (writes the response to the tag). */
+static uint8_t m_resp_buf[256];
+static size_t m_resp_len;
+static bool m_have_resp;    /* a command was processed; m_resp_buf holds the reply to write */
+static bool m_seen_resp;    /* tag already holds a response record; leave it for the phone */
+static enum app_cmd_action m_cmd_action; /* deferred action from app_cmd_handle */
+
+/* Take (and clear) the deferred action from the last processed NFC command, so
+ * the poll thread can run reboot/save AFTER the response was written/read. */
+enum app_cmd_action app_nfc_take_cmd_action(void)
+{
+	enum app_cmd_action a = m_cmd_action;
+	m_cmd_action = APP_CMD_ACTION_NONE;
+	return a;
+}
 
 bool app_nfc_periodic_enabled(void)
 {
@@ -286,6 +309,10 @@ static int nfc_enable_rf_write_it(void)
 		return ret;
 	}
 
+	/* The chip needs a moment after a present-password write before the next
+	 * I2C access is ACKed. */
+	k_msleep(5);
+
 	uint8_t gpo;
 	ret = read_reg(ST25DV_GPO_REG, &gpo, 1);
 	if (ret) {
@@ -348,10 +375,45 @@ static void nfc_access_end(void)
 	k_mutex_unlock(&m_lock);
 }
 
-/* Build the plaintext info NDEF (TLV + single MIME record + terminator) into
- * `out`. Returns the byte length, or 0 if it would not fit. Deterministic for a
- * given firmware/config (no uptime/clock), so app_nfc_check() can compare it to
- * the tag content and skip rewriting when already present. */
+/* Build CC + NDEF Message TLV + a single short MIME record + terminator into
+ * `out`. Returns the byte length, or 0 if it would not fit (short record, so
+ * payload <= 255 B). Shared by the info and command-response writers. */
+static size_t build_ndef_mime(uint8_t *out, size_t out_size, const char *mime,
+			      const uint8_t *payload, size_t payload_len)
+{
+	size_t type_len = strlen(mime);
+
+	/* NDEF record: header + type_len + payload_len + type + payload */
+	size_t msg_len = 1 + 1 + 1 + type_len + payload_len;
+
+	/* Tag content: CC (4) + NDEF Message TLV (0x03, len) + message + Terminator (0xFE) */
+	size_t total = 4 + 2 + msg_len + 1;
+	if (payload_len > 0xFF || msg_len > 0xFE || total > out_size) {
+		return 0;
+	}
+
+	size_t i = 0;
+	out[i++] = ST25DV_CC0; /* Type 5 Capability Container */
+	out[i++] = ST25DV_CC1;
+	out[i++] = ST25DV_CC2;
+	out[i++] = ST25DV_CC3;
+	out[i++] = 0x03;             /* NDEF Message TLV type */
+	out[i++] = (uint8_t)msg_len; /* TLV length (single-byte form) */
+	out[i++] = 0xD2;             /* MB | ME | SR | TNF=MIME(0x02) */
+	out[i++] = (uint8_t)type_len;
+	out[i++] = (uint8_t)payload_len;
+	memcpy(&out[i], mime, type_len);
+	i += type_len;
+	memcpy(&out[i], payload, payload_len);
+	i += payload_len;
+	out[i++] = 0xFE; /* Terminator TLV */
+
+	return i;
+}
+
+/* Build the plaintext info NDEF into `out`. Deterministic for a given
+ * firmware/config (no uptime/clock), so app_nfc_check() can compare it to the
+ * tag content and skip rewriting when already present. */
 static size_t build_info_ndef(uint8_t *out, size_t out_size)
 {
 	struct app_cmd_info info;
@@ -367,35 +429,7 @@ static size_t build_info_ndef(uint8_t *out, size_t out_size)
 	payload[9] = (uint8_t)g_app_config.config_version;
 	payload[10] = info.debug ? 0x01 : 0x00;
 
-	size_t type_len = strlen(NDEF_INFO_TYPE);
-	size_t payload_len = sizeof(payload);
-
-	/* NDEF record: header + type_len + payload_len + type + payload */
-	size_t msg_len = 1 + 1 + 1 + type_len + payload_len;
-
-	/* Tag content: CC (4) + NDEF Message TLV (0x03, len) + message + Terminator (0xFE) */
-	size_t total = 4 + 2 + msg_len + 1;
-	if (total > out_size || msg_len > 0xFE) {
-		return 0;
-	}
-
-	size_t i = 0;
-	out[i++] = ST25DV_CC0; /* Type 5 Capability Container */
-	out[i++] = ST25DV_CC1;
-	out[i++] = ST25DV_CC2;
-	out[i++] = ST25DV_CC3;
-	out[i++] = 0x03;             /* NDEF Message TLV type */
-	out[i++] = (uint8_t)msg_len; /* TLV length (single-byte form) */
-	out[i++] = 0xD2;             /* MB | ME | SR | TNF=MIME(0x02) */
-	out[i++] = (uint8_t)type_len;
-	out[i++] = (uint8_t)payload_len;
-	memcpy(&out[i], NDEF_INFO_TYPE, type_len);
-	i += type_len;
-	memcpy(&out[i], payload, payload_len);
-	i += payload_len;
-	out[i++] = 0xFE; /* Terminator TLV */
-
-	return i;
+	return build_ndef_mime(out, out_size, NDEF_INFO_TYPE, payload, sizeof(payload));
 }
 
 static int decrypt(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_size, size_t *out_len)
@@ -485,6 +519,37 @@ static int parser_callback(const struct app_ndef_parser_record_info *record_info
 		return 0;
 	}
 
+	/* Command record: hand the raw protobuf Command to app_cmd and stage the
+	 * response for nfc_check_locked to write back to the tag. */
+	size_t cmd_type_len = strlen(NDEF_COMMAND_TYPE);
+	if (record_info->type_len == cmd_type_len &&
+	    strncmp((const char *)record_info->type, NDEF_COMMAND_TYPE, cmd_type_len) == 0) {
+		LOG_INF("Found command record - length: %u byte(s)", record_info->payload_len);
+
+		enum app_cmd_action cmd_action = APP_CMD_ACTION_NONE;
+		ret = app_cmd_handle(APP_CMD_TRANSPORT_NFC, record_info->payload,
+				     record_info->payload_len, m_resp_buf, sizeof(m_resp_buf),
+				     &m_resp_len, &cmd_action);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("app_cmd_handle", ret);
+			m_resp_len = 0;
+			return ret;
+		}
+
+		m_have_resp = (m_resp_len > 0);
+		m_cmd_action = cmd_action;
+		return 0;
+	}
+
+	/* Response record already on the tag (our previous reply): leave it so the
+	 * phone can read it; don't overwrite with the info record. */
+	size_t resp_type_len = strlen(NDEF_RESPONSE_TYPE);
+	if (record_info->type_len == resp_type_len &&
+	    strncmp((const char *)record_info->type, NDEF_RESPONSE_TYPE, resp_type_len) == 0) {
+		m_seen_resp = true;
+		return 0;
+	}
+
 	size_t expected_type_len = strlen(NDEF_SUPPORTED_TYPE);
 
 	/* Check if type matches */
@@ -569,6 +634,9 @@ static int nfc_check_locked(enum app_nfc_action *action)
 	int ret;
 	int res = 0;
 
+	m_have_resp = false;
+	m_seen_resp = false;
+
 	/* Build the expected info record up front (no I2C); used both to detect
 	 * "tag already holds our info" and to (re)write it. */
 	uint8_t info[80];
@@ -598,15 +666,39 @@ static int nfc_check_locked(enum app_nfc_action *action)
 		return 0;
 	}
 
-	/* Pending data written by a phone: parse it (config ingest sets *action). */
+	/* Pending data written by a phone: parse it. parser_callback may ingest a
+	 * config (sets *action), or process a command (stages m_resp_buf), or flag
+	 * that the tag already holds our response (m_seen_resp). */
 	ret = app_ndef_parser_run(m_buf, ST25DV_USER_MEM_SIZE, parser_callback, action);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("app_ndef_parser_run", ret);
 		res = ret;
 	}
 
-	/* Replace the tag content with the info record. This clears the consumed
-	 * config (anti-replay) and restores the metadata a phone expects to read. */
+	/* A command was processed: write the response back to the tag. Reuse m_buf
+	 * as the output buffer (its parsed contents are no longer needed; the reply
+	 * is already copied into m_resp_buf) to keep this off the thread stack. */
+	if (m_have_resp) {
+		size_t out_len = build_ndef_mime(m_buf, ST25DV_USER_MEM_SIZE, NDEF_RESPONSE_TYPE,
+						 m_resp_buf, m_resp_len);
+		LOG_INF("Writing command response to NFC (%zu B)...", m_resp_len);
+		if (out_len) {
+			ret = write_mem(0, m_buf, out_len);
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("write_mem", ret);
+				res = ret;
+			}
+		}
+		return res;
+	}
+
+	/* Our response is already on the tag (awaiting the phone read): leave it. */
+	if (m_seen_resp) {
+		return res;
+	}
+
+	/* Config consumed (or unrecognized data): (re)write the info record. This
+	 * clears the consumed config (anti-replay) and restores the metadata. */
 	LOG_INF("Writing info record to NFC...");
 	if (info_len) {
 		ret = write_mem(0, info, info_len);

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -44,13 +44,20 @@
 LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
 
 #define ST25DV_I2C_ADDR_E0 0x53
-#define ST25DV_I2C_ADDR_E1 0x55
+/* System/dynamic register device address. With user memory at 0x53 (E2=1),
+ * the system area is at 0x57 (the prior 0x55 was the E2=0 value and NACKed). */
+#define ST25DV_I2C_ADDR_E1 0x57
 
 #define ST25DV_MAX_SEQ_WRITE_BYTES 256
 #define ST25DV_INT_PAGE_BYTES      4
 #define ST25DV_TW_MS_PER_PAGE      5
 
 #define ST25DV_USER_MEM_SIZE 512
+
+/* Dynamic register IT_STS_Dyn (device E0, addr 0x2005): interrupt status,
+ * read-clears. Non-zero => RF activity since last read (field change / RF
+ * write / etc.). Used to skip the full 512 B read when nothing happened. */
+#define ST25DV_IT_STS_DYN 0x2005
 
 #define NDEF_TNF_MIME       0x02
 #define NDEF_SUPPORTED_TYPE "application/vnd.hardwario.sticker-config.v1"
@@ -168,6 +175,62 @@ static int write_mem(uint16_t reg, const void *buf, size_t len)
 		reg += chunk;
 		p += chunk;
 		remaining -= chunk;
+	}
+
+	return 0;
+}
+
+/* ST25DV register device select: dynamic registers (>=0x2000, e.g. IT_STS_Dyn
+ * 0x2005, GPO_Dyn 0x2000) live on the user-memory device (E0 0x53); the static
+ * system configuration area (<0x2000, e.g. GPO 0x0000) is on the system device
+ * (E1 0x57). */
+static inline uint8_t reg_dev_addr(uint16_t reg)
+{
+	return (reg >= 0x2000) ? ST25DV_I2C_ADDR_E0 : ST25DV_I2C_ADDR_E1;
+}
+
+/* Read ST25DV system/dynamic register(s). No password needed for reads. */
+static int read_reg(uint16_t reg, void *buf, size_t len)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(i2c1));
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Device not ready");
+		return -ENODEV;
+	}
+
+	uint8_t reg_[2];
+	sys_put_be16(reg, reg_);
+
+	int ret = i2c_write_read(dev, reg_dev_addr(reg), reg_, sizeof(reg_), buf, len);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("i2c_write_read", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/* Write an ST25DV register. Dynamic registers need no password; the static
+ * system config area requires an open I2C security session (not handled here). */
+static int write_reg(uint16_t reg, const void *buf, size_t len)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(i2c1));
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Device not ready");
+		return -ENODEV;
+	}
+	if (len > 16) {
+		return -EINVAL;
+	}
+
+	uint8_t frame[2 + 16];
+	sys_put_be16(reg, frame);
+	memcpy(&frame[2], buf, len);
+
+	int ret = i2c_write(dev, frame, 2 + len, reg_dev_addr(reg));
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("i2c_write", ret);
+		return ret;
 	}
 
 	return 0;
@@ -411,28 +474,22 @@ int app_nfc_init(void)
 	return 0;
 }
 
-int app_nfc_check(enum app_nfc_action *action)
+/* Core NFC check: read the tag, parse/ingest a pending config, and restore the
+ * info record. Caller must hold the access lock (nfc_access_begin). */
+static int nfc_check_locked(enum app_nfc_action *action)
 {
 	int ret;
 	int res = 0;
-
-	*action = APP_NFC_ACTION_NONE;
 
 	/* Build the expected info record up front (no I2C); used both to detect
 	 * "tag already holds our info" and to (re)write it. */
 	uint8_t info[80];
 	size_t info_len = build_info_ndef(info, sizeof(info));
 
-	ret = nfc_access_begin();
-	if (ret) {
-		return ret;
-	}
-
 	ret = read_mem(0, m_buf, ST25DV_USER_MEM_SIZE);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("read_mem", ret);
-		res = ret;
-		goto out;
+		return ret;
 	}
 
 	/* Empty tag: lay down the info record so a phone always finds metadata. */
@@ -444,13 +501,13 @@ int app_nfc_check(enum app_nfc_action *action)
 				res = ret;
 			}
 		}
-		goto out;
+		return res;
 	}
 
 	/* Tag already holds exactly our info record: nothing pending, leave it
-	 * (avoids rewriting the EEPROM on every periodic check). */
+	 * (avoids rewriting the EEPROM on every check). */
 	if (info_len && memcmp(m_buf, info, info_len) == 0) {
-		goto out;
+		return 0;
 	}
 
 	/* Pending data written by a phone: parse it (config ingest sets *action). */
@@ -471,7 +528,47 @@ int app_nfc_check(enum app_nfc_action *action)
 		}
 	}
 
-out:
+	return res;
+}
+
+/* Full NFC check: always reads the tag. Used at boot and by `nfc check`
+ * (an I2C-side `nfc write` does not set the RF IT_STS_Dyn flags). */
+int app_nfc_check(enum app_nfc_action *action)
+{
+	*action = APP_NFC_ACTION_NONE;
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		return ret;
+	}
+
+	int res = nfc_check_locked(action);
+
+	nfc_access_end();
+	return res;
+}
+
+/* Gated poll for the periodic main-loop check: read the 1-byte IT_STS_Dyn
+ * (read-clears). Only when it shows RF activity since the last poll do the full
+ * 512 B read + parse. Saves waking the bus / parsing when nothing changed. */
+int app_nfc_poll(enum app_nfc_action *action)
+{
+	*action = APP_NFC_ACTION_NONE;
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		return ret;
+	}
+
+	int res = 0;
+	uint8_t it_sts = 0;
+	ret = read_reg(ST25DV_IT_STS_DYN, &it_sts, sizeof(it_sts));
+	if (ret) {
+		res = ret;
+	} else if (it_sts != 0) {
+		res = nfc_check_locked(action);
+	}
+
 	nfc_access_end();
 	return res;
 }
@@ -641,6 +738,66 @@ static int cmd_nfc_check(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_nfc_reg(const struct shell *sh, size_t argc, char **argv)
+{
+	unsigned long addr = strtoul(argv[1], NULL, 0);
+	unsigned long count = (argc >= 3) ? strtoul(argv[2], NULL, 0) : 1;
+
+	if (count == 0 || count > 64) {
+		shell_error(sh, "count must be 1..64");
+		return -EINVAL;
+	}
+
+	uint8_t buf[64];
+	int ret = nfc_access_begin();
+	if (ret) {
+		shell_error(sh, "nfc access failed: %d", ret);
+		return ret;
+	}
+
+	ret = read_reg((uint16_t)addr, buf, count);
+	nfc_access_end();
+
+	if (ret) {
+		shell_error(sh, "reg read failed: %d", ret);
+		return ret;
+	}
+
+	shell_hexdump(sh, buf, count);
+	return 0;
+}
+
+static int cmd_nfc_regw(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	unsigned long addr = strtoul(argv[1], NULL, 0);
+
+	uint8_t buf[16];
+	size_t n = hex2bin(argv[2], strlen(argv[2]), buf, sizeof(buf));
+	if (n == 0) {
+		shell_error(sh, "bad hex (or empty / too long, max 16 B)");
+		return -EINVAL;
+	}
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		shell_error(sh, "nfc access failed: %d", ret);
+		return ret;
+	}
+
+	ret = write_reg((uint16_t)addr, buf, n);
+	nfc_access_end();
+
+	if (ret) {
+		shell_error(sh, "reg write failed: %d", ret);
+		return ret;
+	}
+
+	shell_print(sh, "wrote %zu byte(s) to reg 0x%lx", n, addr);
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_nfc, SHELL_CMD_ARG(dump, NULL, "Hex dump all 512 B of NFC memory.", cmd_nfc_dump, 1, 0),
 	SHELL_CMD_ARG(read, NULL, "Read a range. Usage: read <offset> <len>", cmd_nfc_read, 3, 0),
@@ -651,6 +808,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_nfc_autocheck, 2, 0),
 	SHELL_CMD_ARG(check, NULL, "Run the NFC check now (parse + apply config).", cmd_nfc_check, 1,
 		      0),
+	SHELL_CMD_ARG(reg, NULL, "Read system/dynamic register (E1). Usage: reg <addr> [count]",
+		      cmd_nfc_reg, 2, 1),
+	SHELL_CMD_ARG(regw, NULL, "Write system/dynamic register (E1). Usage: regw <addr> <hex>",
+		      cmd_nfc_regw, 3, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(nfc, &sub_nfc, "ST25DV NFC memory access (debug).", NULL);

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -9,6 +9,7 @@
 #include "app_config_ingest.h"
 #include "app_config.h"
 #include "app_ndef_parser.h"
+#include "app_settings.h"
 #include "app_version.h"
 #include "app_log.h"
 
@@ -84,6 +85,16 @@ static uint8_t m_buf[ST25DV_USER_MEM_SIZE];
 static K_MUTEX_DEFINE(m_lock);
 
 static const struct gpio_dt_spec m_lpd = GPIO_DT_SPEC_GET(DT_NODELABEL(lpd), gpios);
+
+/* Periodic NFC check enable (toggled via `nfc autocheck`). Lets a config blob
+ * be written over several `nfc write` calls without the periodic check racing
+ * it and rewriting the tag to the info record mid-write. */
+static bool m_periodic = true;
+
+bool app_nfc_periodic_enabled(void)
+{
+	return m_periodic;
+}
 
 static int read_mem(uint16_t reg, void *buf, size_t len)
 {
@@ -588,12 +599,58 @@ static int cmd_nfc_clear(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_nfc_autocheck(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	if (strcmp(argv[1], "on") == 0) {
+		m_periodic = true;
+	} else if (strcmp(argv[1], "off") == 0) {
+		m_periodic = false;
+	} else {
+		shell_error(sh, "usage: nfc autocheck on|off");
+		return -EINVAL;
+	}
+
+	shell_print(sh, "periodic NFC check %s", m_periodic ? "on" : "off");
+	return 0;
+}
+
+static int cmd_nfc_check(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	enum app_nfc_action action;
+	int ret = app_nfc_check(&action);
+	if (ret) {
+		shell_error(sh, "nfc check failed: %d", ret);
+		return ret;
+	}
+
+	if (action == APP_NFC_ACTION_SAVE) {
+		ret = app_settings_save(true);
+		shell_print(sh, "config applied%s", ret ? " (save failed!)" : " and saved");
+	} else if (action == APP_NFC_ACTION_RESET) {
+		ret = app_settings_reset();
+		shell_print(sh, "factory reset%s", ret ? " (failed!)" : "");
+	} else {
+		shell_print(sh, "no config on tag (no action)");
+	}
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_nfc, SHELL_CMD_ARG(dump, NULL, "Hex dump all 512 B of NFC memory.", cmd_nfc_dump, 1, 0),
 	SHELL_CMD_ARG(read, NULL, "Read a range. Usage: read <offset> <len>", cmd_nfc_read, 3, 0),
 	SHELL_CMD_ARG(write, NULL, "Write hex bytes. Usage: write <offset> <hexbytes>", cmd_nfc_write,
 		      3, 0),
 	SHELL_CMD_ARG(clear, NULL, "Zero all 512 B of NFC memory.", cmd_nfc_clear, 1, 0),
+	SHELL_CMD_ARG(autocheck, NULL, "Enable/disable periodic check. Usage: autocheck on|off",
+		      cmd_nfc_autocheck, 2, 0),
+	SHELL_CMD_ARG(check, NULL, "Run the NFC check now (parse + apply config).", cmd_nfc_check, 1,
+		      0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(nfc, &sub_nfc, "ST25DV NFC memory access (debug).", NULL);

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -57,10 +57,18 @@ LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
 /* Dynamic register IT_STS_Dyn (device E0, addr 0x2005): interrupt status,
  * read-clears. Non-zero => RF activity since last read (field change / RF
  * write / etc.). Used to skip the full 512 B read when nothing happened. */
-#define ST25DV_IT_STS_DYN 0x2005
+#define ST25DV_IT_STS_DYN  0x2005
+#define ST25DV_IT_RF_WRITE 0x80 /* IT_STS_Dyn bit7: RF wrote to the EEPROM */
+
+/* Static system config (device E1 0x57). Writing it needs an open I2C security
+ * session (present password). GPO bit6 RF_WRITE_EN makes RF EEPROM writes show
+ * up in IT_STS_Dyn, letting the poll gate on writes specifically. */
+#define ST25DV_GPO_REG         0x0000
+#define ST25DV_GPO_RF_WRITE_EN 0x40
+#define ST25DV_I2C_PWD_REG     0x0900
 
 #define NDEF_TNF_MIME       0x02
-#define NDEF_SUPPORTED_TYPE "application/vnd.hardwario.sticker-config.v1"
+#define NDEF_SUPPORTED_TYPE "application/com.hardwario.sticker.config"
 
 /* Plaintext info record the firmware keeps on the tag so a phone learns the
  * sticker identity and schema version the moment it taps, without decrypting
@@ -72,7 +80,7 @@ LOG_MODULE_REGISTER(app_nfc, LOG_LEVEL_DBG);
  *   [9]    config/schema version (APP_CONFIG_VERSION)
  *   [10]   flags: bit0 = debug build
  */
-#define NDEF_INFO_TYPE   "application/vnd.hardwario.sticker-info.v1"
+#define NDEF_INFO_TYPE   "application/com.hardwario.sticker.info"
 #define NDEF_INFO_FORMAT 0x01
 
 /* NFC Forum Type 5 Capability Container (4-byte form) for ST25DV04K:
@@ -97,6 +105,10 @@ static const struct gpio_dt_spec m_lpd = GPIO_DT_SPEC_GET(DT_NODELABEL(lpd), gpi
  * be written over several `nfc write` calls without the periodic check racing
  * it and rewriting the tag to the info record mid-write. */
 static bool m_periodic = true;
+
+/* True when GPO RF_WRITE_EN was successfully enabled, so the poll can gate on
+ * the RF_WRITE bit specifically. False => gate on any RF activity (fallback). */
+static bool m_rf_write_gate;
 
 bool app_nfc_periodic_enabled(void)
 {
@@ -234,6 +246,69 @@ static int write_reg(uint16_t reg, const void *buf, size_t len)
 	}
 
 	return 0;
+}
+
+/* Open the I2C security session by presenting an 8-byte password (required to
+ * write the static system config such as GPO). Frame: addr(2) + pwd(8) + 0x09
+ * (present code) + pwd(8). */
+static int nfc_present_password(const uint8_t pwd[8])
+{
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(i2c1));
+	if (!device_is_ready(dev)) {
+		LOG_ERR("Device not ready");
+		return -ENODEV;
+	}
+
+	uint8_t frame[2 + 8 + 1 + 8];
+	sys_put_be16(ST25DV_I2C_PWD_REG, frame);
+	memcpy(&frame[2], pwd, 8);
+	frame[10] = 0x09;
+	memcpy(&frame[11], pwd, 8);
+
+	int ret = i2c_write(dev, frame, sizeof(frame), ST25DV_I2C_ADDR_E1);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("i2c_write(password)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/* Set GPO RF_WRITE_EN so RF EEPROM writes are reported in IT_STS_Dyn. Needs the
+ * default (all-zero) I2C password. Returns 0 if RF_WRITE reporting is active.
+ * Caller must hold the access lock. */
+static int nfc_enable_rf_write_it(void)
+{
+	static const uint8_t default_pwd[8] = {0};
+
+	int ret = nfc_present_password(default_pwd);
+	if (ret) {
+		return ret;
+	}
+
+	uint8_t gpo;
+	ret = read_reg(ST25DV_GPO_REG, &gpo, 1);
+	if (ret) {
+		return ret;
+	}
+
+	if (gpo & ST25DV_GPO_RF_WRITE_EN) {
+		return 0; /* already enabled */
+	}
+
+	gpo |= ST25DV_GPO_RF_WRITE_EN;
+	ret = write_reg(ST25DV_GPO_REG, &gpo, 1);
+	if (ret) {
+		return ret;
+	}
+
+	uint8_t check = 0;
+	ret = read_reg(ST25DV_GPO_REG, &check, 1);
+	if (ret) {
+		return ret;
+	}
+
+	return (check & ST25DV_GPO_RF_WRITE_EN) ? 0 : -EIO;
 }
 
 /* Power the ST25DV up for I2C access (LPD low) and take the access lock. On
@@ -471,6 +546,19 @@ int app_nfc_init(void)
 		return ret;
 	}
 
+	/* Try to enable RF-write reporting in IT_STS_Dyn so the poll can gate on
+	 * writes specifically. Needs the default I2C password; on failure the poll
+	 * falls back to gating on any RF activity. Not fatal. */
+	if (nfc_access_begin() == 0) {
+		if (nfc_enable_rf_write_it() == 0) {
+			m_rf_write_gate = true;
+			LOG_INF("NFC: RF_WRITE IT enabled (precise poll gate)");
+		} else {
+			LOG_WRN("NFC: RF_WRITE IT enable failed; poll gates on any RF activity");
+		}
+		nfc_access_end();
+	}
+
 	return 0;
 }
 
@@ -565,8 +653,13 @@ int app_nfc_poll(enum app_nfc_action *action)
 	ret = read_reg(ST25DV_IT_STS_DYN, &it_sts, sizeof(it_sts));
 	if (ret) {
 		res = ret;
-	} else if (it_sts != 0) {
-		res = nfc_check_locked(action);
+	} else {
+		/* With RF_WRITE reporting on, gate on the write bit only (skip mere
+		 * reads/field changes); otherwise gate on any RF activity. */
+		bool trigger = m_rf_write_gate ? (it_sts & ST25DV_IT_RF_WRITE) : (it_sts != 0);
+		if (trigger) {
+			res = nfc_check_locked(action);
+		}
 	}
 
 	nfc_access_end();

--- a/app/src/app_nfc.h
+++ b/app/src/app_nfc.h
@@ -20,7 +20,13 @@ enum app_nfc_action {
 };
 
 int app_nfc_init(void);
+
+/* Full check: always reads the tag. Use at boot and for on-demand checks. */
 int app_nfc_check(enum app_nfc_action *action);
+
+/* Gated poll for the periodic check: reads the 1-byte IT_STS_Dyn first and only
+ * does the full read when RF activity is flagged. Cheaper when nothing changed. */
+int app_nfc_poll(enum app_nfc_action *action);
 
 /* Whether the main loop should run the periodic NFC check. Toggled by the
  * `nfc autocheck on|off` shell command so a multi-step `nfc write` of a config

--- a/app/src/app_nfc.h
+++ b/app/src/app_nfc.h
@@ -7,6 +7,8 @@
 #ifndef APP_NFC_H_
 #define APP_NFC_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,6 +21,11 @@ enum app_nfc_action {
 
 int app_nfc_init(void);
 int app_nfc_check(enum app_nfc_action *action);
+
+/* Whether the main loop should run the periodic NFC check. Toggled by the
+ * `nfc autocheck on|off` shell command so a multi-step `nfc write` of a config
+ * blob is not raced (and overwritten) by the periodic check mid-write. */
+bool app_nfc_periodic_enabled(void);
 
 #ifdef __cplusplus
 }

--- a/app/src/app_nfc.h
+++ b/app/src/app_nfc.h
@@ -9,6 +9,8 @@
 
 #include <stdbool.h>
 
+#include "app_cmd.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -27,6 +29,12 @@ int app_nfc_check(enum app_nfc_action *action);
 /* Gated poll for the periodic check: reads the 1-byte IT_STS_Dyn first and only
  * does the full read when RF activity is flagged. Cheaper when nothing changed. */
 int app_nfc_poll(enum app_nfc_action *action);
+
+/* Take (and clear) the deferred action requested by the last NFC command
+ * (reboot/save/factory-reset). The caller runs it after the response is on the
+ * tag, so the phone can still read the Ack first. Returns APP_CMD_ACTION_NONE
+ * when there is nothing pending. */
+enum app_cmd_action app_nfc_take_cmd_action(void);
 
 /* Whether the main loop should run the periodic NFC check. Toggled by the
  * `nfc autocheck on|off` shell command so a multi-step `nfc write` of a config

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -280,7 +280,7 @@ int main(void)
 		}
 #endif /* defined(CONFIG_WATCHDOG) */
 
-		if (++m_nfc_counter >= NFC_CHECK_BLINKS) {
+		if (app_nfc_periodic_enabled() && ++m_nfc_counter >= NFC_CHECK_BLINKS) {
 			m_nfc_counter = 0;
 
 			ret = app_nfc_check(&action);

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -40,8 +40,11 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
  * short interval is cheap. */
 #define NFC_POLL_INTERVAL_SECONDS  2
 #define NFC_POLL_START_DELAY_MS    3000
-#define NFC_POLL_THREAD_STACK_SIZE 2048
+#define NFC_POLL_THREAD_STACK_SIZE 3072
 #define NFC_POLL_THREAD_PRIO       K_LOWEST_APPLICATION_THREAD_PRIO
+/* Delay before running an NFC command's deferred action, so the phone can read
+ * the Ack response off the tag before the device reboots/saves. */
+#define NFC_CMD_ACTION_DELAY_SECONDS 3
 
 #define APP_ALARM_ORANGE_RATE_LIMIT_MS 500
 #define APP_ALARM_ORANGE_AUTO_OFF_MS   (60 * 60 * 1000)
@@ -129,6 +132,27 @@ static void nfc_poll_thread_fn(void *p1, void *p2, void *p3)
 			ret = app_settings_reset();
 			if (ret) {
 				LOG_ERR_CALL_FAILED_INT("app_settings_reset", ret);
+			}
+		}
+
+		/* Deferred action from an NFC command (reboot/save/factory-reset). Run
+		 * it after a short delay so the phone can still read the Ack response
+		 * off the tag first. */
+		enum app_cmd_action cmd_action = app_nfc_take_cmd_action();
+		if (cmd_action != APP_CMD_ACTION_NONE) {
+			k_sleep(K_SECONDS(NFC_CMD_ACTION_DELAY_SECONDS));
+			switch (cmd_action) {
+			case APP_CMD_ACTION_SETTINGS_SAVE:
+				app_settings_save(true);
+				break;
+			case APP_CMD_ACTION_REBOOT:
+				sys_reboot(SYS_REBOOT_COLD);
+				break;
+			case APP_CMD_ACTION_FACTORY_RESET:
+				app_settings_reset();
+				break;
+			default:
+				break;
 			}
 		}
 	}

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -193,10 +193,13 @@ int main(void)
 
 	enum app_nfc_action action;
 
+	/* A stale/replay config left on the tag makes app_nfc_check() fail
+	 * (anti-replay) on every boot. Do NOT die() here — that would brick the
+	 * device into a reboot loop. Log and continue, like the periodic check
+	 * in the main loop does. */
 	ret = app_nfc_check(&action);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("app_nfc_check", ret);
-		die();
 	}
 
 	if (action == APP_NFC_ACTION_SAVE) {

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -283,7 +283,7 @@ int main(void)
 		if (app_nfc_periodic_enabled() && ++m_nfc_counter >= NFC_CHECK_BLINKS) {
 			m_nfc_counter = 0;
 
-			ret = app_nfc_check(&action);
+			ret = app_nfc_poll(&action);
 			if (ret) {
 				LOG_ERR_CALL_FAILED_INT("app_nfc_check", ret);
 			}

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -34,7 +34,14 @@
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
 #define BLINK_INTERVAL_SECONDS 3
-#define NFC_CHECK_BLINKS       10
+
+/* NFC poll runs on its own thread (not tied to the LED blink loop). Each poll
+ * reads the 1-byte IT_STS_Dyn and only does a full read on RF activity, so a
+ * short interval is cheap. */
+#define NFC_POLL_INTERVAL_SECONDS  2
+#define NFC_POLL_START_DELAY_MS    3000
+#define NFC_POLL_THREAD_STACK_SIZE 2048
+#define NFC_POLL_THREAD_PRIO       K_LOWEST_APPLICATION_THREAD_PRIO
 
 #define APP_ALARM_ORANGE_RATE_LIMIT_MS 500
 #define APP_ALARM_ORANGE_AUTO_OFF_MS   (60 * 60 * 1000)
@@ -45,7 +52,6 @@ enum app_mode {
 	APP_MODE_CALIBRATION,
 };
 
-static int m_nfc_counter;
 
 static void die(void)
 {
@@ -89,6 +95,47 @@ static void play_carousel_nfc(void)
 	app_led_blink(&req);
 	k_sleep(K_MSEC(10 * 200 - 100));
 }
+
+/* Dedicated NFC poll thread: independent of the LED blink loop. Each cycle does
+ * the cheap gated poll (1-byte IT_STS_Dyn; full read only on RF activity) and
+ * applies a consumed config. Started after a delay so app_nfc_init() has run. */
+static void nfc_poll_thread_fn(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	for (;;) {
+		k_sleep(K_SECONDS(NFC_POLL_INTERVAL_SECONDS));
+
+		if (!app_nfc_periodic_enabled()) {
+			continue;
+		}
+
+		enum app_nfc_action action;
+		int ret = app_nfc_poll(&action);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("app_nfc_poll", ret);
+		}
+
+		if (action == APP_NFC_ACTION_SAVE) {
+			play_carousel_nfc();
+			ret = app_settings_save(true);
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("app_settings_save", ret);
+			}
+		} else if (action == APP_NFC_ACTION_RESET) {
+			play_carousel_nfc();
+			ret = app_settings_reset();
+			if (ret) {
+				LOG_ERR_CALL_FAILED_INT("app_settings_reset", ret);
+			}
+		}
+	}
+}
+
+K_THREAD_DEFINE(nfc_poll_tid, NFC_POLL_THREAD_STACK_SIZE, nfc_poll_thread_fn, NULL, NULL, NULL,
+		NFC_POLL_THREAD_PRIO, 0, NFC_POLL_START_DELAY_MS);
 
 static enum app_mode detect_mode(void)
 {
@@ -280,30 +327,7 @@ int main(void)
 		}
 #endif /* defined(CONFIG_WATCHDOG) */
 
-		if (app_nfc_periodic_enabled() && ++m_nfc_counter >= NFC_CHECK_BLINKS) {
-			m_nfc_counter = 0;
-
-			ret = app_nfc_poll(&action);
-			if (ret) {
-				LOG_ERR_CALL_FAILED_INT("app_nfc_check", ret);
-			}
-
-			if (action == APP_NFC_ACTION_SAVE) {
-				play_carousel_nfc();
-
-				ret = app_settings_save(true);
-				if (ret) {
-					LOG_ERR_CALL_FAILED_INT("app_settings_save", ret);
-				}
-			} else if (action == APP_NFC_ACTION_RESET) {
-				play_carousel_nfc();
-
-				ret = app_settings_reset();
-				if (ret) {
-					LOG_ERR_CALL_FAILED_INT("app_settings_reset", ret);
-				}
-			}
-		}
+		/* NFC is polled on its own thread (nfc_poll_thread_fn), not here. */
 
 		/* Detect magnet on BOTH Hall sensors → reboot into calibration mode */
 		if (k_uptime_get() < (int64_t)APP_CALIBRATION_ACTIVATION_WINDOW_MIN * 60 * 1000) {

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -38,10 +38,10 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 /* NFC poll runs on its own thread (not tied to the LED blink loop). Each poll
  * reads the 1-byte IT_STS_Dyn and only does a full read on RF activity, so a
  * short interval is cheap. */
-#define NFC_POLL_INTERVAL_SECONDS  2
-#define NFC_POLL_START_DELAY_MS    3000
-#define NFC_POLL_THREAD_STACK_SIZE 3072
-#define NFC_POLL_THREAD_PRIO       K_LOWEST_APPLICATION_THREAD_PRIO
+#define NFC_POLL_INTERVAL_SECONDS    2
+#define NFC_POLL_START_DELAY_MS      3000
+#define NFC_POLL_THREAD_STACK_SIZE   3072
+#define NFC_POLL_THREAD_PRIO         K_LOWEST_APPLICATION_THREAD_PRIO
 /* Delay before running an NFC command's deferred action, so the phone can read
  * the Ack response off the tag before the device reboots/saves. */
 #define NFC_CMD_ACTION_DELAY_SECONDS 3
@@ -54,7 +54,6 @@ enum app_mode {
 	APP_MODE_NORMAL = 0,
 	APP_MODE_CALIBRATION,
 };
-
 
 static void die(void)
 {

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -259,6 +259,7 @@ The TTN/ChirpStack payload formatter (`app/decoder/ttn.js`) was extended for v1.
 | `ats …` | **Renamed** from `tester` — diagnostics/test commands |
 | `ats lrw reset` | **New** — clear LoRaWAN frame counters + DevNonce (reboots) |
 | `ats cmd lrw \| nfc <hex>` | **New** (debug) — inject a command over the LoRaWAN/NFC transport for bench testing |
+| `nfc dump` / `read` / `write` / `clear` / `check` / `autocheck` / `reg` / `regw` | **New** (debug) — direct ST25DV tag access; `nfc check` prints a readable trace of what it read, decoded and wrote back (see §10) |
 | `config history-enable` / `history-sensors` / `alarm-limit` / `alarm-notif-time` / `pir-notify-act` | **New** parameters (see §6, §7) |
 
 Existing commands (`config`, `settings save`/`reset`, `join`, `send`) are unchanged.
@@ -281,6 +282,29 @@ v1.4.0 organizes configuration keys **by sensor/source** rather than under a glo
 **Unchanged:** discrete sources (`hall-*`, `input-*`, `pir-notify-act`) and global params (`alarm-limit`, `alarm-notif-time`). `accel-motion-sensitivity` defaults to `off` (no accelerometer detection).
 
 The protobuf field numbers are **unchanged**, so the over-the-air wire format stays compatible; only the user-facing keys and code identifiers change. Devices must be reprovisioned with the new shell keys (the NVS settings keys moved).
+
+---
+
+## 10. Local NFC access (NEW)
+
+The device now uses its **ST25DV NFC tag** as a local, phone-tappable channel — for reading the sticker's identity and for the same command protocol available over LoRaWAN, without a network connection.
+
+**Identity record (always present).** When idle, the firmware keeps a small plaintext **info record** on the tag, so a phone learns the sticker identity and config-schema version the moment it taps — no decryption, no app required. Payload (11 bytes): format version, serial number, firmware version, build type, config-schema version, debug flag. The record is self-healing: it is restored whenever the tag is empty or after a written config/command has been consumed, and it is **not** rewritten while it is already present (no needless EEPROM wear).
+
+**Command/response over NFC.** A phone can drive the **same commands as over LoRaWAN** (`get_info`, `set_param`, `get_config`, `reboot`, …; see §1) by writing a command record to the tag. The firmware processes it with the transport-agnostic command engine and replaces it with a **response record** for the phone to read back. Deferred actions (reboot / save / factory-reset) run *after* the response is written, so the phone always reads the acknowledgement first. Encrypted **config provisioning** over NFC (AES-CCM, serial + monotonic nonce, anti-replay) is also applied through the same path.
+
+**Tag format.** Records are NFC Forum **Type 5**: a 4-byte Capability Container (`E1 40 40 01`) followed by an NDEF message. Each record uses a short **NFC Forum external type** to keep the 512-byte user memory free for payload:
+
+| Record | NDEF type |
+|---|---|
+| Info | `hio.stck:inf` |
+| Config (encrypted) | `hio.stck:cfg` |
+| Command (phone → device) | `hio.stck:cmd` |
+| Response (device → phone) | `hio.stck:rsp` |
+
+A phone's Web NFC reader sees each as `record.recordType === "hio.stck:…"`.
+
+**Power.** The periodic check is gated on the tag's `IT_STS_Dyn` register — the firmware reads a single byte each cycle and only performs the full read + NDEF parse when RF activity occurred since the last poll, so an untouched tag costs almost nothing.
 
 ---
 


### PR DESCRIPTION
**Draft — work in progress (Phase 0 + Phase 1 done, HW-verified).**

Adds direct firmware-side NFC access and makes the firmware publish identity/version metadata on the ST25DV tag, so a phone (or a shell) learns what sticker it is and which config schema it speaks the moment it taps — no decryption needed.

## What's done

### `nfc` shell command (debug, `CONFIG_SHELL`)
- `nfc dump` / `nfc read <off> <len>` / `nfc write <off> <hex>` / `nfc clear` — full ST25DV memory access over RTT.
- `nfc autocheck on|off` — pause the periodic NFC check.
- `nfc check` — run `app_nfc_check` on demand (parse → decrypt → ingest → save).
- Shared `nfc_access_begin/end` helper (LPD pin + `k_mutex`) serialises the shell against the periodic check.

### Info NDEF on the tag (Phase 1)
- Instead of zero-filling after a config is consumed, the firmware now keeps a **plaintext info NDEF** on the tag: MIME `application/vnd.hardwario.sticker-info.v1`, payload = `[format | serial(4) | fw_major | fw_minor | fw_patch | build_type | config_version | debug]`.
- Includes the NFC Forum **Type 5 Capability Container** (`E1 40 40 01`) required for a phone's Web NFC reader to recognise the tag — without it the tag reads as empty over RF.
- Self-healing: rewritten only when missing/changed (`memcmp` guard), restored after a config is consumed.

### Boot-loop fix
- On boot, a failed `app_nfc_check` no longer calls `die()`. A stale/replay config left on the tag previously bricked the device into a 60s reboot loop; it is now logged and boot continues (matching the periodic-check behaviour).

## Verified on hardware (JLink/RTT + phone)
- `nfc dump/read/write/clear` round-trips.
- Phone reads the info NDEF over Web NFC (serial / fw / config_version).
- Phone-free config download via shell: `nfc write` an encrypted config blob (16-byte chunks) + `nfc check` → config applied (interval 900→600) and nonce advanced (0→1).

## Not in this PR (next)
- **Phase 2**: detect "new data present" via the ST25DV `IT_STS_Dyn` register (1 byte over I2C) instead of polling the full 512 B each cycle, to save power. (The GPO interrupt pin is not wired on the board.)

Companion tooling (phone bridge + `tag_image.py` generator) lives in `tools/sticker-nfc-bridge`.