### PR TITLE
NFC/LoRaWAN: lrw_reset (counters+DevNonce) and forced join commands (#109)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -135,6 +135,8 @@ var _CMD_NAMES = {
   11: "req_history",
   12: "clock_sync",
   14: "w1_scan",
+  16: "lrw_reset",
+  17: "lrw_join",
   18: "enter_calibration",
 };
 // END GENERATED COMMANDS

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -74,6 +74,9 @@ const COMMANDS = [
   { name: "force_send", hex: "08064a00", data: { seq: 6, command: "force_send" } },
   { name: "reboot", hex: "08083a00", data: { seq: 8, command: "reboot" } },
   { name: "w1_scan", hex: "08097200", data: { seq: 9, command: "w1_scan" } },
+  { name: "lrw_reset", hex: "0810820100", data: { seq: 16, command: "lrw_reset" } },
+  { name: "lrw_join", hex: "08118a0100", data: { seq: 17, command: "lrw_join" } },
+  { name: "enter_calibration", hex: "0812920100", data: { seq: 18, command: "enter_calibration" } },
 ];
 
 test("decodeDownlink decodes command frames", () => {

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -608,6 +608,14 @@ static void app_cmd_dispatch(enum app_cmd_transport tp, const Command *cmd, Resp
 	case Command_w1_scan_tag:
 		app_cmd_handle_w1_scan(tp, cmd, resp, action);
 		break;
+	case Command_lrw_reset_tag:
+		*action = APP_CMD_ACTION_LRW_RESET;
+		resp->which_body = Response_ack_tag;
+		break;
+	case Command_lrw_join_tag:
+		*action = APP_CMD_ACTION_LRW_JOIN;
+		resp->which_body = Response_ack_tag;
+		break;
 	case Command_enter_calibration_tag:
 		*action = APP_CMD_ACTION_ENTER_CALIBRATION;
 		resp->which_body = Response_ack_tag;

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -36,6 +36,8 @@ enum app_cmd_action {
 	APP_CMD_ACTION_REBOOT,            /* reboot (discards staged edits) */
 	APP_CMD_ACTION_FACTORY_RESET,     /* defaults (keep identity+LoRaWAN) + reboot */
 	APP_CMD_ACTION_ENTER_CALIBRATION, /* persist calibration=true + reboot */
+	APP_CMD_ACTION_LRW_RESET,         /* reset LoRaWAN NVM (counters+DevNonce) + reboot (#109) */
+	APP_CMD_ACTION_LRW_JOIN,          /* trigger a forced (re)join, no reboot (#109) */
 };
 
 /* Plain-C device info snapshot (no protobuf dependency), filled by

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -36,8 +36,8 @@ enum app_cmd_action {
 	APP_CMD_ACTION_REBOOT,            /* reboot (discards staged edits) */
 	APP_CMD_ACTION_FACTORY_RESET,     /* defaults (keep identity+LoRaWAN) + reboot */
 	APP_CMD_ACTION_ENTER_CALIBRATION, /* persist calibration=true + reboot */
-	APP_CMD_ACTION_LRW_RESET,         /* reset LoRaWAN NVM (counters+DevNonce) + reboot (#109) */
-	APP_CMD_ACTION_LRW_JOIN,          /* trigger a forced (re)join, no reboot (#109) */
+	APP_CMD_ACTION_LRW_RESET, /* reset LoRaWAN NVM (counters+DevNonce) + reboot (#109) */
+	APP_CMD_ACTION_LRW_JOIN,  /* trigger a forced (re)join, no reboot (#109) */
 };
 
 /* Plain-C device info snapshot (no protobuf dependency), filled by

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -155,6 +155,8 @@ message Command {
         ReqHistory       req_history       = 11;
         ClockSync        clock_sync        = 12;
         W1Scan           w1_scan           = 14;
+        LrwReset         lrw_reset         = 16;
+        LrwJoin          lrw_join          = 17;
         EnterCalibration enter_calibration = 18;
     }
 // END GENERATED COMMANDS
@@ -193,6 +195,13 @@ message Command {
     // calibration mode (same end state as set_param calibration=true +
     // settings_save). One-shot: app_calibration_init() clears the flag on entry.
     message EnterCalibration { }
+    // Reset the LoRaWAN NVM (frame counters + DevNonce + session) and reboot,
+    // equivalent of `ats lrw reset`. Used during (re)commissioning after re-keying
+    // or moving the device to another network/session (#109).
+    message LrwReset     { }
+    // Trigger a forced (re)join immediately instead of waiting for the next
+    // scheduled attempt (#109). No reboot.
+    message LrwJoin      { }
     message ResetCounters {
         optional bool hall_left  = 1;
         optional bool hall_right = 2;

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -141,6 +141,8 @@ commands:
     - {name: req_history,    proto_id: 11, body: ReqHistory,    kind: handler, response: none, transports: [lrw]}
     - {name: clock_sync,     proto_id: 12, body: ClockSync,     kind: handler, response: info_deferred, transports: [lrw, nfc]}
     - {name: w1_scan,        proto_id: 14, body: W1Scan,        kind: handler, response: w1_scan}
+    - {name: lrw_reset,      proto_id: 16, body: LrwReset,      kind: action,  action: LRW_RESET, response: ack}
+    - {name: lrw_join,       proto_id: 17, body: LrwJoin,       kind: action,  action: LRW_JOIN, response: ack}
     - {name: enter_calibration, proto_id: 18, body: EnterCalibration, kind: action, action: ENTER_CALIBRATION, response: ack, transports: [lrw, nfc]}
 
 parameters:

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -585,6 +585,20 @@ static void post_cmd_work_handler(struct k_work *work)
 		app_config()->calibration = true;
 		app_settings_save(true);
 		break;
+	case APP_CMD_ACTION_LRW_RESET:
+		/* Wipe the LoRaWAN NVM (frame counters + DevNonce + session), then cold
+		 * reboot so the MAC re-initialises from a clean NVM (#109). Same path as
+		 * `ats lrw reset`. The Ack uplink has already left (deferred 8s). */
+		LOG_INF("Command: LoRaWAN reset (NVM wipe) + reboot");
+		app_lrw_reset_nvm();
+		sys_reboot(SYS_REBOOT_COLD);
+		break;
+	case APP_CMD_ACTION_LRW_JOIN:
+		/* Force a (re)join now instead of waiting for the next attempt (#109).
+		 * No reboot — app_lrw_join() just queues a join work item. */
+		LOG_INF("Command: forced LoRaWAN join");
+		app_lrw_join();
+		break;
 	default:
 		break;
 	}

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -76,6 +76,10 @@ static const char *cmd_action_str(enum app_cmd_action a)
 		return "factory-reset";
 	case APP_CMD_ACTION_ENTER_CALIBRATION:
 		return "enter-calibration";
+	case APP_CMD_ACTION_LRW_RESET:
+		return "lrw-reset+reboot";
+	case APP_CMD_ACTION_LRW_JOIN:
+		return "lrw-join";
 	default:
 		return "?";
 	}

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -160,6 +160,15 @@ static void nfc_poll_thread_fn(void *p1, void *p2, void *p3)
 				app_config()->calibration = true;
 				app_settings_save(true);
 				break;
