### PR TITLE
log: drop float printf to free ~3.5 KB debug flash

### DIFF
--- a/app/debug.conf
+++ b/app/debug.conf
@@ -1,4 +1,6 @@
-CONFIG_CBPRINTF_FP_SUPPORT=y
+# Float printf support is not needed: all %f log/shell output was converted to
+# integer formatting (APP_FP* in app_log.h), freeing debug flash.
+CONFIG_CBPRINTF_FP_SUPPORT=n
 
 CONFIG_FW_DEBUG=y
 

--- a/app/src/app_accel.c
+++ b/app/src/app_accel.c
@@ -119,9 +119,9 @@ int app_accel_read(float *accel_x, float *accel_y, float *accel_z, int *orientat
 	float accel_y_ = sensor_value_to_float(&val[1]);
 	float accel_z_ = sensor_value_to_float(&val[2]);
 
-	LOG_DBG("Acceleration X: %.3f m/s^2", (double)accel_x_);
-	LOG_DBG("Acceleration Y: %.3f m/s^2", (double)accel_y_);
-	LOG_DBG("Acceleration Z: %.3f m/s^2", (double)accel_z_);
+	LOG_DBG("Acceleration X: %s%d.%03d m/s^2", APP_FP3(accel_x_));
+	LOG_DBG("Acceleration Y: %s%d.%03d m/s^2", APP_FP3(accel_y_));
+	LOG_DBG("Acceleration Z: %s%d.%03d m/s^2", APP_FP3(accel_z_));
 
 	if (accel_x != NULL) {
 		*accel_x = accel_x_;

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -586,9 +586,11 @@ static int cmd_alarm_list(const struct shell *sh, size_t argc, char **argv)
 		bool active = app_alarm_is_active(r->source, r->quantity);
 		switch (app_alarm_quantity_kind(r->quantity)) {
 		case APP_ALARM_KIND_THRESHOLD:
-			shell_print(sh, "  %s %s  lo=%.2f hi=%.2f hst=%.2f  en=%d  active=%d", src,
-				    q, (double)r->lo, (double)r->hi, (double)r->hst, r->enabled,
-				    active);
+			shell_print(sh,
+				    "  %s %s  lo=%s%d.%02d hi=%s%d.%02d hst=%s%d.%02d  en=%d  "
+				    "active=%d",
+				    src, q, APP_FP2(r->lo), APP_FP2(r->hi), APP_FP2(r->hst),
+				    r->enabled, active);
 			break;
 		case APP_ALARM_KIND_STATE:
 			shell_print(sh, "  %s %s  %u->%u (%s)  en=%d  active=%d", src, q,

--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -5,6 +5,7 @@
  */
 
 #include "app_accel.h"
+#include "app_log.h"
 #include "app_ds18b20.h"
 #include "app_hall.h"
 #include "app_input.h"
@@ -410,7 +411,8 @@ static void cmd_check_sensor(const struct shell *shell, size_t argc, char **argv
 		switch (kind) {
 		case SVAL_FLOAT:
 			if (cf != pf) {
-				shell_print(shell, SHELL_PFX " %s: %.2f", sensor_name, (double)cf);
+				shell_print(shell, SHELL_PFX " %s: %s%d.%02d", sensor_name,
+					    APP_FP2(cf));
 				pf = cf;
 			}
 			break;
@@ -450,7 +452,7 @@ static void print_float(const struct shell *shell, const char *label, float v, c
 	if (isnan(v)) {
 		shell_print(shell, "  %-16s nan", label);
 	} else {
-		shell_print(shell, "  %-16s %.2f %s", label, (double)v, unit);
+		shell_print(shell, "  %-16s %s%d.%02d %s", label, APP_FP2(v), unit);
 	}
 }
 
@@ -478,8 +480,8 @@ static int cmd_print_sample(const struct shell *shell, size_t argc, char **argv)
 		int ori = d->orientation;
 		(void)app_accel_read(&ax, &ay, &az, &ori);
 		shell_print(shell, "  %-16s %d", "orientation:", ori);
-		shell_print(shell, "  %-16s x=%.2f y=%.2f z=%.2f m/s^2", "accel:", (double)ax,
-			    (double)ay, (double)az);
+		shell_print(shell, "  %-16s x=%s%d.%02d y=%s%d.%02d z=%s%d.%02d m/s^2",
+			    "accel:", APP_FP2(ax), APP_FP2(ay), APP_FP2(az));
 	} else {
 		shell_print(shell, "  %-16s nan", "orientation:");
 		shell_print(shell, "  %-16s nan", "accel:");
@@ -513,9 +515,9 @@ static int cmd_print_sample(const struct shell *shell, size_t argc, char **argv)
 		print_float(shell, "illuminance:", s->illuminance, "lux");
 		print_float(shell, "magnetic-field:", s->magnetic_field, "mT");
 		if (!isnan(s->accel_x) || !isnan(s->accel_y) || !isnan(s->accel_z)) {
-			shell_print(shell, "  %-16s x=%.2f y=%.2f z=%.2f m/s^2",
-				    "accel:", (double)s->accel_x, (double)s->accel_y,
-				    (double)s->accel_z);
+			shell_print(shell, "  %-16s x=%s%d.%02d y=%s%d.%02d z=%s%d.%02d m/s^2",
+				    "accel:", APP_FP2(s->accel_x), APP_FP2(s->accel_y),
+				    APP_FP2(s->accel_z));
 		}
 		shell_print(shell, "  %-16s %s",
 			    "tilt-alert:", s->is_tilt_alert ? "true" : "false");

--- a/app/src/app_battery.c
+++ b/app/src/app_battery.c
@@ -109,7 +109,7 @@ int app_battery_measure(float *voltage)
 	if (voltage) {
 		*voltage = voltage_ / 1000.f;
 		*voltage = *voltage / R2_KOHM * (R1_KOHM + R2_KOHM);
-		LOG_DBG("Battery voltage: %.2f V", (double)*voltage);
+		LOG_DBG("Battery voltage: %s%d.%02d V", APP_FP2(*voltage));
 	}
 
 suspend:

--- a/app/src/app_ds18b20.c
+++ b/app/src/app_ds18b20.c
@@ -193,7 +193,7 @@ int app_ds18b20_read(int index, uint64_t *serial_number, float *temperature)
 
 	float temperature_ = val.val1 + val.val2 / 1000000.f;
 
-	LOG_DBG("Temperature: %.2f C", (double)temperature_);
+	LOG_DBG("Temperature: %s%d.%02d C", APP_FP2(temperature_));
 
 	if (temperature) {
 		*temperature = temperature_;

--- a/app/src/app_history.c
+++ b/app/src/app_history.c
@@ -5,6 +5,7 @@
  */
 
 #include "app_history.h"
+#include "app_log.h"
 #include "app_config.h"
 #include "app_sensor.h"
 
@@ -743,9 +744,9 @@ static void print_value(const struct shell *sh, char *buf, size_t cap, int i, bo
 	if (!present) {
 		snprintf(buf, cap, "--");
 	} else if (m_desc[i].enc == ENC_COUNT) {
-		snprintf(buf, cap, "%.0f", v);
+		snprintf(buf, cap, "%d", APP_FP0(v));
 	} else {
-		snprintf(buf, cap, "%.2f", v);
+		snprintf(buf, cap, "%s%d.%02d", APP_FP2(v));
 	}
 	ARG_UNUSED(sh);
 }
@@ -960,8 +961,8 @@ static int cmd_history_stats(const struct shell *sh, size_t argc, char **argv)
 			shell_print(sh, "%-12s %8s %8s %8s %5u", m_desc[i].name, "--", "--", "--",
 				    0);
 		} else {
-			shell_print(sh, "%-12s %8.2f %8.2f %8.2f %5u", m_desc[i].name, mn, mx,
-				    sum / n, n);
+			shell_print(sh, "%-12s %s%d.%02d %s%d.%02d %s%d.%02d %5u", m_desc[i].name,
+				    APP_FP2(mn), APP_FP2(mx), APP_FP2(sum / n), n);
 		}
 	}
 	return 0;

--- a/app/src/app_log.h
+++ b/app/src/app_log.h
@@ -22,11 +22,31 @@ extern "C" {
 #define LOG_ERR_CALL_FAILED_CTX_STR(func, ctx, val)                                                \
 	LOG_ERR("Call `" func "` failed (" ctx "): %s", val)
 
+/* Print a float without CONFIG_CBPRINTF_FP_SUPPORT: scale to fixed decimals and
+ * emit sign + integer + zero-padded fraction as plain %d args. Match the decimal
+ * count in the format string, e.g.
+ *     LOG_INF("T %s%d.%02d C", APP_FP2(t));   // was "%.2f"
+ *     LOG_INF("lux %d", APP_FP0(x));          // was "%.0f"
+ * Only the formatting changes; float arithmetic is unaffected. */
+#define APP_FP_SCALE_(v, s) ((int)((float)(v) * (float)(s) + ((float)(v) < 0 ? -0.5f : 0.5f)))
+#define APP_FP_SIGN_(v)     (((v) < 0) ? "-" : "")
+#define APP_FP_ABS_(x)      ((x) < 0 ? -(x) : (x))
+#define APP_FP0(v)          APP_FP_SCALE_(v, 1) /* matches %.0f -> %d */
+#define APP_FP1(v)                                                                                 \
+	APP_FP_SIGN_(v), APP_FP_ABS_(APP_FP_SCALE_(v, 10)) / 10,                                   \
+		APP_FP_ABS_(APP_FP_SCALE_(v, 10)) % 10 /* %.1f -> %s%d.%01d */
+#define APP_FP2(v)                                                                                 \
+	APP_FP_SIGN_(v), APP_FP_ABS_(APP_FP_SCALE_(v, 100)) / 100,                                 \
+		APP_FP_ABS_(APP_FP_SCALE_(v, 100)) % 100 /* %.2f -> %s%d.%02d */
+#define APP_FP3(v)                                                                                 \
+	APP_FP_SIGN_(v), APP_FP_ABS_(APP_FP_SCALE_(v, 1000)) / 1000,                               \
+		APP_FP_ABS_(APP_FP_SCALE_(v, 1000)) % 1000 /* %.3f -> %s%d.%03d */
+
 #ifdef CONFIG_APP_VERBOSE_LOGGING
 #define LOG_INF_PARAM_BOOL(name, value)                                                            \
 	LOG_INF("Parameter `" name "`: %s", (value) ? "true" : "false")
 #define LOG_INF_PARAM_INT(name, value)   LOG_INF("Parameter `" name "`: %d", (value))
-#define LOG_INF_PARAM_FLOAT(name, value) LOG_INF("Parameter `" name "`: %.2f", (double)(value))
+#define LOG_INF_PARAM_FLOAT(name, value) LOG_INF("Parameter `" name "`: %s%d.%02d", APP_FP2(value))
 #define LOG_INF_PARAM_STR(name, value)   LOG_INF("Parameter `" name "`: %s", (value))
 #else
 #define LOG_INF_PARAM_BOOL(name, value)

--- a/app/src/app_machine_probe.c
+++ b/app/src/app_machine_probe.c
@@ -888,7 +888,7 @@ int app_machine_probe_read_thermometer(int index, uint64_t *serial_number, float
 	}
 
 	if (!res && temperature) {
-		LOG_DBG("Temperature: %.2f C", (double)*temperature);
+		LOG_DBG("Temperature: %s%d.%02d C", APP_FP2(*temperature));
 	}
 
 	COMM_EPILOGUE
@@ -964,11 +964,11 @@ int app_machine_probe_read_hygrometer(int index, uint64_t *serial_number, float 
 	}
 
 	if (!res && temperature) {
-		LOG_DBG("Temperature: %.2f C", (double)*temperature);
+		LOG_DBG("Temperature: %s%d.%02d C", APP_FP2(*temperature));
 	}
 
 	if (!res && humidity) {
-		LOG_DBG("Humidity: %.1f %%", (double)*humidity);
+		LOG_DBG("Humidity: %s%d.%01d %%", APP_FP1(*humidity));
 	}
 
 	COMM_EPILOGUE
@@ -1048,7 +1048,7 @@ int app_machine_probe_read_lux_meter(int index, uint64_t *serial_number, float *
 	}
 
 	if (!res && illuminance) {
-		LOG_DBG("Illuminance: %.0f lux", (double)*illuminance);
+		LOG_DBG("Illuminance: %d lux", APP_FP0(*illuminance));
 	}
 
 	COMM_EPILOGUE
@@ -1076,7 +1076,7 @@ int app_machine_probe_read_magnetometer(int index, uint64_t *serial_number, floa
 	}
 
 	if (!res && magnetic_field) {
-		LOG_DBG("Magnetic field: %.2f mT", (double)*magnetic_field);
+		LOG_DBG("Magnetic field: %s%d.%02d mT", APP_FP2(*magnetic_field));
 	}
 
 	COMM_EPILOGUE
@@ -1117,15 +1117,15 @@ int app_machine_probe_read_accelerometer(int index, uint64_t *serial_number, flo
 	}
 
 	if (!res && accel_x) {
-		LOG_DBG("Acceleration in X-axis: %.3f m/s^2", (double)*accel_x);
+		LOG_DBG("Acceleration in X-axis: %s%d.%03d m/s^2", APP_FP3(*accel_x));
 	}
 
 	if (!res && accel_y) {
-		LOG_DBG("Acceleration in Y-axis: %.3f m/s^2", (double)*accel_y);
+		LOG_DBG("Acceleration in Y-axis: %s%d.%03d m/s^2", APP_FP3(*accel_y));
 	}
 
 	if (!res && accel_z) {
-		LOG_DBG("Acceleration in Z-axis: %.3f m/s^2", (double)*accel_z);
+		LOG_DBG("Acceleration in Z-axis: %s%d.%03d m/s^2", APP_FP3(*accel_z));
 	}
 
 	COMM_EPILOGUE

--- a/app/src/app_mpl3115a2.c
+++ b/app/src/app_mpl3115a2.c
@@ -45,7 +45,7 @@ int app_mpl3115a2_read(float *altitude, float *pressure, float *temperature)
 
 	float altitude_ = sensor_value_to_float(&val);
 
-	LOG_DBG("Altitude: %.1f m", (double)altitude_);
+	LOG_DBG("Altitude: %s%d.%01d m", APP_FP1(altitude_));
 
 	if (altitude) {
 		*altitude = altitude_;
@@ -59,7 +59,7 @@ int app_mpl3115a2_read(float *altitude, float *pressure, float *temperature)
 
 	float pressure_ = sensor_value_to_float(&val);
 
-	LOG_DBG("Pressure: %.2f hPa", (double)(pressure_ * 10.f));
+	LOG_DBG("Pressure: %s%d.%02d hPa", APP_FP2(pressure_ * 10.f));
 
 	if (pressure) {
 		*pressure = pressure_;
@@ -73,7 +73,7 @@ int app_mpl3115a2_read(float *altitude, float *pressure, float *temperature)
 
 	float temperature_ = sensor_value_to_float(&val);
 
-	LOG_DBG("Temperature: %.2f C", (double)temperature_);
+	LOG_DBG("Temperature: %s%d.%02d C", APP_FP2(temperature_));
 
 	if (temperature) {
 		*temperature = temperature_;

--- a/app/src/app_opt3001.c
+++ b/app/src/app_opt3001.c
@@ -44,7 +44,7 @@ int app_opt3001_read(float *illuminance)
 
 	float illuminance_ = sensor_value_to_float(&val);
 
-	LOG_DBG("Illuminance: %.0f lux", (double)illuminance_);
+	LOG_DBG("Illuminance: %d lux", APP_FP0(illuminance_));
 
 	if (illuminance) {
 		*illuminance = illuminance_;

--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -395,9 +395,10 @@ void app_sensor_sample(void)
 				continue;
 			}
 			if (w1[s].present) {
-				LOG_INF("Slot %d / Temperature: %.2f C / Humidity: %.1f %% / "
-					"Tilt: %sactive",
-					s, (double)w1[s].temperature, (double)w1[s].humidity,
+				LOG_INF("Slot %d / Temperature: %s%d.%02d C / Humidity: %s%d.%01d "
+					"%% "
+					"/ Tilt: %sactive",
+					s, APP_FP2(w1[s].temperature), APP_FP1(w1[s].humidity),
 					w1[s].is_tilt_alert ? "" : "not ");
 			}
 		}

--- a/app/src/app_sht4x.c
+++ b/app/src/app_sht4x.c
@@ -66,7 +66,7 @@ int app_sht4x_read(float *temperature, float *humidity)
 
 	float temperature_ = sensor_value_to_float(&val);
 
-	LOG_DBG("Temperature: %.2f C", (double)temperature_);
+	LOG_DBG("Temperature: %s%d.%02d C", APP_FP2(temperature_));
 
 	if (temperature) {
 		*temperature = temperature_;
@@ -80,7 +80,7 @@ int app_sht4x_read(float *temperature, float *humidity)
 
 	float humidity_ = sensor_value_to_float(&val);
 
-	LOG_DBG("Humidity: %.1f %%", (double)humidity_);
+	LOG_DBG("Humidity: %s%d.%01d %%", APP_FP1(humidity_));
 
 	if (humidity) {
 		*humidity = humidity_;

--- a/app/src/app_w1_slots.c
+++ b/app/src/app_w1_slots.c
@@ -666,11 +666,12 @@ static int cmd_sensor_list(const struct shell *shell, size_t argc, char **argv)
 		char reading[40] = "--";
 		if (app_w1_slots_read(s, &r) == 0 && r.present) {
 			if (!isnan(r.humidity)) {
-				snprintf(reading, sizeof(reading), "%.2f C / %.1f %%%s",
-					 (double)r.temperature, (double)r.humidity,
+				snprintf(reading, sizeof(reading), "%s%d.%02d C / %s%d.%01d %%%s",
+					 APP_FP2(r.temperature), APP_FP1(r.humidity),
 					 r.is_tilt_alert ? " / TILT" : "");
 			} else if (!isnan(r.temperature)) {
-				snprintf(reading, sizeof(reading), "%.2f C", (double)r.temperature);
+				snprintf(reading, sizeof(reading), "%s%d.%02d C",
+					 APP_FP2(r.temperature));
 			}
 		}
 

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -340,4 +340,13 @@ A phone's Web NFC reader sees each as `record.recordType === "hio.stck:…"`.
 
 ---
 
+## 11. Footprint & build notes (internal)
+
+Not user-facing, but worth recording: v1.4.0 grew enough that the debug image RAM/flash budgets got tight, so two footprint optimizations landed.
+
+- **mbedtls AES tables in flash** — `CONFIG_MBEDTLS_AES_ROM_TABLES` + `MBEDTLS_AES_FEWER_TABLES`. mbedtls otherwise generates the AES T-tables in RAM at runtime (~8 KB of `.bss`); these keep them `const` in flash. Frees **~8.8 KB RAM** (debug 99 % → 86 %) for ~2 KB flash. AES-CCM (NFC config decrypt) and LoRaWAN crypto are functionally unchanged. The LoRaWAN MAC uses its own (already-flash) soft-SE AES, so only the PSA path is affected.
+- **Integer log formatting** — all `%f`/`%g` in `LOG_*`/`shell_print`/`snprintf` were converted to scaled-integer output via the `APP_FP0/1/2/3` helpers in `app_log.h` (e.g. `"%s%d.%02d"`, sign + integer + zero-padded fraction). With no float format specifiers left, the debug build sets `CONFIG_CBPRINTF_FP_SUPPORT=n`, freeing **~3.5 KB debug flash**. Float arithmetic is unchanged; only the printed representation differs (e.g. `21.91`, `-5.50`).
+
+---
+
 *Applies to firmware v1.4.0. Reflects the v1.4.0 source. For full configuration parameters and base behaviour, see the device datasheet / v1.3.x documentation.*


### PR DESCRIPTION
Converts all `%f`/`%g` log, shell and `snprintf` output to integer formatting and disables `CONFIG_CBPRINTF_FP_SUPPORT` in `debug.conf`.

## What
- New `APP_FP0/1/2/3` helpers in `app_log.h`: scale a float to fixed decimals and print sign + integer + zero-padded fraction as plain `%d` args, e.g. `LOG_INF("T %s%d.%02d C", APP_FP2(t))` (was `%.2f`). Rounds, handles negatives/near-zero.
- All `%f` sites converted: sensor `LOG_DBG`/`LOG_INF` (accel, ds18b20, battery, opt3001, mpl3115a2, sht4x, machine_probe, sensor slot), `shell_print` (`ats sensors`, `alarm` dump, `history` stats), and `snprintf` (history values, w1 readings).
- `debug.conf`: `CONFIG_CBPRINTF_FP_SUPPORT=n`.

## Why / impact
Float **arithmetic is unchanged** — only formatting. Measured (board `sticker`, debug): **FLASH 95.90 % → 94.44 % (−3.5 KB)**, RAM unchanged. Release builds clean.

Most `%f` lived in `LOG_DBG`/`LOG_INF`, already compiled out at the debug `LOG_MAX_LEVEL=2` — converting them is for correctness if the level is raised locally; the real saving comes from the `shell_print` (cbprintf) sites.

## Notes
- Independent of the AES-tables RAM change (#128 / #129); the two stack (that one frees ~8.8 KB RAM, this one ~3.5 KB debug flash).
- `app_calibration` and all uplink/alarm/LoRaWAN paths are untouched (no float printf there).
- No HW flash yet (pending HW availability).