### PR TITLE
feat(nfc): event-driven low-power command pickup via ST25DV GPO interrupt

### DIFF
--- a/app/app.overlay
+++ b/app/app.overlay
@@ -11,5 +11,8 @@
 	zephyr,user {
 		pir-si-gpios = <&gpioa 11 GPIO_ACTIVE_HIGH>;
 		pir-dl-gpios = <&gpiob 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		/* ST25DV GPO interrupt output (U11 pin 11 -> STM32 PB12, EXTI12),
+		 * handled in app_nfc.c to wake the NFC handler on RF events. */
+		nfc-gpo-gpios = <&gpiob 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -151,6 +151,18 @@ static K_MUTEX_DEFINE(m_lock);
 
 static const struct gpio_dt_spec m_lpd = GPIO_DT_SPEC_GET(DT_NODELABEL(lpd), gpios);
 
+/* ST25DV GPO interrupt line (PB12). Asserts on the RF events enabled in the GPO
+ * config (RF write, field change, ...), letting us wake on demand instead of
+ * polling. Handled directly here. */
+static const struct gpio_dt_spec m_gpo =
+	GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), nfc_gpo_gpios);
+static struct gpio_callback m_gpo_cb;
+
+/* Given by the GPO ISR on each RF event; the NFC poll thread sleeps on it so the
+ * CPU only wakes to service the tag when the phone is actually doing something
+ * (max count 1 — bursts coalesce into one wake, which is fine). */
+static K_SEM_DEFINE(m_gpo_sem, 0, 1);
+
 /* Periodic NFC check enable (toggled via `nfc autocheck`). Lets a config blob
  * be written over several `nfc write` calls without the periodic check racing
  * it and rewriting the tag to the info record mid-write. */
@@ -794,6 +806,49 @@ static bool is_buffer_zero(const void *buf, size_t len)
 	return true;
 }
 
+/* ST25DV GPO interrupt handler: wake the NFC poll thread to service the tag. */
+static void gpo_isr(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(pins);
+	k_sem_give(&m_gpo_sem);
+}
+
+/* Block the NFC poll thread until the GPO line signals RF activity, or until
+ * `fallback_ms` elapses (a safety net so a missed edge can't stall the
+ * channel). Returns 0 if woken by GPO, -EAGAIN on the fallback timeout. */
+int app_nfc_wait_event(int fallback_ms)
+{
+	return k_sem_take(&m_gpo_sem, K_MSEC(fallback_ms));
+}
+
+/* Configure the GPO line (PB12) as an input with an edge interrupt. */
+static int nfc_gpo_irq_setup(void)
+{
+	if (!gpio_is_ready_dt(&m_gpo)) {
+		LOG_ERR("GPO gpio not ready");
+		return -ENODEV;
+	}
+	int ret = gpio_pin_configure_dt(&m_gpo, GPIO_INPUT);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("gpio_pin_configure_dt(gpo)", ret);
+		return ret;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&m_gpo, GPIO_INT_EDGE_BOTH);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("gpio_pin_interrupt_configure_dt(gpo)", ret);
+		return ret;
+	}
+	gpio_init_callback(&m_gpo_cb, gpo_isr, BIT(m_gpo.pin));
+	ret = gpio_add_callback(m_gpo.port, &m_gpo_cb);
+	if (ret) {
+		LOG_ERR_CALL_FAILED_INT("gpio_add_callback(gpo)", ret);
+		return ret;
+	}
+	return 0;
+}
+
 int app_nfc_init(void)
 {
 	int ret;
@@ -828,6 +883,13 @@ int app_nfc_init(void)
 			LOG_WRN("NFC: RF_WRITE_EN config failed (not used by the poll)");
 		}
 		nfc_access_end();
+	}
+
+	ret = nfc_gpo_irq_setup();
+	if (ret) {
+		LOG_WRN("NFC: GPO IRQ setup failed: %d", ret);
+	} else {
+		LOG_INF("NFC: GPO IRQ on PB12 ready");
 	}
 
 	return 0;
@@ -974,17 +1036,13 @@ int app_nfc_check(enum app_nfc_action *action)
 	return res;
 }
 
