### PR TITLE
Extract report orchestration out of app_lrw into app_report (#126)

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources_ifdef(CONFIG_ADC app PRIVATE src/app_battery.c)
 target_sources_ifdef(CONFIG_DS28E17 app PRIVATE src/app_machine_probe.c)
 target_sources_ifdef(CONFIG_LIS2DH app PRIVATE src/app_accel.c)
 target_sources_ifdef(CONFIG_LORAWAN app PRIVATE src/app_lrw.c)
+target_sources_ifdef(CONFIG_LORAWAN app PRIVATE src/app_report.c)
 target_include_directories_ifdef(CONFIG_LORAWAN app PRIVATE
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac
   ${ZEPHYR_LORAMAC_NODE_MODULE_DIR}/src/mac/region

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -10,6 +10,7 @@
 #include "app_config.h"
 #include "app_log.h"
 #include "app_lrw.h"
+#include "app_report.h"
 #include "app_sensor.h"
 
 #if defined(__has_include) && __has_include("app_clock.h")
@@ -108,7 +109,7 @@ static void alarm_lrw_send(void)
 		return;
 	}
 	m_last_alarm_send_ms = now;
-	app_lrw_send();
+	app_report_trigger();
 #endif
 }
 

--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -11,6 +11,7 @@
 #include "app_input.h"
 #include "app_led.h"
 #include "app_lrw.h"
+#include "app_report.h"
 #include "app_machine_probe.h"
 #include "app_sensor.h"
 #include "app_sht4x.h"
