### PR TITLE
Split settings reset/erase so no remote path can un-provision (#108)

### DIFF
--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -182,7 +182,7 @@ static int h_commit(void)
 			m_app_config.config_version, APP_CONFIG_VERSION);
 
 		/* Reset application parameters to defaults, but carry over factory
-		 * identity and network credentials (preserve_on_migration in the
+		 * identity and network credentials (preserve_on_reset in the
 		 * YAML) so a schema bump never un-provisions a field device. */
 		struct app_config stored = m_app_config;
 
@@ -1931,10 +1931,10 @@ int app_config_factory_reset(void)
 	int ret;
 
 	/* Reset every parameter to its compiled-in default, but carry over the
-	 * factory identity and network credentials (preserve_on_migration in the
+	 * factory identity and network credentials (preserve_on_reset in the
 	 * YAML) so the reset never un-provisions the device or drops it off the
 	 * LoRaWAN network. A full wipe (incl. identity) stays shell-only via
-	 * `settings reset`. Mirrors the migration restore in h_commit. */
+	 * `settings erase`. Mirrors the migration restore in h_commit. */
 	struct app_config preserved = m_app_config;
 
 	m_app_config = m_app_config_defaults;

--- a/app/src/app_config.h
+++ b/app/src/app_config.h
@@ -109,9 +109,9 @@ extern struct app_config g_app_config;
 struct app_config *app_config(void);
 
 /* Reset every parameter to its compiled-in default EXCEPT the factory identity
- * and network credentials (preserve_on_migration), then persist. Backs the
+ * and network credentials (preserve_on_reset), then persist. Backs the
  * factory_reset command so the device keeps its LoRaWAN session; the shell
- * `settings reset` still does a full NVS wipe. Returns 0 or a negative errno.
+ * `settings erase` still does a full NVS wipe. Returns 0 or a negative errno.
  * The caller reboots so every module re-reads the restored config. */
 int app_config_factory_reset(void);
 

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -151,7 +151,7 @@ parameters:
     proto_callback: true
     type: bytes
     size: 16
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set device secret key (32 hexadecimal digits)."
 
   - name: serial_number
@@ -159,7 +159,7 @@ parameters:
     proto_id: 3
     type: uint32
     format: "%010u"
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set device serial number (10 decimal digits)."
     extras:
       digits: 10
@@ -168,7 +168,7 @@ parameters:
     proto_group: root
     proto_id: 4
     type: uint32
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set nonce counter (unsigned integer)."
 
   - name: calibration
@@ -233,7 +233,7 @@ parameters:
     proto_id: 1
     type: enum
     enum: lrw_region
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN region (eu868/us915/au915)."
 
   - name: lrw_sub_band
@@ -243,7 +243,7 @@ parameters:
     default: 2
     min: 0
     max: 8
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set US915/AU915 sub-band (1-8, 0 = all channels). Default 2 matches TTN/Helium/ChirpStack."
 
   - name: lrw_network
@@ -251,14 +251,14 @@ parameters:
     proto_id: 2
     type: enum
     enum: lrw_network
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN network (public/private)."
 
   - name: lrw_adr
     proto_group: lorawan
     proto_id: 3
     type: bool
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN ADR (true/false)."
 
   - name: lrw_activation
@@ -266,7 +266,7 @@ parameters:
     proto_id: 4
     type: enum
     enum: lrw_activation
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN activation (otaa/abp)."
 
   - name: lrw_deveui
@@ -274,7 +274,7 @@ parameters:
     proto_id: 5
     type: bytes
     size: 8
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN DevEUI (16 hex digits)."
 
   - name: lrw_joineui
@@ -282,7 +282,7 @@ parameters:
     proto_id: 6
     type: bytes
     size: 8
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN JoinEUI (16 hex digits)."
 
   - name: lrw_nwkkey
@@ -291,7 +291,7 @@ parameters:
     dump: false
     type: bytes
     size: 16
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN NwkKey (32 hex digits)."
 
   - name: lrw_appkey
@@ -300,7 +300,7 @@ parameters:
     dump: false
     type: bytes
     size: 16
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN AppKey (32 hex digits)."
 
   - name: lrw_devaddr
@@ -308,7 +308,7 @@ parameters:
     proto_id: 9
     type: bytes
     size: 4
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN DevAddr (8 hex digits)."
 
   - name: lrw_nwkskey
