### PR TITLE
fix(lrw): TX-path robustness — GetParam paging, downlink buffer, snapshot/alarm races (#93)

### DIFF
--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -109,13 +109,26 @@ static void alarm_lrw_send(void)
 #if defined(CONFIG_LORAWAN)
 	int limit = g_app_config.alarm_limit;
 	int64_t now = k_uptime_get();
+	bool send;
 
+	/* m_last_alarm_send_ms is read-modify-written from three contexts (main
+	 * poll, PIR thread, system WQ). A 64-bit RMW is not atomic on Cortex-M4, so
+	 * guard it under m_lock (#93.6); release before app_lrw_send() so the radio
+	 * call never runs while holding the alarm lock. */
+	k_mutex_lock(&m_lock, K_FOREVER);
 	if (limit > 0 && m_last_alarm_send_ms != 0 &&
 	    (now - m_last_alarm_send_ms) < (int64_t)limit * 1000) {
+		send = false;
+	} else {
+		m_last_alarm_send_ms = now;
+		send = true;
+	}
+	k_mutex_unlock(&m_lock);
+
+	if (!send) {
 		LOG_INF("Alarm uplink rate-limited (limit %d s)", limit);
 		return;
 	}
-	m_last_alarm_send_ms = now;
 	app_report_trigger();
 #endif
 }

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -168,38 +168,8 @@ static void app_cmd_handle_set_param(enum app_cmd_transport tp, const Command *c
 	}
 }
 
-static void app_cmd_handle_get_param(enum app_cmd_transport tp, const Command *cmd, Response *resp,
-				     enum app_cmd_action *action)
-{
-	ARG_UNUSED(tp);
-	ARG_UNUSED(action);
-	const Command_GetParam *gp = &cmd->body.get_param;
-
-	resp->which_body = Response_config_dump_tag;
-	resp->body.config_dump.page_index = 0;
-	resp->body.config_dump.page_count = 1;
-
-	if (gp->lorawan_field_count > 0) {
-		resp->body.config_dump.has_lorawan = true;
-		app_config_fill_lorawan(&resp->body.config_dump.lorawan, gp->lorawan_field,
-					gp->lorawan_field_count);
-	}
-	if (gp->application_field_count > 0) {
-		resp->body.config_dump.has_application = true;
-		app_config_fill_application(&resp->body.config_dump.application,
-					    gp->application_field, gp->application_field_count);
-	}
-	if (gp->sensors_field_count > 0) {
-		resp->body.config_dump.has_sensors = true;
-		app_config_fill_sensors(&resp->body.config_dump.sensors, gp->sensors_field,
-					gp->sensors_field_count);
-	}
-	if (gp->alarms_field_count > 0) {
-		resp->body.config_dump.has_alarms = true;
-		app_config_fill_alarms(&resp->body.config_dump.alarms, gp->alarms_field,
-				       gp->alarms_field_count);
-	}
-}
+/* app_cmd_handle_get_param is defined after DUMP_FIELDS (it pages like
+ * get_config); see below. */
 
 static void app_cmd_handle_get_info(enum app_cmd_transport tp, const Command *cmd, Response *resp,
 				    enum app_cmd_action *action)