@@ -575,7 +576,8 @@ static int cmd_lrw_status(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_lrw_check(const struct shell *shell, size_t argc, char **argv)
 {
-	app_lrw_send_with_link_check();
+	app_lrw_force_link_check();
+	app_report_trigger();
 	shell_print(shell, "Sending data with link check request");
 	return 0;
 }

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -11,6 +11,7 @@
 #include "app_input.h"
 #include "app_log.h"
 #include "app_lrw.h"
+#include "app_report.h"
 #include "app_config_ingest.h"
 
 /* Wall-clock source (PR #41, branch lrw-rtc-time). Until that lands on this
@@ -348,7 +349,7 @@ static void app_cmd_handle_force_send(enum app_cmd_transport tp, const Command *
 	ARG_UNUSED(resp);
 	ARG_UNUSED(action);
 #if defined(CONFIG_LORAWAN)
-	app_lrw_send();
+	app_report_trigger();
 #endif
 	/* No ack — the triggered telemetry uplink IS the answer; an extra ack
 	 * would just cost a second uplink. Leave which_body == 0 (emit nothing). */

--- a/app/src/app_history.c
+++ b/app/src/app_history.c
@@ -110,8 +110,9 @@ static uint16_t m_start; /* index of oldest record */
 static uint16_t m_count;
 static uint32_t m_base_time; /* oldest record's time: uptime-s unsynced, unix synced */
 static bool m_base_synced;
-static uint32_t m_interval; /* interval_report (s) the buffer was recorded at; records
-			     * are periodic so per-record time = base + ord*interval */
+static uint32_t m_interval;  /* interval_report (s) the buffer was recorded at; records
+			      * are periodic so per-record time = base + ord*interval */
+static bool m_replay_active; /* true while app_lrw streams a replay (capture self-skips, #126) */
 
 static bool cap_on(size_t cap_off)
 {
@@ -414,9 +415,20 @@ static void decode_record(const uint8_t *rec, struct app_history_record *out)
 
 /* ---- Public API --------------------------------------------------------- */
 
+void app_history_set_replay_active(bool active)
+{
+	m_replay_active = active;
+}
+
 void app_history_capture(void)
 {
 	if (!m_enabled || m_sample_size == 0 || m_capacity == 0) {
+		return;
+	}
+
+	/* A replay is streaming the buffer back; don't mutate it underneath. */
+	if (m_replay_active) {
+		LOG_DBG("history capture skipped: replay active");
 		return;
 	}
 

--- a/app/src/app_history.h
+++ b/app/src/app_history.h
@@ -58,8 +58,13 @@ struct app_history_record {
 int app_history_init(void);
 
 /* Capture one record from the current g_app_sensor_data (called once per
- * interval_report). No-op when history is disabled. */
+ * interval_report). No-op when history is disabled or while a replay is active. */
 void app_history_capture(void);
+
+/* Pause/resume history capture while a LoRaWAN replay is streaming records back
+ * (#126). app_lrw sets it true at replay start and false at finish; capture
+ * self-skips in between so the buffer it is replaying can't shift underneath it. */
+void app_history_set_replay_active(bool active);
 
 /* Fix up the buffer base time once the wall-clock becomes available, so all
  * stored records gain correct absolute timestamps. Idempotent. */

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -13,7 +13,6 @@
 #include "app_history.h"
 #include "app_log.h"
 #include "app_lrw.h"
-#include "app_sensor.h"
 #include "app_settings.h"
 
 /* Zephyr includes */
@@ -53,11 +52,17 @@ LOG_MODULE_REGISTER(app_lrw, LOG_LEVEL_DBG);
  * action of the old state and the entry action of the new state (counter
  * resets, timer start/stop) in one place.
  *
- * Three independent timers, each with a single meaning (no more inferring a
+ * Two independent timers, each with a single meaning (no more inferring a
  * timer's purpose from the current state):
- *   - m_send_timer        : periodic report cadence
  *   - m_lc_timeout_timer  : link-check response timeout only
  *   - m_rejoin_timer      : rejoin backoff only
+ *
+ * The periodic report cadence lives in app_report (#126): it samples, captures
+ * history and triggers app_lrw_send_telemetry(). app_lrw stays transport — it
+ * composes the snapshot (app_compose), splits it into DR-budget frames, sends
+ * them with the LinkCheckReq piggyback + duty-cycle retry, drains the
+ * response/alarm queues and streams a history replay. On a link-ready edge (join
+ * success / replay finish) app_lrw kicks app_report via the registered callback.
  */
 
 /* Link check configuration constants.
@@ -80,19 +85,18 @@ static K_THREAD_STACK_DEFINE(m_work_stack, 2048);
 static struct k_work_q m_work_q;
 
 /* --- Timers (each one meaning only) --- */
-static struct k_timer m_send_timer;
 static struct k_timer m_lc_timeout_timer;
 static struct k_timer m_rejoin_timer;
 
 /* --- Works --- */
-static struct k_work m_send_work;
+static struct k_work m_send_work;            /* drains response/alarm, then composes telemetry */
 static struct k_work_delayable m_frame_work; /* multi-frame snapshot continuation */
 static struct k_work m_join_work;
 static struct k_work m_link_check_work;       /* LC timeout (from m_lc_timeout_timer) */
 static struct k_work m_downlink_success_work; /* deferred from downlink_callback */
 static struct k_work m_lc_response_work;      /* deferred from link_check_callback */
-static struct k_work m_send_with_lc_work;
-static struct k_work m_dl_request_work; /* drains m_dl_msgq (port-85 commands) */
+static struct k_work m_force_lc_work;         /* arm a forced LC on the next telemetry */
+static struct k_work m_dl_request_work;       /* drains m_dl_msgq (port-85 commands) */
 static struct k_work_delayable m_post_cmd_work;
 static struct k_work_delayable m_join_complete_work;
 static struct k_work_delayable m_hist_work;
@@ -185,6 +189,10 @@ static enum app_cmd_action m_post_cmd_action;
  * (with the synced unix_time) instead of the command acking immediately. */
 static bool m_clock_sync_info_pending;
 
+/* Kicked on a link-ready edge (join success / history-replay finish) so
+ * app_report can resume the report cadence with an immediate uplink. */
+static void (*m_ready_cb)(void);
+
 /* Forward declarations */
 static void on_join_success(void);
 static void on_join_failure(void);
@@ -194,7 +202,14 @@ static void on_lc_timeout(void);
 static void on_downlink_received(void);
 static void state_transition(enum app_lrw_state new_state);
 static bool should_request_link_check(void);
-static void send_with_lc_work_handler(struct k_work *work);
+static void force_lc_work_handler(struct k_work *work);
+
+static void fire_ready_cb(void)
+{
+	if (m_ready_cb) {
+		m_ready_cb();
+	}
+}
 
 static uint32_t calculate_rejoin_backoff(int attempt)
 {
@@ -277,15 +292,16 @@ static void state_transition(enum app_lrw_state new_state)
 	switch (new_state) {
 	case APP_LRW_STATE_IDLE:
 	case APP_LRW_STATE_DISABLED:
-		/* Radio-silent: no periodic report, no link-check, no rejoin. */
-		k_timer_stop(&m_send_timer);
+		/* Radio-silent: no link-check, no rejoin. (The report cadence is
+		 * app_report's; it self-pauses while not app_lrw_is_ready().) */
 		k_timer_stop(&m_lc_timeout_timer);
 		k_timer_stop(&m_rejoin_timer);
 		break;
 
 	case APP_LRW_STATE_JOINING:
-		k_timer_stop(&m_send_timer);
-		m_hist_active = false; /* drop any in-flight history replay across (re)join */
+		/* Drop any in-flight history replay across (re)join. */
+		m_hist_active = false;
+		app_history_set_replay_active(false);
 		break;
 
 	case APP_LRW_STATE_HEALTHY:
@@ -350,8 +366,11 @@ static void on_join_success(void)
 		LOG_WRN("app_cmd_build_info failed; skipping GetInfo-on-join");
 	}
 
-	/* Send first message immediately after join (with LC). */
-	k_work_submit_to_queue(&m_work_q, &m_send_work);
+	/* Kick app_report to start the report cadence with an immediate uplink (its
+	 * cycle samples, captures and triggers app_lrw_send_telemetry; the first
+	 * telemetry frame carries LC, msg #1). The queued GetInfo above drains first
+	 * via m_send_work. */
+	fire_ready_cb();
 }
 
 static void on_join_failure(void)
@@ -794,8 +813,8 @@ static void tx_telemetry_frame(bool first_frame)
 			return;
 		}
 		if (m_frame_len == 0) {
-			k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report),
-				      K_FOREVER);
+			/* Nothing to report (e.g. all sensors NaN pre-sample); app_report
+			 * owns the cadence, so just return. */
 			return;
 		}
 		m_frame_first = first_frame;
@@ -838,12 +857,8 @@ static void tx_telemetry_frame(bool first_frame)
 	if (m_frame_more) {
 		k_work_schedule_for_queue(&m_work_q, &m_frame_work, K_SECONDS(FRAME_GAP_SEC));
 	} else {
-		int timeout = g_app_config.interval_report;
-#if defined(CONFIG_ENTROPY_GENERATOR)
-		timeout += (int32_t)sys_rand32_get() % (g_app_config.interval_report / 10);
-#endif
-		LOG_INF("Snapshot complete; next report in %d s", timeout);
-		k_timer_start(&m_send_timer, K_SECONDS(timeout), K_FOREVER);
+		/* Snapshot complete; app_report's timer schedules the next report. */
+		LOG_INF("Snapshot complete");
 	}
 }
 
@@ -917,18 +932,16 @@ static void send_work_handler(struct k_work *work)
 
 	struct lrw_tx_msg tx;
 
-	/* Priority drain: command response (port 85) first, then alarm (port 3).
-	 * One TX per call; if more are queued, re-submit. The periodic timer is
-	 * only (re)started when nothing is queued AND no history replay owns it. */
+	/* Priority drain: command response (port 85) first, then alarm (port 3). One
+	 * TX per call; if more are queued, re-submit. A drain never falls through to
+	 * telemetry — telemetry is composed only when this handler runs with both
+	 * queues already empty (i.e. when app_report triggered the send). */
 	if (k_msgq_get(&m_response_msgq, &tx, K_NO_WAIT) == 0) {
 		if (!tx_send_queued(&m_response_msgq, &tx, tx.port)) {
 			return; /* requeued; a backoff retry is scheduled */
 		}
 		if (k_msgq_num_used_get(&m_response_msgq) || k_msgq_num_used_get(&m_alarm_msgq)) {
 			k_work_submit_to_queue(&m_work_q, &m_send_work);
-		} else if (!m_hist_active) {
-			k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report),
-				      K_FOREVER);
 		}
 		return;
 	}
