### PR TITLE
Keep mbedtls AES tables in flash to free ~8.8 KB RAM (#128)

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -65,3 +65,9 @@ CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_PSA_CRYPTO_C=y
 CONFIG_PSA_WANT_KEY_TYPE_AES=y
 CONFIG_PSA_WANT_ALG_CCM=y
+# Keep the AES tables in flash instead of generating them in RAM at runtime
+# (~8 KB of .bss otherwise). FEWER_TABLES stores 2 KB and derives the rest by
+# rotation. Frees ~8.8 KB RAM for a ~2 KB flash cost; AES speed cost negligible
+# at this device's crypto volume (#128).
+CONFIG_MBEDTLS_AES_ROM_TABLES=y
+CONFIG_MBEDTLS_AES_FEWER_TABLES=y


### PR DESCRIPTION
Closes #128.

Without `MBEDTLS_AES_ROM_TABLES`, mbedtls generates the AES T-tables at runtime into RAM (`FT0..FT3` + `RT0..RT3` = ~8 KB of `.bss`). This enables ROM tables so they live in flash, plus `FEWER_TABLES` (store 2 KB, derive the rest by rotation).

```
CONFIG_MBEDTLS_AES_ROM_TABLES=y
CONFIG_MBEDTLS_AES_FEWER_TABLES=y
```

## Measured (board `sticker`)

| build | RAM before | RAM after | FLASH |
|-------|-----------|-----------|-------|
| debug | 99.1 % | **85.7 %** (−8.8 KB) | +~2 KB |
| release | ~75.8 % | ~61 % | +~2 KB |

(`ram_report` flagged the AES tables as the single biggest RAM consumer.)

## Notes
- No functional change — AES-CCM (NFC config decrypt) and LoRaWAN crypto are unaffected; the fewer-tables rotation cost is negligible at this device’s crypto volume.
- Unblocks the tight debug RAM budget for the in-flight LoRaWAN work (#71/#73) and deferred items like #93 (downlink buffer 64→224 B fits once this lands).
- Build debug + release clean.