+			case APP_CMD_ACTION_LRW_RESET:
+				/* Wipe LoRaWAN NVM (counters + DevNonce) + reboot (#109). */
+				app_lrw_reset_nvm();
+				sys_reboot(SYS_REBOOT_COLD);
+				break;
+			case APP_CMD_ACTION_LRW_JOIN:
+				/* Force a (re)join now, no reboot (#109). */
+				app_lrw_join();
+				break;
 			default:
 				break;
 			}

--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -57,6 +57,8 @@ byte is the `seq` and is echoed in the reply.
 | `reboot` | `08083a00` |
 | `reset_counters` (hall-left + input-a) | `0807520408011801` |
 | `set_param`: ADR on, `interval_report`=120 s, `alarm_0`=onboard temp 5–30 °C (hyst 1) | `0801121e0a021801120220782a14b2031103000000000000a0400000f0410000803f` |
+| `lrw_reset` | `0801820100` |
+| `lrw_join` | `08018a0100` |
 
 ### Legend
 
@@ -1177,6 +1179,20 @@ rejected with `error` `BAD_REQUEST` "bad epoch".
 > build (encryption on): present a plaintext command record and confirm it is rejected; present an
 > AES-CCM record (serial + nonce > last) and confirm an encrypted response is written back, and that
 > the info record (`hio.stck:inf`) is still readable without the key. Report all results.