@@ -939,23 +952,17 @@ static void send_work_handler(struct k_work *work)
 		}
 		if (k_msgq_num_used_get(&m_alarm_msgq)) {
 			k_work_submit_to_queue(&m_work_q, &m_send_work);
-		} else if (!m_hist_active) {
-			k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report),
-				      K_FOREVER);
 		}
 		return;
 	}
 
-	/* MED-9: history replay owns the send cadence; don't inject telemetry. */
+	/* MED-9: history replay owns the radio; don't inject telemetry. */
 	if (m_hist_active) {
 		return;
 	}
 
-	if (!g_app_config.interval_sample) {
-		app_sensor_sample();
-	}
-	app_history_capture();
-
+	/* Both queues empty: compose + split the telemetry snapshot built from the
+	 * sensor data app_report just sampled/captured. */
 	m_frame_resend = false; /* start a new snapshot */
 	tx_telemetry_frame(true);
 }
@@ -979,7 +986,9 @@ static size_t history_frame_cap(void)
 static void history_replay_finish(void)
 {
 	m_hist_active = false;
-	k_timer_start(&m_send_timer, K_SECONDS(g_app_config.interval_report), K_FOREVER);
+	app_history_set_replay_active(false);
+	/* Hand the report cadence back to app_report with an immediate uplink. */
+	fire_ready_cb();
 }
 
 static void m_hist_work_handler(struct k_work *work)
