### PR TITLE
Add enter_calibration command (#141)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -135,6 +135,7 @@ var _CMD_NAMES = {
   11: "req_history",
   12: "clock_sync",
   14: "w1_scan",
+  18: "enter_calibration",
 };
 // END GENERATED COMMANDS
 var _CMD_TAGS = _invert(_CMD_NAMES);

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -608,6 +608,10 @@ static void app_cmd_dispatch(enum app_cmd_transport tp, const Command *cmd, Resp
 	case Command_w1_scan_tag:
 		app_cmd_handle_w1_scan(tp, cmd, resp, action);
 		break;
+	case Command_enter_calibration_tag:
+		*action = APP_CMD_ACTION_ENTER_CALIBRATION;
+		resp->which_body = Response_ack_tag;
+		break;
 	default:
 		LOG_WRN("Command tag %u not implemented", cmd->which_body);
 		make_error(resp, Response_Error_Code_UNKNOWN, "not implemented");

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -32,9 +32,10 @@ enum app_cmd_transport {
  * leaves before the device reboots). Set by app_cmd_handle(). */
 enum app_cmd_action {
 	APP_CMD_ACTION_NONE = 0,
-	APP_CMD_ACTION_SETTINGS_SAVE, /* persist staged config + reboot */
-	APP_CMD_ACTION_REBOOT,        /* reboot (discards staged edits) */
-	APP_CMD_ACTION_FACTORY_RESET, /* defaults (keep identity+LoRaWAN) + reboot */
+	APP_CMD_ACTION_SETTINGS_SAVE,     /* persist staged config + reboot */
+	APP_CMD_ACTION_REBOOT,            /* reboot (discards staged edits) */
+	APP_CMD_ACTION_FACTORY_RESET,     /* defaults (keep identity+LoRaWAN) + reboot */
+	APP_CMD_ACTION_ENTER_CALIBRATION, /* persist calibration=true + reboot */
 };
 
 /* Plain-C device info snapshot (no protobuf dependency), filled by

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -143,18 +143,19 @@ message Command {
 
     // BEGIN GENERATED COMMANDS
     oneof body {
-        SetParam      set_param      = 2;
-        GetParam      get_param      = 3;
-        GetInfo       get_info       = 4;
-        GetConfig     get_config     = 5;
-        SettingsSave  settings_save  = 6;
-        Reboot        reboot         = 7;
-        FactoryReset  factory_reset  = 8;
-        ForceSend     force_send     = 9;
-        ResetCounters reset_counters = 10;
-        ReqHistory    req_history    = 11;
-        ClockSync     clock_sync     = 12;
-        W1Scan        w1_scan        = 14;
+        SetParam         set_param         = 2;
+        GetParam         get_param         = 3;
+        GetInfo          get_info          = 4;
+        GetConfig        get_config        = 5;
+        SettingsSave     settings_save     = 6;
+        Reboot           reboot            = 7;
+        FactoryReset     factory_reset     = 8;
+        ForceSend        force_send        = 9;
+        ResetCounters    reset_counters    = 10;
+        ReqHistory       req_history       = 11;
+        ClockSync        clock_sync        = 12;
+        W1Scan           w1_scan           = 14;
+        EnterCalibration enter_calibration = 18;
     }
 // END GENERATED COMMANDS
 
@@ -188,6 +189,10 @@ message Command {
     message Reboot       { }
     message FactoryReset { }
     message ForceSend    { }
+    // Persist calibration=true + cold reboot, so the next boot enters
+    // calibration mode (same end state as set_param calibration=true +
+    // settings_save). One-shot: app_calibration_init() clears the flag on entry.
+    message EnterCalibration { }
     message ResetCounters {
         optional bool hall_left  = 1;
         optional bool hall_right = 2;

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -141,6 +141,8 @@ commands:
     - {name: req_history,    proto_id: 11, body: ReqHistory,    kind: handler, response: none, transports: [lrw]}
     - {name: clock_sync,     proto_id: 12, body: ClockSync,     kind: handler, response: info_deferred, transports: [lrw, nfc]}
     - {name: w1_scan,        proto_id: 14, body: W1Scan,        kind: handler, response: w1_scan}
+    - {name: enter_calibration, proto_id: 18, body: EnterCalibration, kind: action, action: ENTER_CALIBRATION, response: ack, transports: [lrw, nfc]}
+
 parameters:
   - name: secret_key
     proto_group: root

--- a/app/src/app_lrw.c
+++ b/app/src/app_lrw.c
@@ -576,6 +576,15 @@ static void post_cmd_work_handler(struct k_work *work)
 		LOG_INF("Command: reboot");
 		sys_reboot(SYS_REBOOT_COLD);
 		break;
+	case APP_CMD_ACTION_ENTER_CALIBRATION:
+		/* Persist calibration=true + reboot; main() enters calibration
+		 * mode on the next boot (app_calibration_init() clears the flag).
+		 * Write the staging config (app_config()) — that is what settings_save
+		 * persists; g_app_config is only the boot-time read copy. */
+		LOG_INF("Command: entering calibration mode + reboot");
+		app_config()->calibration = true;
+		app_settings_save(true);
+		break;
 	default:
 		break;
 	}

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -74,6 +74,8 @@ static const char *cmd_action_str(enum app_cmd_action a)
 		return "reboot";
 	case APP_CMD_ACTION_FACTORY_RESET:
 		return "factory-reset";