+
+- [ ] Pass
+
+### N5 — LoRaWAN reset & forced join over NFC (#109)
+
+**Goal:** A phone can reset the LoRaWAN counters and force a join via the NFC command channel, completing the set-params → `lrw_reset` → `lrw_join` commissioning flow without a shell/J-Link.
+**Observable:** `lrw_reset` writes an `ack` back to the tag, then RTT shows `Command: LoRaWAN reset (NVM wipe) + reboot` and the device cold-reboots (frame counter / `DevNonce` back to 0). `lrw_join` writes an `ack` and RTT shows `Command: forced LoRaWAN join` with a fresh join (no reboot).
+
+**Prompt for Claude:**
+> On a default (encrypted) build: present an AES-CCM `hio.stck:cmd` record carrying `lrw_join`
+> (`08018a0100`) and confirm the `ack` is written back to the tag and RTT logs `Command: forced
+> LoRaWAN join` followed by a join attempt — with no reboot. Then present `lrw_reset` (`0801820100`),
+> confirm the `ack` is readable first, then RTT logs the NVM wipe + reboot and the LoRaWAN frame
+> counter restarts at 0 after reboot. Also verify both commands work as fPort-85 downlinks. Report results.
 
 - [ ] Pass
 

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -38,8 +38,8 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 | `clock_sync` | Sync the wall-clock. **Empty** (LoRaWAN): request a network time sync. **With `unix_time`** (NFC): set the RTC directly from the phone's clock (UTC seconds) | LoRaWAN: **`info`, deferred** — sent once the network time lands. NFC: **`info`** immediately — carries the new `unix_time` |
 | `req_history` | Replay stored history for a time window | `history_frame` (multiple) |
 | `w1_scan` | Enumerate the 1-Wire bus; returns the discovered ROMs so you can teach a slot via `set_param sensorN_rom` | `w1_scan` |