@@ -1087,8 +1096,8 @@ bool app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t
 	m_hist_cursor = 0;
 	m_hist_retries = 0;
 	m_hist_active = true;
+	app_history_set_replay_active(true); /* pause capture; app_report telemetry self-skips */
 
-	k_timer_stop(&m_send_timer); /* replay owns the cadence */
 	LOG_INF("History replay start: %u frames (window %u..%u)", (unsigned)n, from_unix, to_unix);
 	k_work_schedule_for_queue(&m_work_q, &m_hist_work, K_NO_WAIT);
 	return true;
@@ -1097,12 +1106,6 @@ bool app_lrw_start_history_replay(uint32_t from_unix, uint32_t to_unix, uint32_t
 /* ======================================================================== */
 /* Timer ISR handlers (thin: enqueue the right work, no state decisions)    */
 /* ======================================================================== */
-
-static void send_timer_handler(struct k_timer *timer)
-{
-	ARG_UNUSED(timer);
-	k_work_submit_to_queue(&m_work_q, &m_send_work);
-}
 
 static void lc_timeout_timer_handler(struct k_timer *timer)
 {
@@ -1340,7 +1343,7 @@ int app_lrw_init(void)
 	k_work_init(&m_link_check_work, link_check_work_handler);
 	k_work_init(&m_downlink_success_work, downlink_success_work_handler);
 	k_work_init(&m_lc_response_work, lc_response_work_handler);
-	k_work_init(&m_send_with_lc_work, send_with_lc_work_handler);
+	k_work_init(&m_force_lc_work, force_lc_work_handler);
 	k_work_init(&m_dl_request_work, dl_request_work_handler);
 	k_work_init_delayable(&m_post_cmd_work, post_cmd_work_handler);
 	k_work_init_delayable(&m_join_complete_work, join_complete_work_handler);
@@ -1349,7 +1352,6 @@ int app_lrw_init(void)
 	k_work_init(&m_dbg_lc_work, dbg_lc_work_handler);
 #endif
 
-	k_timer_init(&m_send_timer, send_timer_handler, NULL);
 	k_timer_init(&m_lc_timeout_timer, lc_timeout_timer_handler, NULL);
 	k_timer_init(&m_rejoin_timer, rejoin_timer_handler, NULL);
 
@@ -1364,39 +1366,30 @@ void app_lrw_join(void)
 	k_work_submit_to_queue(&m_work_q, &m_join_work);
 }
 
-void app_lrw_send(void)
+void app_lrw_send_telemetry(void)
 {
+	/* Compose + split + send a telemetry snapshot from the current sensor data.
+	 * Runs on m_work_q; send_work_handler drains response/alarm first, then falls
+	 * through to the telemetry compose when both queues are empty. */
 	k_work_submit_to_queue(&m_work_q, &m_send_work);
 }
 
-static void send_with_lc_work_handler(struct k_work *work)
+void app_lrw_register_ready_cb(void (*cb)(void))
+{
+	m_ready_cb = cb;
+}
+
+/* Arm a forced LinkCheckReq on the next telemetry first-frame (shell/test path;
+ * pair with app_report_trigger() to actually emit the uplink). */
+static void force_lc_work_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
-
-	enum app_lrw_state state = (enum app_lrw_state)atomic_get(&m_state);
-
-	if (state != APP_LRW_STATE_HEALTHY && state != APP_LRW_STATE_WARNING) {
-		LOG_WRN("Cannot send with link check in %s", state_name(state));
-		return;
-	}
-
-	int ret = lorawan_request_link_check(false);
-
-	if (ret) {
-		LOG_ERR("Link check request failed: %d", ret);
-		m_force_lc_remaining = 1; /* retry LC on the next message */
-	} else {
-		m_link_check_pending = true;
-		k_timer_start(&m_lc_timeout_timer, K_SECONDS(LINK_CHECK_TIMEOUT_SEC), K_FOREVER);
-		LOG_INF("Link check requested, timeout in %d s", LINK_CHECK_TIMEOUT_SEC);
-	}
-
-	k_work_submit_to_queue(&m_work_q, &m_send_work);
+	m_force_lc_remaining = 1;
 }
 