@@ -322,6 +292,93 @@ static void app_cmd_handle_get_config(enum app_cmd_transport tp, const Command *
 		cd->has_alarms = true;
 		app_config_fill_alarms(&cd->alarms, ids[DUMP_SECTION_ALARMS],
 				       n[DUMP_SECTION_ALARMS]);
+	}
+}
+
+/* Encoded-size bound for a (section, tag) from DUMP_FIELDS. Returns false for a
+ * field that isn't dumpable (secret / unknown id): such ids never appear in the
+ * response (app_config_fill_<group>() skips them) so they take no page budget. */
+static bool dump_field_size(uint8_t section, uint32_t tag, uint8_t *size)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(DUMP_FIELDS); i++) {
+		if (DUMP_FIELDS[i].section == section && DUMP_FIELDS[i].tag == tag) {
+			*size = DUMP_FIELDS[i].size;
+			return true;
+		}
+	}
+	return false;
+}
+
+static void app_cmd_handle_get_param(enum app_cmd_transport tp, const Command *cmd, Response *resp,
+				     enum app_cmd_action *action)
+{
+	ARG_UNUSED(tp);
+	ARG_UNUSED(action);
+	const Command_GetParam *gp = &cmd->body.get_param;
+	uint32_t page = gp->has_page ? gp->page : 0;
+
+	/* Requested ids per section, in ConfigDump section order. DUMP_SECTION_*
+	 * equals the index here (0..3). */
+	const uint32_t *req_ids[4] = {gp->lorawan_field, gp->application_field, gp->sensors_field,
+				      gp->alarms_field};
+	const size_t req_n[4] = {gp->lorawan_field_count, gp->application_field_count,
+				 gp->sensors_field_count, gp->alarms_field_count};
+
+	/* Collected ids for the requested page, one buffer per section sized to its
+	 * own request array (the page can't hold more than was requested). */
+	uint32_t lw[ARRAY_SIZE(gp->lorawan_field)], ap[ARRAY_SIZE(gp->application_field)],
+		se[ARRAY_SIZE(gp->sensors_field)], al[ARRAY_SIZE(gp->alarms_field)];
+	uint32_t *out_ids[4] = {lw, ap, se, al};
+	size_t out_n[4] = {0};
+
+	/* One greedy pass over all requested (dumpable) ids, continuous across
+	 * sections like get_config: pack into DR0-sized pages by DUMP_PAGE_BUDGET
+	 * and collect the requested page's tags per section. */
+	uint32_t cur_page = 0, used = 0;
+	for (uint8_t s = 0; s < 4; s++) {
+		for (size_t j = 0; j < req_n[s]; j++) {
+			uint8_t sz;
+			if (!dump_field_size(s, req_ids[s][j], &sz)) {
+				continue; /* secret/unknown → not dumpable */
+			}
+			if (used > 0 && used + sz > DUMP_PAGE_BUDGET) {
+				cur_page++;
+				used = 0;
+			}
+			used += sz;
+			if (cur_page == page) {
+				out_ids[s][out_n[s]++] = req_ids[s][j];
+			}
+		}
+	}
+	uint32_t page_count = cur_page + 1;
+
+	if (page >= page_count) {
+		make_error(resp, Response_Error_Code_OUT_OF_RANGE, "page");
+		resp->body.error.fault_field = 1;
+		return;
+	}
+
+	Response_ConfigDump *cd = &resp->body.config_dump;
+	resp->which_body = Response_config_dump_tag;
+	cd->page_index = page;
+	cd->page_count = page_count;
+
+	if (out_n[DUMP_SECTION_LORAWAN] > 0) {
+		cd->has_lorawan = true;
+		app_config_fill_lorawan(&cd->lorawan, lw, out_n[DUMP_SECTION_LORAWAN]);
+	}
+	if (out_n[DUMP_SECTION_APPLICATION] > 0) {
+		cd->has_application = true;
+		app_config_fill_application(&cd->application, ap, out_n[DUMP_SECTION_APPLICATION]);
+	}
+	if (out_n[DUMP_SECTION_SENSORS] > 0) {
+		cd->has_sensors = true;
+		app_config_fill_sensors(&cd->sensors, se, out_n[DUMP_SECTION_SENSORS]);
+	}
+	if (out_n[DUMP_SECTION_ALARMS] > 0) {
+		cd->has_alarms = true;
+		app_config_fill_alarms(&cd->alarms, al, out_n[DUMP_SECTION_ALARMS]);
 	}
 }
 
@@ -800,6 +857,17 @@ int app_cmd_handle(enum app_cmd_transport transport, const uint8_t *in, size_t i
 	}
 
 	int ret = encode_response(&resp, out, out_cap, out_len);