-/* Periodic main-loop NFC poll: read the tag and process any pending command /
- * config, restoring the info record otherwise.
- *
- * We deliberately do the full read every poll instead of gating on IT_STS_Dyn.
- * On this hardware IT_STS reads 0x00 on every poll (the dynamic register is
- * cleared by the LPD power-cycle that nfc_access_begin() does each poll), so it
- * never reports the phone's RF write. And a command can only be read / answered
- * over I2C while the RF field is briefly off — which IT_STS wouldn't flag
- * anyway. The poll already power-cycles the chip (150 ms LPD settle), so the
- * extra 512 B read is cheap next to that. A GPO-pin hardware interrupt would be
- * the proper low-power trigger for the production FW (see firmware issue). */
+/* NFC service pass: read the tag and process any pending command / config,
+ * restoring the info record otherwise. The poll thread calls this after
+ * app_nfc_wait_event() wakes it on the GPO interrupt (low-power; no busy
+ * polling). It always does the full read — software gating on IT_STS_Dyn is
+ * useless here (the register reads 0x00 every pass, cleared by the LPD
+ * power-cycle in nfc_access_begin), and a command can only be read / answered
+ * while the RF field is briefly off, which IT_STS wouldn't flag anyway. */
 int app_nfc_poll(enum app_nfc_action *action)
 {
 	*action = APP_NFC_ACTION_NONE;

--- a/app/src/app_nfc.h
+++ b/app/src/app_nfc.h
@@ -26,9 +26,14 @@ int app_nfc_init(void);
 /* Full check: always reads the tag. Use at boot and for on-demand checks. */
 int app_nfc_check(enum app_nfc_action *action);
 
-/* Gated poll for the periodic check: reads the 1-byte IT_STS_Dyn first and only
- * does the full read when RF activity is flagged. Cheaper when nothing changed. */
+/* Reads the tag and processes any pending command/config, restoring the info
+ * record otherwise. Run from the poll thread after app_nfc_wait_event(). */
 int app_nfc_poll(enum app_nfc_action *action);
+
+/* Block until the ST25DV GPO line signals RF activity (the phone touched the
+ * tag) or `fallback_ms` elapses. Lets the poll thread sleep instead of busy
+ * polling. Returns 0 if woken by the GPO interrupt, -EAGAIN on timeout. */
+int app_nfc_wait_event(int fallback_ms);
 
 /* Take (and clear) the deferred action requested by the last NFC command
  * (reboot/save/factory-reset). The caller runs it after the response is on the

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -37,10 +37,11 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
 #define BLINK_INTERVAL_SECONDS 3
 
-/* NFC poll runs on its own thread (not tied to the LED blink loop). Each poll
- * reads the 1-byte IT_STS_Dyn and only does a full read on RF activity, so a
- * short interval is cheap. */
-#define NFC_POLL_INTERVAL_SECONDS    2
+/* NFC poll runs on its own thread (not tied to the LED blink loop). It sleeps
+ * on the ST25DV GPO interrupt (app_nfc_wait_event) and only wakes to read the
+ * tag when the phone touches it — low power. The fallback is a safety net in
+ * case an edge is missed. */
+#define NFC_EVENT_FALLBACK_MS        30000
 #define NFC_POLL_START_DELAY_MS      3000
 #define NFC_POLL_THREAD_STACK_SIZE   3072
 #define NFC_POLL_THREAD_PRIO         K_LOWEST_APPLICATION_THREAD_PRIO
@@ -110,7 +111,9 @@ static void nfc_poll_thread_fn(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p3);
 
 	for (;;) {
-		k_sleep(K_SECONDS(NFC_POLL_INTERVAL_SECONDS));
+		/* Sleep until the GPO interrupt fires (phone touched the tag) or the
+		 * fallback elapses. */
+		app_nfc_wait_event(NFC_EVENT_FALLBACK_MS);
 
 		if (!app_nfc_periodic_enabled()) {
 			continue;


### PR DESCRIPTION
Low-power, event-driven NFC command pickup using the ST25DV **GPO** pin.

### Background
The GPO pin (U11 pin 11) is wired to **STM32 PB12 (EXTI12)** and is even marked on the schematic as an intended external-interrupt input — but the firmware never used it (it polled, and on this HW `IT_STS_Dyn` reads `0x00` every pass, so software gating is useless). PB12 is otherwise free (I2C is on PB6/PB7).

### Change
The NFC poll thread now **sleeps on the GPO interrupt** and only wakes to service the tag when the phone actually touches it:

- `app.overlay`: `nfc-gpo-gpios = <&gpiob 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>` under `zephyr,user`.
- `app_nfc.c`: configure PB12 as an edge interrupt; the ISR gives a semaphore. `app_nfc_wait_event(fallback_ms)` blocks on it.
- `main.c`: the poll thread waits on `app_nfc_wait_event()` instead of a fixed 2 s sleep (kept a 30 s fallback as a safety net).

The GPO config (`RF_WRITE_EN`, already set after #145's timing fix; `GPO_EN` + field-change are on by default) makes the pin pulse on RF write / field change — both the phone tapping and the host releasing the field between write and read.

### Validated on hardware
- GPO interrupt fires on RF activity (phone tap) — confirmed via RTT.
- Full command/response round-trip works end-to-end (GetInfo, single hold).
- **Idle = sleep:** with no RF activity (phone away / screen off) the GPO is silent and the thread only wakes on the 30 s fallback — i.e. the CPU is not busy-polling. (Observed: after screen-off, the next wake was the fallback at +30 s, no GPO wakes.)

Builds on #145 (command-channel fixes). Implements the low-power follow-up described in #144.