-void app_lrw_send_with_link_check(void)
+void app_lrw_force_link_check(void)
 {
-	k_work_submit_to_queue(&m_work_q, &m_send_with_lc_work);
+	k_work_submit_to_queue(&m_work_q, &m_force_lc_work);
 }
 
 enum app_lrw_state app_lrw_get_state(void)

--- a/app/src/app_lrw.h
+++ b/app/src/app_lrw.h
@@ -47,11 +47,26 @@ struct app_lrw_info {
 
 int app_lrw_init(void);
 void app_lrw_join(void);
-void app_lrw_send(void);
-void app_lrw_send_with_link_check(void);
 enum app_lrw_state app_lrw_get_state(void);
 int app_lrw_get_info(struct app_lrw_info *info);
 bool app_lrw_is_ready(void);
+
+/* Compose + split + send a telemetry snapshot (fPort 2) from the current sensor
+ * data. app_lrw builds the snapshot (app_compose), splits it into DR-budget
+ * frames, piggybacks a LinkCheckReq on the first frame when the N-th-message
+ * cadence is due, and retries on a duty-cycle backoff. Triggered by app_report
+ * after it samples + captures history. No-op while joining/reconnecting, during
+ * calibration or while a history replay owns the radio. */
+void app_lrw_send_telemetry(void);
+
+/* Register a callback fired on a link-ready edge (join success / history-replay
+ * finish) so app_report can resume the report cadence with an immediate uplink.
+ * NULL clears it. Called once from app_report_init(). */
+void app_lrw_register_ready_cb(void (*cb)(void));
+
+/* Arm a forced LinkCheckReq on the next telemetry first-frame (shell/test path;
+ * pair with app_report_trigger() to actually emit the uplink). */
+void app_lrw_force_link_check(void);
 
 /* Current application-payload budget (bytes) for the next uplink, taken from the
  * LoRaWAN stack (lorawan_get_payload_sizes) and refreshed on every DR change and

--- a/app/src/app_report.c
+++ b/app/src/app_report.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 HARDWARIO a.s.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app_config.h"
+#include "app_history.h"
+#include "app_log.h"
+#include "app_lrw.h"
+#include "app_report.h"
+#include "app_sensor.h"
+
+/* Zephyr includes */
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/random/random.h>
+
+/* Standard includes */
+#include <stdbool.h>
+#include <stdint.h>
+
+LOG_MODULE_REGISTER(app_report, LOG_LEVEL_DBG);
+
+/* Own work queue so the sensor read (app_sensor_sample) and the history flash
+ * write (app_history_capture) never run on the LoRaWAN TX work queue or the
+ * system work queue (the latter also drives LoRaMacProcess()). */
+static K_THREAD_STACK_DEFINE(m_work_stack, 2048);
+static struct k_work_q m_work_q;
+
+static struct k_timer m_report_timer; /* interval_report cadence */
+static struct k_work m_report_work;   /* one report cycle (sample + capture + trigger) */
+
+/* (Re)arm the periodic cadence for the next report. One-shot + manual restart
+ * (like the old app_lrw m_send_timer) so a multi-frame snapshot in app_lrw
+ * doesn't get a second cycle stacked behind it. */
+static void schedule_next_report(void)
+{
+	int timeout = g_app_config.interval_report;
+#if defined(CONFIG_ENTROPY_GENERATOR)
+	timeout += (int32_t)sys_rand32_get() % (g_app_config.interval_report / 10);
+#endif
+	k_timer_start(&m_report_timer, K_SECONDS(timeout), K_FOREVER);
+}
+
+static void report_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	/* Re-arm the cadence up front so a skipped cycle still keeps ticking. */
+	schedule_next_report();
+
+	/* Block normal reporting during calibration mode. */
+	if (g_app_config.calibration) {
+		return;
+	}
+
+	/* State-gated cadence: skip while the link is joining/reconnecting/disabled.
+	 * app_lrw kicks us (report_kick) on the link-ready edge to resume promptly. */
+	if (!app_lrw_is_ready()) {
+		LOG_DBG("Report skipped: link not ready (%d)", app_lrw_get_state());
+		return;
+	}
+
+	/* Lazy sampling: when interval_sample == 0 the sensors are read here, in the
+	 * report cycle, instead of on a dedicated sensor timer. */
+	if (!g_app_config.interval_sample) {
+		app_sensor_sample();
+	}
+
+	/* Capture one history record at the report cadence (self-skips while a
+	 * replay is active, #126). */
+	app_history_capture();
+
+	/* Hand off to the transport: app_lrw composes the snapshot and splits it
+	 * into DR-budget frames (LC piggyback + duty-cycle retry live there). */
+	app_lrw_send_telemetry();
+}
+
+static void report_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+	k_work_submit_to_queue(&m_work_q, &m_report_work);
+}
+
+/* Link-ready edge from the transport (join success / history-replay finish):
+ * resume the cadence with an immediate report. */
+static void report_kick(void)
+{
+	k_work_submit_to_queue(&m_work_q, &m_report_work);
+}
+
+void app_report_trigger(void)
+{
+	k_work_submit_to_queue(&m_work_q, &m_report_work);
+}
+
+int app_report_init(void)
+{
+	k_work_queue_init(&m_work_q);
+	k_work_queue_start(&m_work_q, m_work_stack, K_THREAD_STACK_SIZEOF(m_work_stack),
+			   K_LOWEST_APPLICATION_THREAD_PRIO, NULL);
+
+	k_work_init(&m_report_work, report_work_handler);
+	k_timer_init(&m_report_timer, report_timer_handler, NULL);
+
+	/* Cadence is not started here — it begins on the first link-ready kick from
+	 * app_lrw (join success), then re-arms itself each cycle. */
+	app_lrw_register_ready_cb(report_kick);
+
+	return 0;
+}

