### PR TITLE
fix(alarm): fire accel & PIR `state` alarms — momentary one-shot (#150)

### DIFF
--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -368,6 +368,14 @@ static bool eval_threshold(const struct app_alarm_rule *rule, struct rstate *rt,
 	return rt->active;
 }
 
+/* Momentary/pulse sources only ever assert (app_alarm_event(src, true)) and never
+ * deassert, so a STATE rule's prev->cur edge can be observed at most once. Handle
+ * them as a per-pulse one-shot in eval_state(). */
+static inline bool source_is_momentary(uint8_t source)
+{
+	return source == APP_ALARM_SRC_ACCEL || source == APP_ALARM_SRC_PIR;
+}
+
 /* STATE rule: from/to over a digital level. from != to is an edge (one-shot:
  * activate, auto-clear after alarm_notif_time, no deactivate); from == to is a
  * level (active while cur == to). */
@@ -384,6 +392,24 @@ static void eval_state(const struct app_alarm_rule *rule, struct rstate *rt, boo
 			*should_send = true;
 			alarm_collect(rule->source, rule->quantity, false, ALARM_SIDE_NONE, true,
 				      0);
+		}
+		rt->have_prev_state = true;
+		rt->prev_state = cur_lvl;
+		return;
+	}
+
+	if (source_is_momentary(rule->source)) {
+		/* Pulse source: each asserted event is a discrete trigger. Fire a one-shot
+		 * (auto-cleared after alarm_notif_time in app_alarm_poll), suppressed while a
+		 * previous one is still latched so we emit at most one alarm per notif-time
+		 * window regardless of event rate. from/to are not meaningful for a source
+		 * that never reports a level, so edge (0->1) and level (1->1) behave alike. */
+		if (cur && !rt->active) {
+			rt->active = true;
+			rt->oneshot_expiry = k_uptime_get() + notif_hold_ms();
+			*should_send = true;
+			alarm_collect(rule->source, rule->quantity, true, ALARM_SIDE_NONE, true,
+				      cur_lvl);
 		}
 		rt->have_prev_state = true;
 		rt->prev_state = cur_lvl;

--- a/app/src/app_alarm.c
+++ b/app/src/app_alarm.c
@@ -431,8 +431,8 @@ static void eval_state(uint8_t slot, const struct app_alarm_rule *rule, struct r
 			rt->active = true;
 			rt->oneshot_expiry = k_uptime_get() + notif_hold_ms();
 			*should_send = true;
-			alarm_collect(rule->source, rule->quantity, true, ALARM_SIDE_NONE, true,
-				      cur_lvl);
+			alarm_collect(slot, rule->source, rule->quantity, true, ALARM_SIDE_NONE,
+				      true, cur_lvl);
 		}
 		rt->have_prev_state = true;
 		rt->prev_state = cur_lvl;


### PR DESCRIPTION
## Problem (#150)
A dynamic `state` alarm on the **accel** or **PIR** source never raised an `AlarmReport` (fPort 3) — no frame, no alarm LED — across 47+ events including clean free-falls. A `level` rule (`from == to`) fired once then latched `active = 1` forever.

**Root cause:** accel and PIR are *momentary* sources — they only ever call `app_alarm_event(src, true)`, never `false`. `eval_state()` reassigns `prev_state` on every call, so after the first pulse `prev_state` sticks at `1` and the configured `0→1` edge never recurs. The one-shot auto-clear in `app_alarm_poll()` reset `active`/`oneshot_expiry` but not `prev_state`, so it could not re-arm either.

## Fix
Treat momentary sources as **per-pulse one-shots** in `eval_state()`: each asserted event fires a one-shot (sets `active` + `oneshot_expiry`), suppressed while a previous one is still latched, and the existing `app_alarm_poll()` auto-clear re-arms it after `alarm_notif_time`. `from/to` are not meaningful for a source that never reports a level, so edge (`0→1`) and level (`1→1`) behave alike.

Hall/input (emit both edges), slot tilt (polled), and threshold/rate paths are **unchanged**. Wire format and `app/decoder/ttn.js` are unchanged. `alarm_notif_time` bounds re-fire cadence and `alarm_limit` still rate-limits sends, so a motion burst cannot flood the alarm uplink path.

## Hardware verification (STM32WLE5CC, v1.4.0 debug image)
With `alarm set accel state 0 1` armed, a 40 s continuous shake produced **395 accelerometer events → exactly 3 fPort-3 `AlarmReport`s**, spaced ~12 s apart (`alarm_notif_time` 10 s + poll latency), all sent on port 3, all within one boot session — confirming **fire, auto-clear, re-arm, and burst flood-suppression (395 → 3)**. A decoded report reads `source=accel, quantity=state, event=activate`. PIR uses the identical `source_is_momentary` path.

## Out of scope
The separate accel-IRQ self-retrigger "storm" and the occasional mid-test reboot under sustained accel load noted in #150 are sensor/IRQ concerns independent of the alarm engine.

Closes #150
