### PR TITLE
configen: generate get_config DUMP_FIELDS[] from YAML (#112)

### DIFF
--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -213,9 +213,12 @@ static void app_cmd_handle_get_info(enum app_cmd_transport tp, const Command *cm
 
 /* Dumpable config fields in fixed order, each with a conservative upper bound
  * on its encoded size (field tag + value; hex fields include the length byte).
- * Mirrors the non-secret fields emitted by app_config_fill_lorawan/application
- * — a new config field needs a row here too (a codegen target once #44 lands).
- * Drives get_config paging: greedy bin-pack into DR0-sized ConfigDump pages. */
+ * Mirrors the non-secret fields emitted by app_config_fill_<group>().
+ * Drives get_config paging: greedy bin-pack into DR0-sized ConfigDump pages.
+ *
+ * The rows are GENERATED from app_config.yml by `west configen` (#112): one per
+ * dumpable parameter (proto_group in a ConfigDump section, not `dump: false`),
+ * with the encoded-size bound derived from its type. Do not edit by hand. */
 /* Sections mirror the config submessages (one fill_<group>() each). Order is
  * the ConfigDump submessage order. */
 #define DUMP_SECTION_LORAWAN     0
@@ -223,53 +226,30 @@ static void app_cmd_handle_get_info(enum app_cmd_transport tp, const Command *cm
 #define DUMP_SECTION_SENSORS     2
 #define DUMP_SECTION_ALARMS      3
 
-#define LRW(tag, size) {DUMP_SECTION_LORAWAN, (tag), (size)}
-#define APP(tag)       {DUMP_SECTION_APPLICATION, (tag), 2}
-#define SEN(tag, size) {DUMP_SECTION_SENSORS, (tag), (size)}
-#define ALM(tag)       {DUMP_SECTION_ALARMS, (tag), 2}
-
 static const struct {
 	uint8_t section;
 	uint8_t tag;
 	uint8_t size;
 } DUMP_FIELDS[] = {
-	/* Lorawan (non-secret): varints 2 B, deveui/joineui 18 B, devaddr 10 B. */
-	LRW(1, 2),
-	LRW(2, 2),
-	LRW(3, 2),
-	LRW(4, 2),
-	LRW(5, 18),
-	LRW(6, 18),
-	LRW(9, 10),
-	LRW(12, 2),
-	/* Application: calibration, intervals, history (varints, 2 B). */
-	APP(1),
-	APP(2),
-	APP(4),
-	APP(49),
-	APP(50),
-	/* Sensors: caps/enum 2 B, sensorN_rom 8 B -> 18 B hex. */
-	SEN(40, 2),
-	SEN(41, 2),
-	SEN(42, 2),
-	SEN(43, 2),
-	SEN(44, 2),
-	SEN(45, 2),
-	SEN(46, 2),
-	SEN(54, 2),
-	SEN(55, 2),
-	SEN(60, 2),
-	SEN(56, 18),
-	SEN(57, 18),
-	SEN(58, 18),
-	SEN(59, 18),
-	/* Alarms: alarm_limit/notif_time + hall/input counters (varints, 2 B). */
-	ALM(51),
-	ALM(52),
-	ALM(25),
-	ALM(28),
-	ALM(31),
-	ALM(34),
+	// BEGIN GENERATED DUMP_FIELDS
+	{DUMP_SECTION_LORAWAN, 1, 2},      {DUMP_SECTION_LORAWAN, 12, 2},
+	{DUMP_SECTION_LORAWAN, 2, 2},      {DUMP_SECTION_LORAWAN, 3, 2},
+	{DUMP_SECTION_LORAWAN, 4, 2},      {DUMP_SECTION_LORAWAN, 5, 18},
+	{DUMP_SECTION_LORAWAN, 6, 18},     {DUMP_SECTION_LORAWAN, 9, 10},
+	{DUMP_SECTION_APPLICATION, 1, 2},  {DUMP_SECTION_APPLICATION, 2, 3},
+	{DUMP_SECTION_APPLICATION, 4, 4},  {DUMP_SECTION_APPLICATION, 49, 3},
+	{DUMP_SECTION_APPLICATION, 50, 7}, {DUMP_SECTION_SENSORS, 40, 3},
+	{DUMP_SECTION_SENSORS, 41, 3},     {DUMP_SECTION_SENSORS, 42, 3},
+	{DUMP_SECTION_SENSORS, 43, 3},     {DUMP_SECTION_SENSORS, 44, 3},
+	{DUMP_SECTION_SENSORS, 45, 3},     {DUMP_SECTION_SENSORS, 46, 3},
+	{DUMP_SECTION_SENSORS, 60, 3},     {DUMP_SECTION_SENSORS, 55, 3},
+	{DUMP_SECTION_SENSORS, 54, 3},     {DUMP_SECTION_SENSORS, 56, 19},
+	{DUMP_SECTION_SENSORS, 57, 19},    {DUMP_SECTION_SENSORS, 58, 19},
+	{DUMP_SECTION_SENSORS, 59, 19},    {DUMP_SECTION_ALARMS, 51, 4},
+	{DUMP_SECTION_ALARMS, 52, 3},      {DUMP_SECTION_ALARMS, 25, 3},
+	{DUMP_SECTION_ALARMS, 28, 3},      {DUMP_SECTION_ALARMS, 31, 3},
+	{DUMP_SECTION_ALARMS, 34, 3},
+	// END GENERATED DUMP_FIELDS
 };
 
 /* Per-page byte budget for the field payload inside one ConfigDump. The encoded

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -646,6 +646,8 @@ COMMANDS_BEGIN = "BEGIN GENERATED COMMANDS"
 COMMANDS_END = "END GENERATED COMMANDS"
 DISPATCH_BEGIN = "BEGIN GENERATED DISPATCH"
 DISPATCH_END = "END GENERATED DISPATCH"
+DUMP_FIELDS_BEGIN = "BEGIN GENERATED DUMP_FIELDS"
+DUMP_FIELDS_END = "END GENERATED DUMP_FIELDS"
 
 # Response-body kinds whose dispatch emits no immediate Response (the command's
 # effect — telemetry, history frames, a deferred Info — is the answer).
@@ -729,6 +731,59 @@ def build_commands_model(config):
         "type_width": max(len(c["body"]) for c in cmds),
         "name_width": max(len(c["name"]) for c in cmds),
     }
+
+
+# get_config DUMP_FIELDS[] codegen ------------------------------------------
+# Section order MUST match the DUMP_SECTION_* enum in app_cmd.c.
+DUMP_SECTIONS = ["lorawan", "application", "sensors", "alarms"]
+
+
+def _varint_bytes(value):
+    """Encoded length of `value` as an unsigned protobuf varint (>= 1 byte)."""
+    v = int(value)
+    n = 1
+    while v >= 0x80:
+        v >>= 7
+        n += 1
+    return n
+
+
+def _dump_field_size(p):
+    """Conservative upper bound on the encoded bytes of one config field inside a
+    ConfigDump: proto tag + value, matching the on-wire encoding configen emits.
+    Tags for proto_id >= 16 take two bytes; integers up to their declared max;
+    bytes are emitted as a hex string (2 chars/byte + a length byte)."""
+    tag = 1 if p["proto_id"] <= 15 else 2
+    t = p.get("type")
+    if t == "bytes":
+        n = 2 * int(p["size"])
+        return tag + _varint_bytes(n) + n
+    if t in ("bool", "enum"):
+        return tag + 1
+    # Integers map to a varint. All current config ints are non-negative, so the
+    # declared max bounds the width; fall back to the uint32 worst case (5 B)
+    # when unbounded or potentially negative.
+    mx = p.get("max")
+    mn = p.get("min")
+    if mx is not None and (mn is None or mn >= 0):
+        return tag + _varint_bytes(int(mx))
+    return tag + 5
+
+
+def build_dump_fields_model(config):
+    """Rows for the get_config DUMP_FIELDS[] table: every dumpable parameter
+    (proto_group in a ConfigDump section and not `dump: false`), grouped by
+    section in DUMP_SECTION order, YAML declaration order within a section."""
+    rows = []
+    for section in DUMP_SECTIONS:
+        macro = "DUMP_SECTION_" + section.upper()
+        for p in config["parameters"]:
+            if p.get("proto_group") != section or "proto_id" not in p:
+                continue
+            if p.get("dump") is False:
+                continue
+            rows.append({"section": macro, "tag": p["proto_id"], "size": _dump_field_size(p)})
+    return {"dump_fields": rows}
 
 
 class Configen(WestCommand):
@@ -961,6 +1016,7 @@ class Configen(WestCommand):
         # availability of every command in one place (configen-commands design).
         commands_model = build_commands_model(config)
         if commands_model:
+            commands_model.update(build_dump_fields_model(config))
             self._generate_commands(env, commands_model, output_dir, args)
 
     def _generate_proto(self, env, config, yaml_path, proto_path, options_path,
@@ -1050,17 +1106,32 @@ class Configen(WestCommand):
         # ahead of it.
         app_cmd_path = args.app_cmd or (output_dir / "app_cmd.c")
         app_cmd_path = app_cmd_path.resolve()
-        if app_cmd_path.exists() and f"// {DISPATCH_BEGIN}" in app_cmd_path.read_text():
-            body = env.get_template("commands_dispatch.c.j2").render(**model)
-            body = body.rstrip("\n")
-            text = rewrite_marked_region(app_cmd_path, body, "//",
-                                         DISPATCH_BEGIN, DISPATCH_END)
-            if args.dry_run:
-                log.inf(f"Would generate dispatch region in: {app_cmd_path}")
-                print(body)
-            else:
+        if app_cmd_path.exists():
+            text = app_cmd_path.read_text()
+            changed = False
+
+            if f"// {DISPATCH_BEGIN}" in text:
+                body = env.get_template("commands_dispatch.c.j2").render(**model).rstrip("\n")
+                text = rewrite_marked_text(text, body, "//", DISPATCH_BEGIN, DISPATCH_END,
+                                           str(app_cmd_path))
+                changed = True
+                if args.dry_run:
+                    log.inf(f"Would generate dispatch region in: {app_cmd_path}")
+                    print(body)
+
+            # get_config DUMP_FIELDS[] paging table (#112).
+            if "dump_fields" in model and f"// {DUMP_FIELDS_BEGIN}" in text:
+                body = env.get_template("dump_fields.c.j2").render(**model).rstrip("\n")
+                text = rewrite_marked_text(text, body, "//", DUMP_FIELDS_BEGIN, DUMP_FIELDS_END,
+                                           str(app_cmd_path))
+                changed = True
+                if args.dry_run:
+                    log.inf(f"Would generate DUMP_FIELDS region in: {app_cmd_path}")
+                    print(body)
+
+            if changed and not args.dry_run:
                 app_cmd_path.write_text(text)
-                log.inf(f"Generated dispatch region: {app_cmd_path}")
+                log.inf(f"Generated app_cmd regions: {app_cmd_path}")
                 self._clang_format([app_cmd_path])
 
     def _clang_format(self, paths):

--- a/scripts/west_commands/templates/dump_fields.c.j2
+++ b/scripts/west_commands/templates/dump_fields.c.j2
@@ -1,0 +1,3 @@
+{% for f in dump_fields -%}
+	{ {{ f.section }}, {{ f.tag }}, {{ f.size }} },
+{% endfor -%}


### PR DESCRIPTION
Closes #112.

`DUMP_FIELDS[]` (the `get_config` paging table in `app_cmd.c`) was the **last config-derived table still maintained by hand**. The rest of the schema (struct / shell / ingest / command dispatch / decoder maps / proto) is already generated by `west configen`; this brings `DUMP_FIELDS` into the same fold.

## What

Generate the table from `app_config.yml` into a `// BEGIN/END GENERATED DUMP_FIELDS` marked region in `app_cmd.c`, using the existing region-rewrite + clang-format mechanism (same as the dispatch/decoder/proto codegen):

- one row per **dumpable** param — `proto_group` in a ConfigDump section (lorawan/application/sensors/alarms) and not `dump: false` (the flag already used to hide the 5 secret keys);
- grouped by section (DUMP_SECTION order), YAML declaration order within a section;
- **encoded-size bound derived from the type** (`configen._dump_field_size`): 2-byte proto tag for `proto_id >= 16`, varint width from the declared `max` for integers, hex string (`2*size` chars + length byte) for `bytes`.

The hand-written `LRW/APP/SEN/ALM` macros are dropped; the `DUMP_SECTION_*` defines and the struct stay as the hand framing.

## Also fixes latent size-bound bugs

The hand bounds were under-sized in several places and only avoided a DR0 page overflow because of the conservative `DUMP_PAGE_BUDGET` (30). The generated bounds are correct:

| field | hand | generated | why |
|-------|------|-----------|-----|
| `proto_id >= 16` (caps, counters, …) | 2 | 3 | tag is 2 bytes for id ≥ 16 |
| `history_sensors` (uint32, no max) | 2 | 7 | 2-byte tag + 5-byte varint |
| `interval_report` (max 86400) | 2 | 4 | 3-byte varint |
| `interval_sample` (max 3600) | 2 | 3 | 2-byte varint |
| `sensorN_rom` (bytes[8]) | 18 | 19 | 2-byte tag |
| `alarm_limit` (max 3600) | 2 | 4 | 2-byte tag + 2-byte varint |

Behaviour: the **dumpable set is identical** to the previous hand table; only the per-field size bounds become accurate (more conservative ⇒ paging is safer, never less safe). Largest single field is 19 B < the 30 B budget, so paging is unchanged in spirit (a few fields now cost 1–5 B more, which can only add pages, never overflow one).

## Test

- Locked by the existing configen pytest: `test_dispatch_region` compares the **regenerated `app_cmd.c` against the committed file**, so the generated DUMP_FIELDS region is now covered (any YAML drift fails CI). `test_generation_is_idempotent` confirms a second run is a no-op.
- `west configen` on the YAML regenerates `ttn.js` / `options.in` with **no diff** (commands codegen unaffected).
- Builds: release 92.26 % / debug 93.05 % FLASH. pytest 20, decoder node 23, native_sim cmd/compose/history all pass.

No HW dependency (codegen + host tests).