--- a/app/src/app_report.h
+++ b/app/src/app_report.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 HARDWARIO a.s.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef APP_REPORT_H_
+#define APP_REPORT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Report orchestration (#126).
+ *
+ * app_report decides *when* to measure and send: it owns the interval_report
+ * cadence, the lazy sample trigger (interval_sample == 0) and the history
+ * capture, then triggers the transport via app_lrw_send_telemetry(). It runs on
+ * its own work queue so the sensor read and the history flash write never sit on
+ * the LoRaWAN TX work queue (m_work_q) or the system work queue (which also
+ * drives LoRaMacProcess()).
+ *
+ * Layering: app_report = *when* to measure & send; app_lrw = *how* it reaches the
+ * network (it composes the snapshot via app_compose, splits it into DR-budget
+ * frames, and handles the LinkCheckReq piggyback / duty-cycle retry). app_report
+ * only reads app_lrw (app_lrw_get_state / app_lrw_is_ready); app_lrw kicks
+ * app_report on a link-ready edge (join success / history-replay finish) via the
+ * callback it registers in app_report_init(). */
+
+/* Initialize the orchestrator: create the work queue, init the timer/works and
+ * register the link-ready kick with app_lrw. Does NOT start the cadence — that
+ * begins on the first link-ready kick from app_lrw (join success). Returns 0 on
+ * success or a negative errno. */
+int app_report_init(void);
+
+/* Force an immediate report cycle (force_send command, `send` shell, alarm
+ * uplink). Sample-if-lazy + capture history + trigger app_lrw_send_telemetry(),
+ * exactly like a timer-driven cycle. The cycle self-skips if the link isn't
+ * ready, and the periodic timer keeps ticking. */
+void app_report_trigger(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APP_REPORT_H_ */

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -15,6 +15,7 @@
 #include "app_log.h"
 #include "app_lrw.h"
 #include "app_nfc.h"
+#include "app_report.h"
 #include "app_sensor.h"
 #include "app_settings.h"
 #include "app_wdog.h"
@@ -317,6 +318,15 @@ int main(void)
 		LOG_ERR_CALL_FAILED_INT("app_lrw_init", ret);
 		die();
 	}
