### PR TITLE
feat(cmd): set RTC wall-clock over NFC via clock_sync unix_time (#107)

### DIFF
--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -337,9 +337,10 @@ static void app_cmd_handle_reset_counters(enum app_cmd_transport tp, const Comma
 	resp->which_body = Response_ack_tag;
 }
 
-/* force_send / req_history / clock_sync are LRW-only (transports: [lrw] in the
- * YAML); the generated dispatch enforces that before calling the handler, so
- * the handlers below assume the LoRaWAN transport. */
+/* force_send / req_history are LRW-only (transports: [lrw] in the YAML); the
+ * generated dispatch enforces that before calling the handler, so the handlers
+ * below assume the LoRaWAN transport. (clock_sync also runs over NFC — see its
+ * handler.) */
 static void app_cmd_handle_force_send(enum app_cmd_transport tp, const Command *cmd, Response *resp,
 				      enum app_cmd_action *action)
 {
@@ -457,20 +458,47 @@ static int w1_scan_cb(struct w1_rom rom, void *user_data)
 
 #endif /* APP_CMD_HAVE_W1 */
 
+/* Sanity bounds for a wall-clock time supplied over NFC: reject obviously wrong
+ * epochs. 2024-01-01 .. 2100-01-01 (UTC) comfortably brackets any real device
+ * provisioning while staying well inside the uint32 range (rolls over in 2106). */
+#define APP_CMD_CLOCK_UNIX_MIN 1704067200UL /* 2024-01-01T00:00:00Z */
+#define APP_CMD_CLOCK_UNIX_MAX 4102444800UL /* 2100-01-01T00:00:00Z */
+
 static void app_cmd_handle_clock_sync(enum app_cmd_transport tp, const Command *cmd, Response *resp,
 				      enum app_cmd_action *action)
 {
 	ARG_UNUSED(tp);
-	ARG_UNUSED(cmd);
 	ARG_UNUSED(action);
-#if defined(APP_CMD_HAVE_CLOCK) && defined(CONFIG_LORAWAN)
-	ARG_UNUSED(resp);
-	/* Re-sync, then answer with an Info uplink once the network time lands
-	 * (carries the synced unix_time). No ack — see app_lrw. */
+#ifdef APP_CMD_HAVE_CLOCK
+	/* unix_time set (NFC): the phone supplies the wall-clock time; set the RTC
+	 * directly and answer with the resulting Info (carries the new unix_time).
+	 * This bootstraps a device before/without a network. */
+	if (cmd->body.clock_sync.has_unix_time) {
+		uint32_t unix_s = cmd->body.clock_sync.unix_time;
+		if (unix_s < APP_CMD_CLOCK_UNIX_MIN || unix_s > APP_CMD_CLOCK_UNIX_MAX) {
+			make_error(resp, Response_Error_Code_BAD_REQUEST, "bad epoch");
+			return;
+		}
+		if (app_clock_set_unix(unix_s) != 0) {
+			make_error(resp, Response_Error_Code_UNKNOWN, "rtc set failed");
+			return;
+		}
+		resp->which_body = Response_info_tag;
+		fill_info(&resp->body.info);
+		return;
+	}
+#ifdef CONFIG_LORAWAN
+	/* Empty (LRW): re-sync from the network, then answer with an Info uplink
+	 * once the network time lands (carries the synced unix_time). No ack — see
+	 * app_lrw. */
 	app_clock_force_resync();
 	app_lrw_send_info_on_clock_sync();
 #else
-	resp->which_body = Response_ack_tag; /* no clock/LRW: just confirm */
+	resp->which_body = Response_ack_tag; /* no LRW: just confirm */
+#endif
+#else
+	ARG_UNUSED(cmd);
+	resp->which_body = Response_ack_tag; /* no clock: just confirm */
 #endif
 }
 
@@ -698,11 +726,6 @@ static void app_cmd_dispatch(enum app_cmd_transport tp, const Command *cmd, Resp
 		app_cmd_handle_req_history(tp, cmd, resp, action);
 		break;
 	case Command_clock_sync_tag:
-		/* transports: [lrw] — the answer is an uplink, meaningless over NFC */
-		if (tp != APP_CMD_TRANSPORT_LRW) {
-			make_error(resp, Response_Error_Code_NOT_READY, "lrw only");
-			break;
-		}
 		app_cmd_handle_clock_sync(tp, cmd, resp, action);
 		break;
 	case Command_alarm_rule_tag:

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -175,7 +175,11 @@ message Command {
         optional bool input_b    = 4;
     }
     message ReqHistory   { optional uint32 from_unix = 1; optional uint32 to_unix = 2; }
-    message ClockSync    { }
+    // Empty (LRW): re-sync the RTC from the network (DeviceTimeReq). With
+    // unix_time set (NFC): the phone supplies the wall-clock time (UTC seconds)
+    // and the RTC is set from it directly — a one-shot bootstrap before/without
+    // a network. A later DeviceTimeAns stays authoritative and may refine it.
+    message ClockSync    { optional uint32 unix_time = 1; }
 
     // Set or clear a dynamic alarm rule in a fixed slot (the slot index is the
     // rule's stable identity; several slots may share one source+quantity for

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -139,7 +139,7 @@ commands:
     - {name: force_send,     proto_id: 9,  body: ForceSend,     kind: handler, response: none, transports: [lrw]}
     - {name: reset_counters, proto_id: 10, body: ResetCounters, kind: handler, response: ack}
     - {name: req_history,    proto_id: 11, body: ReqHistory,    kind: handler, response: none, transports: [lrw]}
-    - {name: clock_sync,     proto_id: 12, body: ClockSync,     kind: handler, response: info_deferred, transports: [lrw]}
+    - {name: clock_sync,     proto_id: 12, body: ClockSync,     kind: handler, response: info_deferred, transports: [lrw, nfc]}
     - {name: alarm_rule,     proto_id: 13, body: AlarmRule,     kind: handler, response: ack}
     - {name: w1_scan,        proto_id: 14, body: W1Scan,        kind: handler, response: w1_scan}
     - {name: req_alarm_rules, proto_id: 15, body: ReqAlarmRules, kind: handler, response: alarm_rules_dump}

--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -996,7 +996,9 @@ rejected with `error` `BAD_REQUEST` "bad epoch".
 > and confirm the response is `error` code 1 (BAD_REQUEST) with detail "bad epoch", and the RTC is
 > left unchanged. Report all three results.
 
-- [ ] Pass
+- [x] Pass — HW-verified 2026-06-16 (debug build, RTT shell). Fresh boot `RTC not set yet`; NFC
+  `clock_sync{unix_time}` set the RTC and `clock get` returned/advanced it (3×); out-of-range
+  `unix_time=1` was rejected, RTC left at ~2026 (no jump to 1970).
 
 ---
 

--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -979,6 +979,25 @@ network: unix=<...>`. Per `doc/version 1.4.md` §5 the sync is **requested autom
 
 - [ ] Pass
 
+### K6 — Set RTC over NFC (`clock_sync` with `unix_time`)
+
+**Goal:** A phone can bootstrap the wall-clock over NFC before/without a network (#107).
+**Observable:** A `clock_sync` command carrying `unix_time` sets the RTC and answers with an `info`
+response whose `unix_time` matches; `clock get` then returns that time. An out-of-range epoch is
+rejected with `error` `BAD_REQUEST` "bad epoch".
+
+**Prompt for Claude:**
+> On a freshly booted device that has **not** synced time (so `clock get` reports unset), inject a
+> `clock_sync` command with a `unix_time` over the NFC transport. On a debug build use the debug
+> shell: `ats cmd nfc 0801620608808bd2bb06` (ClockSync `unix_time = 1735689600`, i.e.
+> 2025-01-01T00:00:00Z) — or present an NFC command record from the manager app. Confirm the
+> decoded response is an `Info` with `unix_time = 1735689600` (not an `ack`), then `clock get`
+> returns ~that time and is advancing. Finally inject an out-of-range epoch (e.g. `unix_time = 1`)
+> and confirm the response is `error` code 1 (BAD_REQUEST) with detail "bad epoch", and the RTC is
+> left unchanged. Report all three results.
+
+- [ ] Pass
+
 ---
 
 ## NFC

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -35,7 +35,7 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 | `factory_reset` | Reset config to defaults but **keep device identity + LoRaWAN keys** (stays provisioned/connected); clears dynamic alarm rules; **reboots** | `ack` |
 | `force_send` | Send a telemetry report immediately | **none** — the report itself is the reply |
 | `reset_counters` | Clear selected hall/input counters | `ack` |
-| `clock_sync` | Request a network time sync | **`info`, deferred** — sent once the network time lands (carries the synced `unix_time`) |
+| `clock_sync` | Sync the wall-clock. **Empty** (LoRaWAN): request a network time sync. **With `unix_time`** (NFC): set the RTC directly from the phone's clock (UTC seconds) | LoRaWAN: **`info`, deferred** — sent once the network time lands. NFC: **`info`** immediately — carries the new `unix_time` |
 | `req_history` | Replay stored history for a time window | `history_frame` (multiple) |
 | `w1_scan` | Enumerate the 1-Wire bus; returns the discovered ROMs so you can teach a slot via `set_param sensorN_rom` | `w1_scan` |
 | `alarm_rule` | Set / clear a dynamic alarm rule in a `slot`, or clear-all (SET/CLEAR require `slot`; the slot index is the rule's stable identity) | `ack` |
@@ -45,7 +45,9 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 >
 > **No redundant acks:** commands whose real answer is the data they produce (`get_info`, `force_send`, `clock_sync`, `req_history`, `w1_scan`) do **not** also send an `ack`, to save an uplink.
 >
-> **LoRaWAN-only commands:** `force_send`, `clock_sync` and `req_history` answer only via an uplink, so they are rejected (`NOT_READY` "lrw only") if sent over NFC.
+> **LoRaWAN-only commands:** `force_send` and `req_history` answer only via an uplink, so they are rejected (`NOT_READY` "lrw only") if sent over NFC.
+>
+> **Setting the clock over NFC:** `clock_sync` with a `unix_time` field sets the RTC directly from a phone, bootstrapping wall-clock time before/without a network (epoch sanity-bounded to 2024-01-01 … 2100-01-01; out-of-range → `BAD_REQUEST` "bad epoch"). A later network `DeviceTimeReq`/`DeviceTimeAns` stays authoritative and may refine it. Empty `clock_sync` over NFC just confirms (no network to query).
 
 **Ready-to-use hex downlinks (fPort 85):**
 
@@ -196,7 +198,7 @@ The same message is returned on demand by the `get_info` command.
 
 ## 5. Real-time clock (NEW)
 
-The device now keeps wall-clock time, synchronised from the network via LoRaWAN `DeviceTimeReq` (requested automatically on join). It timestamps history records and alarm events.
+The device now keeps wall-clock time, synchronised from the network via LoRaWAN `DeviceTimeReq` (requested automatically on join). It timestamps history records and alarm events. A phone can also bootstrap the time over NFC (`clock_sync` with `unix_time`, §1) before/without a network — the network sync stays authoritative once joined.
 
 New `clock` shell command:
 

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -155,9 +155,10 @@ ZTEST(cmd, test_deferred_actions)
 	zassert_equal(handle("08094200", &r), APP_CMD_ACTION_FACTORY_RESET, "factory");
 }
 
-/* force_send / clock_sync / req_history answer only via a LoRaWAN uplink, so
- * over NFC they must be rejected with an Error (NOT_READY) rather than firing a
- * side effect the NFC caller can never observe. */
+/* force_send / req_history answer only via a LoRaWAN uplink, so over NFC they
+ * must be rejected with an Error (NOT_READY) rather than firing a side effect
+ * the NFC caller can never observe. (clock_sync is NOT here — it runs over NFC,
+ * see test_clock_sync_over_nfc.) */
 ZTEST(cmd, test_lrw_only_commands_rejected_over_nfc)
 {
 	Response r;
@@ -170,16 +171,42 @@ ZTEST(cmd, test_lrw_only_commands_rejected_over_nfc)
 	zassert_equal(r.body.error.code, Response_Error_Code_NOT_READY, "code %d",
 		      r.body.error.code);
 
-	/* clock_sync (field 12, empty body) — seq=5. */
-	reset_cfg();
-	handle_via(APP_CMD_TRANSPORT_NFC, "08056200", &r);
-	zassert_equal(r.which_body, Response_error_tag, "clock_sync/NFC should error (which=%d)",
-		      r.which_body);
-
 	/* req_history (field 11) — seq=7, empty window. */
 	reset_cfg();
 	handle_via(APP_CMD_TRANSPORT_NFC, "08075a00", &r);
 	zassert_equal(r.which_body, Response_error_tag, "req_history/NFC should error (which=%d)",
+		      r.which_body);
+}
+
+/* #107: clock_sync carrying unix_time sets the RTC directly (NFC time bootstrap).
+ * A bare clock_sync over NFC just acks here — there is no LoRaWAN in this build
+ * to query for network time. */
+ZTEST(cmd, test_clock_sync_over_nfc)
+{
+	Response r;
+
+	/* clock_sync{ unix_time = 1735689600 } over NFC -> sets the RTC, answers Info. */
+	reset_cfg();
+	handle_via(APP_CMD_TRANSPORT_NFC, "0801620608808bd2bb06", &r);
+	zassert_equal(r.which_body, Response_info_tag, "clock_sync+unix/NFC -> Info (which=%d)",
+		      r.which_body);
+	zassert_equal(test_clock_unix, 1735689600u, "RTC not set (%u)", test_clock_unix);
+	zassert_equal(r.body.info.unix_time, 1735689600u, "Info.unix_time %u",
+		      r.body.info.unix_time);
+
+	/* Out-of-range epoch (unix_time = 1) -> BAD_REQUEST, RTC left untouched. */
+	reset_cfg();
+	handle_via(APP_CMD_TRANSPORT_NFC, "080162020801", &r);
+	zassert_equal(r.which_body, Response_error_tag, "bad epoch -> error (which=%d)",
+		      r.which_body);
+	zassert_equal(r.body.error.code, Response_Error_Code_BAD_REQUEST, "code %d",
+		      r.body.error.code);
+	zassert_false(test_clock_has, "RTC must stay unset after a rejected epoch");
+
+	/* Bare clock_sync over NFC (no unix_time, seq=5) just acks (no network). */
+	reset_cfg();
+	handle_via(APP_CMD_TRANSPORT_NFC, "08056200", &r);
+	zassert_equal(r.which_body, Response_ack_tag, "bare clock_sync/NFC -> ack (which=%d)",
 		      r.which_body);
 }
 

--- a/tests/cmd/src/stubs.c
+++ b/tests/cmd/src/stubs.c
@@ -33,6 +33,13 @@ int app_clock_get_unix(uint32_t *unix_s)
 	return 0;
 }
 
+int app_clock_set_unix(uint32_t unix_s)
+{
+	test_clock_unix = unix_s;
+	test_clock_has = true;
+	return 0;
+}
+
 void app_clock_force_resync(void)
 {
 }


### PR DESCRIPTION
Closes #107.

## What

Let a phone set the device RTC wall-clock over **NFC**, so a Sticker gets the correct time during provisioning without waiting for a network. Today the RTC is set only by LoRaWAN `DeviceTimeReq` (`app_clock`); until a successful join the device has no real time, so history records and alarm `base_time` fall back to uptime.

## Approach (see issue discussion)

Implemented via the **existing command channel** rather than a persisted config field — the time set is inherently one-shot and the NFC command plumbing (decode `Command`, write `Response` back to the tag) already exists.

- `ClockSync { optional uint32 unix_time = 1; }` (UTC seconds).
- `clock_sync` `transports: [lrw, nfc]` — the regenerated dispatch drops the lrw-only gate.
- Handler `app_cmd_handle_clock_sync`:
  - **`unix_time` present (NFC)** → sanity-bound check (2024-01-01 … 2100-01-01) → `app_clock_set_unix()` → synchronous `Info` response carrying the new `unix_time`. Out-of-range → `error BAD_REQUEST` "bad epoch"; RTC write failure → `error UNKNOWN` "rtc set failed".
  - **empty (LRW, unchanged)** → `app_clock_force_resync()` + deferred `Info` uplink.
- Precedence: NFC bootstraps immediately; a later network `DeviceTimeReq`/`DeviceTimeAns` stays authoritative and may refine. Time stored as **UTC** (matches RTC + LoRaWAN source).
- `app_clock_set_unix()` already existed — no new clock API.

## Codegen

`app_config.yml` is the only hand edit on the command side (`transports`); `west configen` regenerated the dispatch, proto oneof, nanopb struct and JS decoder. `ClockSync`'s body field is in the hand-maintained region of `app_config.proto`.

## Tests / build

- Release: FLASH 95.04% / RAM 62.50%. Debug: FLASH 96.47% / RAM 85.84%. Both build clean.
- `tools/test.sh` (SKIP_BUILD): node decoder 24/0, configen pytest 21/0, clang-format, configen-sync — all green.
- Verified `bad epoch` / `rtc set failed` strings + `app_clock_set_unix` are linked into the release image (feature is not dead code).
- **HW test pending.** Bench recipe added as manual-test-plan **K6** (inject `ats cmd nfc 0801620608808bd2bb06` = ClockSync `unix_time=1735689600`).

## Follow-up (out of scope here)

The manager app (`gitlab.hardwario.com/tester/manager-app`) must send `Command{clock_sync{unix_time = <phone now, UTC>}}` over NFC — firmware side only in this PR.