@@ -317,7 +317,7 @@ parameters:
     dump: false
     type: bytes
     size: 16
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN NwkSKey (32 hexadecimal digits)."
 
   - name: lrw_appskey
@@ -326,7 +326,7 @@ parameters:
     dump: false
     type: bytes
     size: 16
-    preserve_on_migration: true
+    preserve_on_reset: true
     help: "Get/Set LoRaWAN AppSKey (32 hexadecimal digits)."
 
   - name: lrw_link_check_interval

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -570,7 +570,7 @@ static void post_cmd_work_handler(struct k_work *work)
 		break;
 	case APP_CMD_ACTION_FACTORY_RESET:
 		LOG_INF("Command: factory reset (keep identity + LoRaWAN) + reboot");
-		app_settings_factory_reset();
+		app_settings_reset();
 		break;
 	case APP_CMD_ACTION_REBOOT:
 		LOG_INF("Command: reboot");

--- a/app/src/app_settings.c
+++ b/app/src/app_settings.c
@@ -48,7 +48,7 @@ static int save(bool reboot)
 	return 0;
 }
 
-static int reset(bool reboot)
+static int erase(bool reboot)
 {
 	int ret;
 
@@ -118,9 +118,23 @@ static int cmd_reset(const struct shell *shell, size_t argc, char **argv)
 {
 	int ret;
 
-	ret = reset(true);
+	ret = app_settings_reset();
 	if (ret) {
-		LOG_ERR("Call `reset` failed: %d", ret);
+		LOG_ERR("Call `app_settings_reset` failed: %d", ret);
+		shell_error(shell, "%s", m_shell_msg_error);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int cmd_erase(const struct shell *shell, size_t argc, char **argv)
+{
+	int ret;
+
+	ret = erase(true);
+	if (ret) {
+		LOG_ERR("Call `erase` failed: %d", ret);
 		shell_error(shell, "%s", m_shell_msg_error);
 		return ret;
 	}
@@ -151,8 +165,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	              cmd_save, 1, 0),
 
 	SHELL_CMD_ARG(reset, NULL,
-	              "Reset all settings and reboot.",
+	              "Reset config + alarm rules to defaults (keeps identity + LoRaWAN) and reboot.",
 	              cmd_reset, 1, 0),
+
+	SHELL_CMD_ARG(erase, NULL,
+	              "Erase the whole NVS partition incl. identity + LoRaWAN credentials, then reboot.",
+	              cmd_erase, 1, 0),
 
 	SHELL_SUBCMD_SET_END
 );
@@ -168,17 +186,19 @@ int app_settings_save(bool reboot)
 	return save(reboot);
 }
 
-int app_settings_reset(void)
+int app_settings_erase(void)
 {
-	return reset(true);
+	return erase(true);
 }
 
-int app_settings_factory_reset(void)
+int app_settings_reset(void)
 {
 	int ret;
 
 	/* Config: defaults for everything except the preserved identity + LoRaWAN
-	 * fields (see app_config_factory_reset). */
+	 * fields (see app_config_factory_reset). This is the only reset reachable
+	 * over LoRaWAN/NFC, so a remote command can never un-provision the device;
+	 * a full wipe (incl. identity) stays shell-only via `settings erase`. */
 	ret = app_config_factory_reset();
 	if (ret) {
 		LOG_ERR("Call `app_config_factory_reset` failed: %d", ret);

--- a/app/src/app_settings.h
+++ b/app/src/app_settings.h
@@ -15,14 +15,19 @@ extern "C" {
 #endif
 
 int app_settings_save(bool reboot);
+
+/* Reset for the shell `settings reset` and the factory_reset command (LoRaWAN /
+ * NFC): restore every config parameter (and clear all dynamic alarm rules) to
+ * defaults but KEEP the device identity and LoRaWAN credentials, then reboot, so
+ * the device stays provisioned and on the network. This is the only reset
+ * reachable remotely, so no command can ever un-provision a field device. */
 int app_settings_reset(void);
 
-/* Factory reset for the factory_reset command: restore every config parameter
- * (and clear all dynamic alarm rules) to defaults but KEEP the device identity
- * and LoRaWAN credentials, then reboot, so the device stays provisioned and on
- * the network. Differs from app_settings_reset(), which wipes the whole NVS
- * partition (identity included) and is reserved for the shell. */
-int app_settings_factory_reset(void);
+/* Full NVS wipe: erase the whole storage partition (identity + LoRaWAN
+ * credentials included), then reboot. Destructive and un-provisions the device,
+ * so it is reserved for the local shell `settings erase` only — never wired to
+ * any LoRaWAN or NFC path. */
+int app_settings_erase(void);
 
 #ifdef __cplusplus
 }

--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -134,18 +134,50 @@ byte is the `seq` and is echoed in the reply.
 
 - [ ] Pass
 
-### G6 — Factory reset
+### G6 — Reset keeps identity (`settings reset` / FactoryReset)
 
-**Goal:** Factory reset clears NVS and reboots.
-**Observable:** Shell `settings reset` (or FactoryReset downlink) → NVS cleared, device reboots,
-config back to defaults.
+**Goal:** `settings reset` and the FactoryReset command restore application config + alarm rules to
+defaults but **keep** the device identity (`serial-number`, `secret-key`) and LoRaWAN provisioning
+(`lrw-deveui`, keys, region, …), so the unit stays provisioned and on the network (issue #108).
+**Observable:** changed app/alarm values back to defaults; DevEUI/keys/serial unchanged; device
+stays joined / rejoins with the same credentials.
 
 **Prompt for Claude:**
-> First capture a couple of non-default config values via `config` (e.g. `config interval-report`).
-> Then run `settings reset` over the RTT shell (this is destructive — confirm it's acceptable on
-> this bench unit). Confirm the device reboots and the previously-changed values are back to
-> defaults. Optionally repeat using a FactoryReset downlink on fPort 85 and confirm the
-> `Response.Ack` precedes the reboot.
+> First capture the identity + a couple of app values via `config` (e.g. `config lrw-deveui`,
+> `config serial-number`, `config interval-report`) and change `interval-report` to a non-default.
+> Then run `settings reset` over the RTT shell. After reboot confirm: `interval-report` is back to
+> default, but `config lrw-deveui` / `config serial-number` are **unchanged**, and the device
+> rejoins with the same DevEUI. Repeat using a FactoryReset downlink on fPort 85 and confirm the
+> `Response.Ack` precedes the reboot and identity again survives.
+
+- [ ] Pass
+
+### G6b — Full erase un-provisions (`settings erase`)
+
+**Goal:** `settings erase` is the only path that wipes the whole NVS partition (identity + LoRaWAN
+credentials included). It is **shell-only** — no LoRaWAN or NFC command can reach it (issue #108).
+**Observable:** after `settings erase` the DevEUI/keys/serial are gone (back to all-zero/defaults);
+the device no longer joins until re-provisioned.
+
+**Prompt for Claude:**
+> ⚠️ Destructive — confirm it's acceptable to un-provision this bench unit first (you'll need to
+> re-flash provisioning afterwards). Run `settings erase` over the RTT shell. After reboot confirm
+> `config lrw-deveui` and `config serial-number` are wiped and the device fails to join. Then
+> re-provision and confirm join works again.
+
+- [ ] Pass
+
+### G6c — Re-flash preserves provisioning (J-Link regression)
+
+**Goal:** A normal `west flash` (no `--erase`) never touches the `storage` NVS partition, so
+re-flashing firmware keeps the device provisioned (issue #108 partition-map contract).
+**Observable:** identity + LoRaWAN credentials survive a firmware re-flash.
+
+**Prompt for Claude:**
+> Capture `config lrw-deveui` / `config serial-number` / `config interval-report` (set the latter
+> to a non-default and `settings save`). Re-flash the firmware with a plain `west flash` (no
+> `--erase`). After reboot confirm all three values are **unchanged** and the device rejoins with
+> the same DevEUI — i.e. the flash preserved the `storage` partition at `0x3C000`.
 
 - [ ] Pass
 
@@ -554,6 +586,24 @@ fPort 10 every 30 s using fixed ABP keys.
 > uplinks on fPort 10 roughly every 30 s (verify on the network server; note the fixed ABP keys).
 > Confirm normal telemetry is suppressed while in calibration mode. Also verify the
 > config-flag path: `config calibration on` + reboot logs `Calibration flag set in config`.
+
+- [ ] Pass
+
+### S12b — `enter_calibration` command (remote)
+
+**Goal:** The `enter_calibration` command (#141) drops the device into calibration mode over
+LoRaWAN and NFC, with the same end state as the magnet/flag path.
+**Observable:** `Response.Ack` on fPort 85; after the deferred action (≈8 s) the device cold-reboots
+and the boot log shows `Calibration flag set in config — entering calibration mode`, then fPort-10
+calibration uplinks. The flag is one-shot, so the next reboot returns to normal.
+
+**Prompt for Claude:**
+> Send the `enter_calibration` command (downlink hex `0801920100` on fPort 85 via the TTS MCP, or
+> over NFC). Confirm the Ack, then that the device reboots into calibration mode (boot log
+> `Calibration flag set in config — entering calibration mode`, fPort-10 uplinks). Reboot once more
+> and confirm it returns to normal telemetry (the flag self-clears). Note: a shell `ats cmd lrw
+> 0801920100` only acks and reports the deferred action without executing it — drive the real entry
+> via an actual downlink or the NFC tag.
 
 - [ ] Pass
 

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -386,8 +386,10 @@ The TTN/ChirpStack payload formatter (`app/decoder/ttn.js`) was extended for v1.
 | `ats cmd lrw \| nfc <hex>` | **New** (debug) — inject a command over the LoRaWAN/NFC transport for bench testing |
 | `nfc dump` / `read` / `write` / `clear` / `check` / `autocheck` / `reg` / `regw` | **New** (debug) — direct ST25DV tag access; `nfc check` prints a readable trace of what it read, decoded and wrote back (see §10) |
 | `config history-enable` / `history-sensors` / `alarm-limit` / `alarm-notif-time` / `pir-notify-act` | **New** parameters (see §6, §7) |
+| `settings reset` | **Changed** — now keeps device identity + LoRaWAN credentials (see §13); restores only application config + alarm rules to defaults |
+| `settings erase` | **New** — full NVS wipe incl. identity + LoRaWAN credentials; shell-only, destructive (see §13) |
 
-Existing commands (`config`, `settings save`/`reset`, `join`, `send`) are unchanged.
+Existing commands (`config`, `settings save`, `join`, `send`) are unchanged.
 
 ---
 
@@ -485,6 +487,48 @@ Follow-up to §12 with no behaviour change: the report *orchestration* was lifte
 - History capture now self-skips while a replay is streaming (`app_history` owns that guard), instead of `app_lrw` gating it.
 
 The report cadence is unified with `interval_report` (there is no separate `interval_history`). No configuration, wire-format or shell change. Validated end-to-end on hardware over ChirpStack on both debug and release builds (join → cadence, force_send, LC piggyback, multi-frame split, history capture; release `f_cnt_up` sustained well past the historical 4–5-message stall).
+
+---
+
+## 14. Identity & provisioning preservation (NEW)
+
+A firmware update or a reset must **never** un-provision a field device. The device identity
+(`serial-number`, `secret-key`, `nonce-counter`) and the LoRaWAN provisioning (`lrw-deveui`,
+`lrw-joineui`, all keys, `lrw-devaddr`, session keys, `region`, `sub-band`, `network`,
+`activation`, `adr`) are a **protected set** that survives every reset and migration path
+(issue #108). These parameters are flagged `preserve_on_reset` in `app_config.yml`, and `configen`
+generates the restore logic from that single source of truth — adding a new protected field is a
+one-line YAML change, no hand-maintained C list.
+
+**Reset semantics**
+
+| Path | Reaches | Effect on identity + LoRaWAN credentials |
+|---|---|---|
+| `settings reset` (shell) | local | **Kept** — only app config + alarm rules go back to defaults |
+| `factory_reset` command | LoRaWAN **and** NFC | **Kept** — same as `settings reset`; this is the only reset reachable remotely, so no command can un-provision a device |
+| NFC config-tag reset | NFC | **Kept** |
+| schema migration (config-version bump) | automatic on boot | **Kept** — a firmware update that bumps the config schema restores the protected set after applying new defaults |
+| `settings erase` (shell) | local **only** | **Wiped** — full NVS erase incl. identity; the deliberate "return to blank" escape hatch, never wired to LoRaWAN/NFC |
+
+**Partition-map contract** (256 KB internal flash, single flat image, no bootloader yet):
+
+| Partition | Offset | Size | Contents |
+|---|---|---|---|
+| `code` | `0x00000` | 160 KB | application image (`CONFIG_FLASH_LOAD_SIZE` link-time budget) |
+| `history` | `0x28000` | 80 KB | sensor history buffer (future FUOTA DFU slot) |
+| `storage` | `0x3C000` | 16 KB | **NVS — the protected set lives here** |
+
+The contract every update path must honour: **never erase the `storage` region at `0x3C000`.**
+
+- **J-Link / SWD** — a plain `west flash` (no `--erase`) writes only the sectors covered by the
+  image, and the image can never overflow into `storage` (the linker fails the build on overflow).
+  A full-chip `--erase` / mass-erase **does** wipe `storage` and must not be used on a provisioned
+  unit. (Hardware write-protect on `storage` is not an option — NVS must write/erase it at runtime.)
+- **NFC firmware update** (future erase-in-place bootloader) and **LoRaWAN FUOTA** (future) must
+  erase/program only the image region and skip `storage`.
+
+See manual-test-plan G6 / G6b / G6c for the regression checks (reset keeps identity, erase wipes
+it, re-flash preserves it).
 
 ---
 

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -441,12 +441,12 @@ static int h_commit(void)
 			m_{{ module.name }}.config_version, {{ module.name | upper }}_VERSION);
 
 		/* Reset application parameters to defaults, but carry over factory
-		 * identity and network credentials (preserve_on_migration in the
+		 * identity and network credentials (preserve_on_reset in the
 		 * YAML) so a schema bump never un-provisions a field device. */
 		struct {{ module.name }} stored = m_{{ module.name }};
 
 		m_{{ module.name }} = m_{{ module.name }}_defaults;
-{% for param in parameters if param.preserve_on_migration | default(false) %}
+{% for param in parameters if param.preserve_on_reset | default(false) %}
 {% if param.type == 'bytes' or param.type == 'string' %}
 		memcpy(m_{{ module.name }}.{{ param.name | c_name }}, stored.{{ param.name | c_name }},
 		       sizeof(m_{{ module.name }}.{{ param.name | c_name }}));
@@ -723,14 +723,14 @@ int {{ module.name }}_factory_reset(void)
 	int ret;
 
 	/* Reset every parameter to its compiled-in default, but carry over the
-	 * factory identity and network credentials (preserve_on_migration in the
+	 * factory identity and network credentials (preserve_on_reset in the
 	 * YAML) so the reset never un-provisions the device or drops it off the
 	 * LoRaWAN network. A full wipe (incl. identity) stays shell-only via
-	 * `settings reset`. Mirrors the migration restore in h_commit. */
+	 * `settings erase`. Mirrors the migration restore in h_commit. */
 	struct {{ module.name }} preserved = m_{{ module.name }};
 
 	m_{{ module.name }} = m_{{ module.name }}_defaults;
-{% for param in parameters if param.preserve_on_migration | default(false) %}
+{% for param in parameters if param.preserve_on_reset | default(false) %}
 {% if param.type == 'bytes' or param.type == 'string' %}
 	memcpy(m_{{ module.name }}.{{ param.name | c_name }}, preserved.{{ param.name | c_name }},
 	       sizeof(m_{{ module.name }}.{{ param.name | c_name }}));

--- a/scripts/west_commands/templates/config.h.j2
+++ b/scripts/west_commands/templates/config.h.j2
@@ -43,9 +43,9 @@ extern struct {{ module.name }} g_{{ module.name }};
 struct {{ module.name }} *{{ module.name }}(void);
 
 /* Reset every parameter to its compiled-in default EXCEPT the factory identity
- * and network credentials (preserve_on_migration), then persist. Backs the
+ * and network credentials (preserve_on_reset), then persist. Backs the
  * factory_reset command so the device keeps its LoRaWAN session; the shell
- * `settings reset` still does a full NVS wipe. Returns 0 or a negative errno.
+ * `settings erase` still does a full NVS wipe. Returns 0 or a negative errno.
  * The caller reboots so every module re-reads the restored config. */
 int {{ module.name }}_factory_reset(void);
 

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -215,13 +215,13 @@ def test_generated_c_matches_committed(workdir):
 
 
 def test_migration_preserves_factory_fields(workdir):
-    """Issue #87: h_commit must restore every preserve_on_migration parameter
+    """Issue #87/#108: h_commit must restore every preserve_on_reset parameter
     after the defaults reset, and must not restore anything else."""
     _run_configen(workdir)
     generated = (workdir / "app_config.c").read_text()
     cfg = _load_config()
 
-    preserved = [p for p in cfg["parameters"] if p.get("preserve_on_migration")]
+    preserved = [p for p in cfg["parameters"] if p.get("preserve_on_reset")]
     # The whole point of #87: identity/credentials are flagged in the YAML.
     assert {p["name"] for p in preserved} >= {
         "secret_key", "serial_number", "nonce_counter",
@@ -230,7 +230,7 @@ def test_migration_preserves_factory_fields(workdir):
     }
 
     for p in cfg["parameters"]:
-        if p.get("preserve_on_migration"):
+        if p.get("preserve_on_reset"):
             if p["type"] in ("bytes", "string"):
                 marker = f"memcpy(m_app_config.{p['name']}, stored.{p['name']}"
             else:
@@ -238,7 +238,7 @@ def test_migration_preserves_factory_fields(workdir):
             assert marker in generated, f"{p['name']} not restored on migration"
         else:
             assert f"stored.{p['name']}" not in generated, \
-                f"{p['name']} restored but not flagged preserve_on_migration"
+                f"{p['name']} restored but not flagged preserve_on_reset"
 
     # The migration must be persisted exactly once, from init, not from h_commit.
     assert "settings_save_subtree(SETTINGS_PFX)" in generated


### PR DESCRIPTION
Closes #108 (the reset/erase paths; J-Link `--erase` and the future NFC/FUOTA bootloader remain a documented contract).

## Problem

A firmware update or reset must **never** erase device identity or LoRaWAN provisioning — re-flashing or resetting must not un-provision a field device. The preserve-on-reset machinery already existed (the `h_commit` migration and `app_config_factory_reset` keep the protected set), **but**:

- the shell `settings reset` and **every NFC reset path** still did a full NVS wipe (`flash_area_erase` of the whole `storage` partition), so a reset over NFC un-provisioned the device;
- the destructive wipe carried the intuitive `reset` name, while the safe path was the oddly-named `app_settings_factory_reset()`.

## Changes

- **YAML flag** `preserve_on_migration` → `preserve_on_reset` (it governs both migration *and* reset). `configen` still generates the restore logic from it, so the protected set stays single-sourced in `app_config.yml` — adding a protected field is a one-line YAML change.
- **`app_settings`**: `app_settings_reset()` now **keeps** identity + LoRaWAN credentials (only application config + alarm rules go back to defaults). New `app_settings_erase()` is the full NVS wipe. Dropped the confusing `app_settings_factory_reset()`.
- **Shell**: `settings reset` keeps identity; **new `settings erase`** is the shell-only, destructive full wipe — never wired to LoRaWAN/NFC.
- **Rewired** the LoRaWAN `factory_reset` command and all NFC reset paths to the safe reset, so **no command can un-provision a device remotely**.
- **Docs**: `version 1.4` §13 (reset semantics table + partition-map contract) and `manual-test-plan` G6 / G6b / G6c regression checks (reset keeps identity, erase wipes it, re-flash preserves it).
- Regenerated `app_config.{c,h}` from the updated templates.

## Protected set

`serial_number`, `secret_key`, `nonce_counter` + all LoRaWAN provisioning (`lrw_deveui`, `lrw_joineui`, keys, `lrw_devaddr`, session keys, `region`, `sub_band`, `network`, `activation`, `adr`).

## Reset matrix after this PR

| Path | Reaches | Identity + LoRaWAN creds |
|---|---|---|
| `settings reset` (shell) | local | kept |
| `factory_reset` command | LoRaWAN + NFC | kept |
| NFC config-tag reset | NFC | kept |
| schema migration | boot | kept |
| `settings erase` (shell) | local only | **wiped** |

## Note on hardware write-protect

"Survive even a careless `--erase`" via flash WRP is not feasible: NVS must write/erase `storage` at runtime, so a hardware write-protect would break settings. The guarantee is instead: default `west flash` (no `--erase`) never touches `storage` at `0x3C000`, and no remote/NFC command can wipe it.

## Testing

- `pytest scripts/west_commands/tests` — 21 passed (incl. the preserve-on-reset codegen check).
- `node --test` decoder — 24 passed.
- Clean release build: FLASH 95.01% / RAM 62.50%.
- Clean debug build: FLASH 96.84% / RAM 85.84%.
- HW regression (G6/G6b/G6c) pending on the bench.