+
+	/* Report orchestration (#126): owns the interval_report cadence and hands
+	 * telemetry frames to app_lrw. Register before the join so the link-ready
+	 * kick is wired when on_join_success fires. */
+	ret = app_report_init();
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("app_report_init", ret);
+		die();
+	}
 #endif /* defined(CONFIG_LORAWAN) */
 
 	ret = app_battery_init();
@@ -456,7 +466,7 @@ static int cmd_join(const struct shell *shell, size_t argc, char **argv)
 
 static int cmd_send(const struct shell *shell, size_t argc, char **argv)
 {
-	app_lrw_send();
+	app_report_trigger();
 
 	shell_print(shell, "command succeeded");
 

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -351,7 +351,7 @@ Not user-facing, but worth recording: v1.4.0 grew enough that the debug image RA
 
 ## 12. LoRaWAN connection management (NEW)
 
-`app_lrw.c` was refactored to a single, explicitly-defined state machine (`IDLE → JOINING → HEALTHY ⇄ WARNING → RECONNECT → JOINING`, plus `DISABLED`). All state changes go through one `state_transition()` with entry/exit actions, and three timers each have a single purpose (report cadence / link-check timeout / rejoin backoff). This removes a long-standing failure mode where a late link-check answer in RECONNECT could cancel the rejoin and leave the device wedged with TX stopped (the *"TX stops after 4–5 messages"* bug) — validated fixed on hardware over both TTN and ChirpStack.
+`app_lrw.c` was refactored to a single, explicitly-defined state machine (`IDLE → JOINING → HEALTHY ⇄ WARNING → RECONNECT → JOINING`, plus `DISABLED`). All state changes go through one `state_transition()` with entry/exit actions, and the link-check-timeout and rejoin-backoff timers each have a single purpose (the report-cadence timer moved out to `app_report`, see §13). This removes a long-standing failure mode where a late link-check answer in RECONNECT could cancel the rejoin and leave the device wedged with TX stopped (the *"TX stops after 4–5 messages"* bug) — validated fixed on hardware over both TTN and ChirpStack.
 
 **New configuration keys** (LoRaWAN link supervision, runtime-tunable):
 
@@ -365,6 +365,18 @@ Behaviour notes:
 - **OTAA rejoin** uses exponential backoff (60 s → ×2 → capped 3600 s); **ABP** cannot rejoin and stays in WARNING (it never had a join).
 - **Radio-silent mode (#98)** — if the configured **DevEUI is all-zero** (an un-provisioned device), the firmware enters `DISABLED` instead of looping on join requests that can never succeed, saving power. It stays DISABLED until reprovisioned and rebooted.
 - Debug builds expose `ats lrw lc ok|fail` to drive the state machine deterministically on the bench (no real RF outage needed).
+
+---
+
+## 13. Report orchestration split (internal, #126)
+
+Follow-up to §12 with no behaviour change: the report *orchestration* was lifted out of `app_lrw.c` into a new `app_report` module, leaving `app_lrw` as pure LoRaWAN transport.
+
+- **`app_report`** owns *when* to measure & send — the `interval_report` cadence timer, the lazy sample trigger (`interval_sample == 0`) and the per-cycle history capture — and runs on its **own work queue**, so the sensor read and the history flash write no longer execute on the LoRaWAN TX work queue (or the system work queue that also drives the MAC). Each cycle it samples, captures, then calls `app_lrw_send_telemetry()`.
+- **`app_lrw`** still owns *how* it reaches the network: it composes the snapshot, splits it into per-DR-budget frames, piggybacks the `LinkCheckReq`, retries on duty-cycle backoff and drains the response/alarm queues. On a link-ready edge (join success / history-replay finish) it kicks `app_report` to resume the cadence.
+- History capture now self-skips while a replay is streaming (`app_history` owns that guard), instead of `app_lrw` gating it.
+
+The report cadence is unified with `interval_report` (there is no separate `interval_history`). No configuration, wire-format or shell change. Validated end-to-end on hardware over ChirpStack on both debug and release builds (join → cadence, force_send, LC piggyback, multi-frame split, history capture; release `f_cnt_up` sustained well past the historical 4–5-message stall).
 
 ---
 


### PR DESCRIPTION
Closes #126 (once HW-verified).

Extracts report orchestration out of `app_lrw` into a new `app_report` module so `app_lrw` is **pure LoRaWAN transport**. After the #71/PR #73 state-machine refactor, `app_lrw.send_work_handler` still owned the report cadence, the sample trigger and the history capture — none of which is LoRaWAN.

## Layering

> `app_report` decides **when** to measure & send · `app_lrw` handles **how** it reaches the network (compose + split + frame).

### `app_report` (new) — orchestration
- Owns the `interval_report` timer (+ jitter) on its **own work queue**, so the sensor read (`app_sensor_sample`) and the history flash write (`app_history_capture`) no longer run on the LoRaWAN TX work queue (`m_work_q`) or the system work queue (which also drives `LoRaMacProcess()`).
- Each cycle: sample-if-lazy (`interval_sample == 0`) → `app_history_capture()` → `app_lrw_send_telemetry()`.
- State-gated: skips while `!app_lrw_is_ready()`; resumes on a link-ready kick.

### `app_lrw` — transport only
- `app_lrw_send_telemetry()` triggers the snapshot send. **`app_lrw` keeps `app_compose()` + the multi-frame split into DR-budget frames + the LinkCheckReq piggyback + the duty-cycle retry** — i.e. it receives the whole payload and splits it by the max payload itself. `send_work_handler` drains response/alarm first and composes telemetry only when both queues are empty (no unsolicited telemetry).
- `app_lrw_register_ready_cb()` fires on **join success** / **history-replay finish** to kick `app_report`; `app_lrw_force_link_check()` replaces `app_lrw_send_with_link_check()`.
- Dropped `m_send_timer`, the `app_sensor` include and the `app_history_capture()` call. Keeps `app_history` only for the replay stream.

### `app_history`
- `app_history_set_replay_active()` now owns the replay guard; `app_history_capture()` **self-skips** while a replay streams (set/cleared by `app_lrw_start/finish_history_replay`), instead of `app_lrw` gating capture.

### Callers
`force_send` command, `send` shell command and the alarm uplink now call `app_report_trigger()`.

## Resolved design decisions (see issue discussion)
1. **Frame boundary** → `app_lrw` receives the whole telemetry payload and splits it into DR-budget frames internally (keeps `app_compose` + the multi-frame engine). `app_report` only triggers.
2. **History cadence** → unified with `interval_report`; **no** separate `interval_history` config key.

## Acceptance
- [x] New `app_report.{c,h}` owning cadence + sample trigger + history capture
- [x] `app_lrw` public API narrowed (telemetry triggered via `app_lrw_send_telemetry()`)
- [x] `app_lrw` no longer includes/uses `app_sensor` or calls `app_history_capture()` (keeps `app_history` for replay only)
- [x] Behaviour preserved: multi-frame telemetry, LC piggyback cadence, force_send, history replay, alarm/response priority, state-gated pause
- [x] Build debug + release clean (release FLASH 94.51% / RAM 65.9%; debug FLASH 95.83% / RAM 89.4%)
- [x] node decoder + configen pytest green (configen-sync failure is pre-existing, unrelated)
- [ ] **HW test pending** (join → telemetry cadence, multi-frame, LC piggyback, force_send, alarm, history replay)

## Out of scope
- LoRaWAN state machine (#71) · native LoRaWAN backend (#16) · `interval_history` config key.