+	if (ret == -EMSGSIZE) {
+		/* The composed response doesn't fit the transport buffer. Don't fail
+		 * silently (#93.3) — replace it with a compact Error carrying the same
+		 * seq so the host learns the request couldn't be answered (e.g. an
+		 * over-broad GetParam/GetConfig page). */
+		LOG_WRN("Response too large for buffer; sending Error instead");
+		Response err = Response_init_zero;
+		err.seq = resp.seq;
+		make_error(&err, Response_Error_Code_UNKNOWN, "response too large");
+		ret = encode_response(&err, out, out_cap, out_len);
+	}
 	if (ret) {
 		return ret;
 	}

--- a/app/src/app_compose.c
+++ b/app/src/app_compose.c
@@ -290,6 +290,16 @@ static void fill_snapshot(void)
 	boot = false;
 }
 
+void app_compose_reset(void)
+{
+	/* Drop the in-progress snapshot; the next app_compose() takes a fresh one.
+	 * These run solely on m_work_q (as does the join path that calls this), so
+	 * no lock is needed. */
+	m_active = false;
+	m_pending = 0;
+	m_w1_sent = 0;
+}
+
 int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more)
 {
 	return app_compose_ex(buf, size, len, more, app_lrw_get_max_payload());

--- a/app/src/app_compose.h
+++ b/app/src/app_compose.h
@@ -32,6 +32,11 @@ int app_compose(uint8_t *buf, size_t size, size_t *len, bool *more);
  * returns -EAGAIN. */
 int app_compose_ex(uint8_t *buf, size_t size, size_t *len, bool *more, uint8_t budget);
 
+/* Discard any in-progress snapshot so the next app_compose() starts fresh.
+ * Call from the join path: a rejoin must not continue a pre-outage snapshot
+ * with stale data and no indication (#93.5). */
+void app_compose_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -155,11 +155,17 @@ message Command {
         optional AppConfigMessage.Alarms      alarms      = 5;
     }
 
+    // Read back selected non-secret config fields. Paged like GetConfig:
+    // omitted/0 page = first; the response (Response.ConfigDump) carries
+    // page_count so the host can fetch the rest. A request that selects more
+    // fields than fit one DR0 page would otherwise overflow the response and be
+    // dropped silently (#93.3).
     message GetParam {
         repeated uint32 lorawan_field     = 1;
         repeated uint32 application_field = 2;
         repeated uint32 sensors_field     = 3;
         repeated uint32 alarms_field      = 4;
+        optional uint32 page              = 5;
     }
 
     message GetInfo      { }

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -162,11 +162,23 @@ static uint8_t m_lc_response_gw_count;
 
 /* --- TX queues (MED-7/8: were single overwrite-able slots) --- */
 #define APP_LRW_RESPONSE_BUF_SIZE 64
-#define APP_LRW_REQUEST_BUF_SIZE  64
+/* Incoming command buffer. The network can deliver up to the LoRaWAN MTU
+ * (~222 B at the highest DR) on a single downlink; a realistic SetParam with
+ * deveui+joineui+appkey encodes to ~90 B. 224 covers the full MTU so large
+ * commands are never silently dropped (#93.4 — was 64, which dropped them with
+ * only a LOG_WRN and the host never learned the command wasn't processed). */
+#define APP_LRW_REQUEST_BUF_SIZE  224
 #define APP_LRW_DOWNLINK_CMD_PORT 85
 #define APP_LRW_ALARM_PORT        3
 #define APP_LRW_TX_QUEUE_DEPTH    4
 #define APP_LRW_DL_QUEUE_DEPTH    4
+
+/* The request buffer must hold a full-MTU downlink so the largest command the
+ * network can deliver still fits (#93.4/#93.7). Response/frame buffers are
+ * deliberately NOT asserted against the nanopb *_size bounds: those frames are
+ * DR-budget-limited and paged (get_config/get_param/history), so the on-air
+ * size is always far below the protobuf worst case. */
+BUILD_ASSERT(APP_LRW_REQUEST_BUF_SIZE >= 222, "request buffer below LoRaWAN MTU");
 
 struct lrw_tx_msg {
 	uint8_t port;
@@ -692,6 +704,10 @@ static void join_work_handler(struct k_work *work)
 	}
 
 	state_transition(APP_LRW_STATE_JOINING); /* stops send timer, drops history */
+
+	/* Discard any in-progress telemetry snapshot: a rejoin must not resume a
+	 * pre-outage snapshot with stale sensor data and no indication (#93.5). */
+	app_compose_reset();
 
 	if (m_init_join) {
 		LOG_INF("Initial join after boot");

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -28,7 +28,7 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 |---|---|---|
 | `get_info` | Firmware version, serial, uptime, wall-clock, build type | `info` (no ack) |
 | `set_param` | Change any configuration parameters (LoRaWAN/application/sensors/alarms) | `ack` |
-| `get_param` | Read back selected parameters | `config_dump` |
+| `get_param` | Read back selected parameters (paged) | `config_dump` |
 | `get_config` | Dump the whole configuration (paged) | `config_dump` |
 | `settings_save` | Persist staged changes (**reboots**) | `ack` |
 | `reboot` | Cold reboot | `ack` |
@@ -48,6 +48,8 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 > **LoRaWAN-only commands:** `force_send` and `req_history` answer only via an uplink, so they are rejected (`NOT_READY` "lrw only") if sent over NFC.
 >
 > **Setting the clock over NFC:** `clock_sync` with a `unix_time` field sets the RTC directly from a phone, bootstrapping wall-clock time before/without a network (epoch sanity-bounded to 2024-01-01 … 2100-01-01; out-of-range → `BAD_REQUEST` "bad epoch"). A later network `DeviceTimeReq`/`DeviceTimeAns` stays authoritative and may refine it. Empty `clock_sync` over NFC just confirms (no network to query).
+>
+> **`get_param` is paged** like `get_config`: the reply carries `page_index`/`page_count`, and an optional `page` field in the request selects which page (omit = 0). When the selected fields don't all fit one data-rate frame they are split across pages — fetch the rest by re-sending with the next `page`. A page out of range returns `OUT_OF_RANGE`. If any response still doesn't fit the buffer it is replaced by an `error` (same `seq`) rather than dropped silently.
 
 **Ready-to-use hex downlinks (fPort 85):**
 
@@ -322,6 +324,9 @@ The TTN/ChirpStack payload formatter (`app/decoder/ttn.js`) was extended for v1.
 ```
 ```json
 { "command": "get_param", "seq": 2, "get_param": { "lorawan_field": [3], "application_field": [4, 7] } }
+```
+```json
+{ "command": "get_param", "seq": 3, "get_param": { "lorawan_field": [5, 6, 9], "page": 1 } }
 ```
 ```json
 { "command": "reset_counters", "reset_counters": { "hall_left": true, "input_a": true } }

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -123,6 +123,44 @@ ZTEST(cmd, test_get_param_config_dump)
 	zassert_true(r.body.config_dump.sensors.cap_barometer, "cap_barometer value");
 }
 
+/* get_param pages like get_config when the requested fields don't fit one DR0
+ * response (#93.3). deveui(18 B) + joineui(18 B) + devaddr(10 B) = 46 B > the
+ * 30 B page budget, so they split: page 0 = {deveui}, page 1 = {joineui,
+ * devaddr}, page_count = 2. */
+ZTEST(cmd, test_get_param_paging)
+{
+	Response r;
+
+	/* seq2 get_param{ lorawan_field=[5 deveui, 6 joineui, 9 devaddr] } — page omitted (0). */
+	reset_cfg();
+	handle("08021a050a03050609", &r);
+	zassert_equal(r.which_body, Response_config_dump_tag, "page0 which=%d", r.which_body);
+	zassert_equal(r.body.config_dump.page_index, 0, "page0 index");
+	zassert_equal(r.body.config_dump.page_count, 2, "page_count %u",
+		      r.body.config_dump.page_count);
+	zassert_true(r.body.config_dump.lorawan.has_deveui, "deveui on page0");
+	zassert_false(r.body.config_dump.lorawan.has_joineui, "joineui must not be on page0");
+	zassert_false(r.body.config_dump.lorawan.has_devaddr, "devaddr must not be on page0");
+
+	/* Same request with page=1 (field 5 varint = 0x28 0x01). */
+	reset_cfg();
+	handle("08021a070a030506092801", &r);
+	zassert_equal(r.which_body, Response_config_dump_tag, "page1 which=%d", r.which_body);
+	zassert_equal(r.body.config_dump.page_index, 1, "page1 index");
+	zassert_equal(r.body.config_dump.page_count, 2, "page1 count");
+	zassert_false(r.body.config_dump.lorawan.has_deveui, "deveui must not be on page1");
+	zassert_true(r.body.config_dump.lorawan.has_joineui, "joineui on page1");
+	zassert_true(r.body.config_dump.lorawan.has_devaddr, "devaddr on page1");
+
+	/* Out-of-range page → Error. */
+	reset_cfg();
+	handle("08021a070a030506092805", &r);
+	zassert_equal(r.which_body, Response_error_tag, "oob page should Error, which=%d",
+		      r.which_body);
+	zassert_equal(r.body.error.code, Response_Error_Code_OUT_OF_RANGE, "code %d",
+		      r.body.error.code);
+}
+
 ZTEST(cmd, test_build_info)
 {
 	uint8_t out[128];


### PR DESCRIPTION
Addresses the remaining open findings from #93. The #71 state-machine refactor already fixed **#93.1** (response/alarm budget check + retry, `tx_send_queued()`) and **#93.6a** (downlink-buffer overwrite, now `m_dl_msgq`); **#93.5a** is moot after #80 (hall/input send the whole group with counts, idempotent). This PR covers what was still open.

## Changes

### #93.3 — GetParam paging + no silent `-EMSGSIZE`
- `app_cmd_handle_get_param` now pages like `get_config` (greedy pack by `DUMP_PAGE_BUDGET`, new `dump_field_size()` helper) instead of hardcoding `page_count = 1`. A request selecting more fields than fit one DR0 response no longer overflows and dies silently.
- Adds an `optional uint32 page = 5` field to `Command.GetParam` (hand-written proto section; configen preserves it).
- `app_cmd_handle` now falls back to a compact `Error` (same `seq`) when a composed response won't fit the transport buffer, so the host always learns the request couldn't be answered — applies to every command, not just GetParam.

### #93.4 / #93.7 — downlink request buffer
- `APP_LRW_REQUEST_BUF_SIZE` 64 → **224 B** so a full-MTU downlink fits (a realistic SetParam with deveui+joineui+appkey is ~90 B and was previously dropped with only a `LOG_WRN`, the host never learning the command was ignored).
- Adds a `BUILD_ASSERT` tying the buffer to the LoRaWAN MTU.

### #93.5b — stale snapshot survives rejoin
- New `app_compose_reset()` (app_compose.c/.h), called from `join_work_handler`, so a rejoin starts a fresh telemetry snapshot instead of resuming a pre-outage one with stale data.

### #93.6b — unsynchronized `m_last_alarm_send_ms`
- The 64-bit read-modify-write (not atomic on Cortex-M4, written from three contexts) is now guarded by `m_lock`; the lock is released before the radio call.

## Not included
- **#93.2** (sensor sweep runs on the TX work queue when `interval_sample=0`) — left out by request. `m_sensor_work_q` already exists in app_sensor.c; the fix would run the sample blocking on it.

## Tests
- New `test_get_param_paging` (tests/cmd/src/main.c): page 0 vs page 1 split + out-of-range page → `Error`.
- All green: release + debug build, node decoder tests, configen pytest (21), clang-format, configen sync, cmd ztest (10/10).

## Follow-up
- **manager-app coupling**: the GetParam `page` field is backward-compatible (omitted = page 0), but the Flutter NFC config app must fetch subsequent pages to read large field sets.

Rebased onto v1.4.0 after #133 (app-report-extraction) merged (`app_lrw_send()` → `app_report_trigger()`).