-| `alarm_rule` | Set / clear a dynamic alarm rule in a `slot`, or clear-all (SET/CLEAR require `slot`; the slot index is the rule's stable identity) | `ack` |
-| `req_alarm_rules` | Read back the stored dynamic alarm rules (paged); optional `slot` filter selects one slot, or `source`+`quantity` selects every slot on that pair | `alarm_rules_dump` |
+| `lrw_reset` | Reset the LoRaWAN NVM — frame counters + `DevNonce` + session (same as `ats lrw reset`); **reboots** so the MAC re-initialises clean | `ack` |
+| `lrw_join` | Trigger a forced (re)join immediately instead of waiting for the next scheduled attempt; **no reboot** | `ack` |
 | `enter_calibration` | Persist `calibration=true` + **reboot** into calibration mode (same end state as `set_param calibration=true` + `settings_save`); the flag is cleared on entry, so the device returns to normal after the calibration window | `ack` |
 
 > After `set_param`, send `settings_save` to persist (it reboots). If a command fails, the device returns an `error` with a code (1 = BAD_REQUEST, 2 = OUT_OF_RANGE, 3 = NOT_READY, 4 = HISTORY_UNAVAILABLE, 5 = UNSUPPORTED_FIELD, 6 = PERSIST_FAILED), an optional `fault_field`, and a `detail` string.
@@ -49,6 +49,8 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 > **LoRaWAN-only commands:** `force_send` and `req_history` answer only via an uplink, so they are rejected (`NOT_READY` "lrw only") if sent over NFC.
 >
 > **Setting the clock over NFC:** `clock_sync` with a `unix_time` field sets the RTC directly from a phone, bootstrapping wall-clock time before/without a network (epoch sanity-bounded to 2024-01-01 … 2100-01-01; out-of-range → `BAD_REQUEST` "bad epoch"). A later network `DeviceTimeReq`/`DeviceTimeAns` stays authoritative and may refine it. Empty `clock_sync` over NFC just confirms (no network to query).
+>
+> **Commissioning a device with just a phone (NFC):** the LoRaWAN identifiers/keys are written through the encrypted NFC config channel (`set_param`/config ingest covers every `lorawan` field — DevEUI, JoinEUI, AppKey, NwkKey, DevAddr, NwkSKey, AppSKey, region, sub-band, network, activation, ADR, link-check). The typical order is **set params → `lrw_reset` → `lrw_join`**: write the keys, reset the counters/`DevNonce` (so a re-keyed or relocated device starts a clean session), then force the join. `lrw_reset` reboots; the `ack` is written back to the tag first, then the reset + reboot run after a short delay (the phone can read the reply before the device restarts). `lrw_reset` and `lrw_join` work over both NFC and a LoRaWAN downlink.
 >
 > **`get_param` is paged** like `get_config`: the reply carries `page_index`/`page_count`, and an optional `page` field in the request selects which page (omit = 0). When the selected fields don't all fit one data-rate frame they are split across pages — fetch the rest by re-sending with the next `page`. A page out of range returns `OUT_OF_RANGE`. If any response still doesn't fit the buffer it is replaced by an `error` (same `seq`) rather than dropped silently.
 
@@ -70,6 +72,8 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 | `req_alarm_rules` (all rules, page 0) | `08017a00` |
 | `req_alarm_rules` (slot 0 only) | `08017a022000` |
 | `req_alarm_rules` (all slots on onboard temperature) | `08017a0408001000` |
+| `lrw_reset` | `0801820100` |
+| `lrw_join` | `08018a0100` |
 | `enter_calibration` | `0801920100` |
 
 (The leading byte is the `seq` you chose; it is echoed in the reply.)


### PR DESCRIPTION
Closes #109 (points 2 & 3); point 1 verified (no code change needed — see below).

## What

Adds two **action commands** to the `Command` protocol so a phone (or a LoRaWAN downlink) can finish LoRaWAN commissioning without a shell/J-Link:

| Command | proto_id | Effect | Reply |
|---|---|---|---|
| `lrw_reset` | 16 | Wipe the LoRaWAN NVM (frame counters + `DevNonce` + session) via `app_lrw_reset_nvm()`, then cold-reboot so the MAC re-initialises clean — same as `ats lrw reset` | `ack` |
| `lrw_join` | 17 | Force a (re)join now via `app_lrw_join()`; **no reboot** | `ack` |

Both work over **NFC and LoRaWAN** (no `transports` restriction). They reuse the existing `Command` mechanism, so the reply is deferred behind the `ack` (the phone reads the ack off the tag, or the LoRaWAN ack uplink leaves, before the reset/reboot runs).

## Point 1 — set LoRaWAN params (verified, no change)

Setting the LoRaWAN keys/identifiers over NFC already works through the encrypted config-ingest path (`app_config_apply_lorawan`). Reviewed for coverage + robustness:

- **All 14 `lorawan` fields** covered: region, network, adr, activation, deveui, joineui, nwkkey, appkey, devaddr, nwkskey, appskey, sub_band, link_check_interval, link_check_fail_rejoin.
- **Hex length** validated (`strlen != 2*len` → reject); **invalid/partial hex** decoded into a temp buffer and committed only on full success (no half-write, #91).
- **Enum/range** bounds enforced.
- All `lrw_*` keys are `preserve_on_migration` (#108) — never wiped by an update path.

→ No code change for point 1.

## Implementation

- `app_config.yml`: two `kind: action` command entries → `west configen` regenerates the proto `Command` oneof, the `app_cmd_dispatch()` switch, and the `ttn.js` command maps.
- `app_config.proto`: hand-written `LrwReset {}` / `LrwJoin {}` marker messages.
- `app_cmd.h`: `APP_CMD_ACTION_LRW_RESET` / `APP_CMD_ACTION_LRW_JOIN`.
- Action execution wired into both deferred-action sites: `app_lrw.c` `post_cmd_work_handler` (LoRaWAN, deferred 8 s) and the NFC poll loop in `main.c` (deferred so the tag reply is readable). `app_nfc.c` action trace updated.

`app_lrw_join()` is safe to call from the command context: it no-ops on an all-zero DevEUI (DISABLED, #98) and ignores re-entry while already JOINING.

## Ready-to-use hex (fPort 85)

- `lrw_reset` → `0801820100`
- `lrw_join` → `08018a0100`

## Tests

- Release + debug builds pass (debug FLASH 97.4 %, RAM 91.2 % — under budget).
- `tools/test.sh` green: node decoder, configen pytest, clang-format, configen-in-sync.
- HW + encrypted-NFC test pending (manual-test-plan **N5** added).

## Follow-up

- **manager-app** (`gitlab.hardwario.com/tester/manager-app`) must expose the two actions on its NFC command channel to drive the set-params → `lrw_reset` → `lrw_join` flow.