+	case APP_CMD_ACTION_ENTER_CALIBRATION:
+		return "enter-calibration";
 	default:
 		return "?";
 	}

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -152,6 +152,14 @@ static void nfc_poll_thread_fn(void *p1, void *p2, void *p3)
 			case APP_CMD_ACTION_FACTORY_RESET:
 				app_settings_reset();
 				break;
+			case APP_CMD_ACTION_ENTER_CALIBRATION:
+				/* Persist calibration=true + reboot; next boot enters
+				 * calibration mode (app_calibration_init() clears it).
+				 * Write the staging config (settings_save persists that,
+				 * not the boot-time g_app_config copy). */
+				app_config()->calibration = true;
+				app_settings_save(true);
+				break;
 			default:
 				break;
 			}

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -40,6 +40,7 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 | `w1_scan` | Enumerate the 1-Wire bus; returns the discovered ROMs so you can teach a slot via `set_param sensorN_rom` | `w1_scan` |
 | `alarm_rule` | Set / clear a dynamic alarm rule in a `slot`, or clear-all (SET/CLEAR require `slot`; the slot index is the rule's stable identity) | `ack` |
 | `req_alarm_rules` | Read back the stored dynamic alarm rules (paged); optional `slot` filter selects one slot, or `source`+`quantity` selects every slot on that pair | `alarm_rules_dump` |
+| `enter_calibration` | Persist `calibration=true` + **reboot** into calibration mode (same end state as `set_param calibration=true` + `settings_save`); the flag is cleared on entry, so the device returns to normal after the calibration window | `ack` |
 
 > After `set_param`, send `settings_save` to persist (it reboots). If a command fails, the device returns an `error` with a code (1 = BAD_REQUEST, 2 = OUT_OF_RANGE, 3 = NOT_READY, 4 = HISTORY_UNAVAILABLE, 5 = UNSUPPORTED_FIELD, 6 = PERSIST_FAILED), an optional `fault_field`, and a `detail` string.
 >
@@ -69,6 +70,7 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 | `req_alarm_rules` (all rules, page 0) | `08017a00` |
 | `req_alarm_rules` (slot 0 only) | `08017a022000` |
 | `req_alarm_rules` (all slots on onboard temperature) | `08017a0408001000` |
+| `enter_calibration` | `0801920100` |
 
 (The leading byte is the `seq` you chose; it is echoed in the reply.)
 


### PR DESCRIPTION
Closes #141.

## What

Adds a dedicated protobuf command `enter_calibration` that drops the device into calibration mode remotely, over **LoRaWAN** (fPort 85) and **NFC**. Until now calibration could only be entered by placing **both magnets** on the Hall sensors at boot, or via the two-step `set_param calibration=true` + `settings_save`.

## How

Modeled as a `kind: action` command (`proto_id: 18`) — same shape as `settings_save`/`reboot`/`factory_reset`, so no bespoke handler:

- The generated dispatch acks and sets `APP_CMD_ACTION_ENTER_CALIBRATION`.
- The deferred post-command action (8 s after the ack leaves, on `m_work_q` for LoRaWAN / after the NFC read window) persists `calibration = true` and cold-reboots.
- `main()` enters calibration on the next boot (`main.c:172`), and `app_calibration_init()` clears the flag one-shot (`app_calibration.c:266`) — so the device returns to normal after the 2 h window. End state is identical to the existing flag path; the magnet trigger is untouched.

> **proto_id 18, not 16** — `lrw_reset`/`lrw_join` (16/17) from the in-flight #109 PR also target v1.4.0, so this took 18 to avoid a configen duplicate-id collision on the second merge.

## Changes

| File | Change |
|---|---|
| `app/src/app_config.yml` | new command, `transports: [lrw, nfc]` |
| `app/src/app_config.proto` | `EnterCalibration` body + regenerated oneof (`west configen`) |
| `app/src/app_cmd.{c,h}` | regenerated dispatch + `APP_CMD_ACTION_ENTER_CALIBRATION` |
| `app/src/app_lrw.c`, `app/src/main.c` | handle the action over LoRaWAN and NFC |
| `app/src/app_nfc.c` | action-name string for the debug report |
| `app/decoder/ttn.js`, `doc/version 1.4.md` | command table + hex example |

Ready-to-use downlink (fPort 85): `0801920100` (`seq=1`, empty `enter_calibration`).

## Test

- `west build -b sticker app` (release): green, FLASH 95.74 % / RAM 67.77 %.
- `tools/test.sh`: node decoder + configen pytest (21) + clang-format + configen-sync all green.
- Hex downlink verified by decoding the wire bytes (seq=1, field 18 empty message).
- **HW test pending** — enter over LoRaWAN + NFC, confirm reboot into calibration TX on fPort 10, confirm return to normal after the window.

Design discussion: #141 (comment).
