### PR TITLE
Config bytes as native protobuf bytes (cut LRW/NFC payload) [#154]

### DIFF
--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -731,6 +731,13 @@ static int cmd_cmd_inject(const struct shell *sh, enum app_cmd_transport transpo
 
 	LOG_HEXDUMP_INF(out, out_len, "Response:");
 
+	/* Mirror the response to the shell terminal as one hex line. The log channel
+	 * can drop the INF hexdump under debug-level noise, so this is the reliable
+	 * way to capture the Response for an over-the-wire round-trip check. */
+	char resp_hex[2 * sizeof(out) + 1];
+	bin2hex(out, out_len, resp_hex, sizeof(resp_hex));
+	shell_print(sh, "RESP %s", resp_hex);
+
 	/* Don't reboot the bench from a shell inject — just report what an LRW
 	 * downlink would trigger. Use `settings save` / `settings reset` to apply. */
 	if (action != APP_CMD_ACTION_NONE) {

--- a/app/src/app_config.options.in
+++ b/app/src/app_config.options.in
@@ -1,15 +1,15 @@
 # BEGIN GENERATED CONFIG
-AppConfigMessage.Lorawan.deveui max_length:16
-AppConfigMessage.Lorawan.joineui max_length:16
-AppConfigMessage.Lorawan.nwkkey max_length:32
-AppConfigMessage.Lorawan.appkey max_length:32
-AppConfigMessage.Lorawan.devaddr max_length:8
-AppConfigMessage.Lorawan.nwkskey max_length:32
-AppConfigMessage.Lorawan.appskey max_length:32
-AppConfigMessage.Sensors.sensor1_rom max_length:16
-AppConfigMessage.Sensors.sensor2_rom max_length:16
-AppConfigMessage.Sensors.sensor3_rom max_length:16
-AppConfigMessage.Sensors.sensor4_rom max_length:16
+AppConfigMessage.Lorawan.deveui max_size:8 fixed_length:true
+AppConfigMessage.Lorawan.joineui max_size:8 fixed_length:true
+AppConfigMessage.Lorawan.nwkkey max_size:16 fixed_length:true
+AppConfigMessage.Lorawan.appkey max_size:16 fixed_length:true
+AppConfigMessage.Lorawan.devaddr max_size:4 fixed_length:true
+AppConfigMessage.Lorawan.nwkskey max_size:16 fixed_length:true
+AppConfigMessage.Lorawan.appskey max_size:16 fixed_length:true
+AppConfigMessage.Sensors.sensor1_rom max_size:8 fixed_length:true
+AppConfigMessage.Sensors.sensor2_rom max_size:8 fixed_length:true
+AppConfigMessage.Sensors.sensor3_rom max_size:8 fixed_length:true
+AppConfigMessage.Sensors.sensor4_rom max_size:8 fixed_length:true
 # END GENERATED CONFIG
 
 Response.Error.detail       max_size:32

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -32,13 +32,13 @@ message AppConfigMessage {
         optional Network network = 2;
         optional bool adr = 3;
         optional Activation activation = 4;
-        optional string deveui = 5;
-        optional string joineui = 6;
-        optional string nwkkey = 7;
-        optional string appkey = 8;
-        optional string devaddr = 9;
-        optional string nwkskey = 10;
-        optional string appskey = 11;
+        optional bytes deveui = 5;
+        optional bytes joineui = 6;
+        optional bytes nwkkey = 7;
+        optional bytes appkey = 8;
+        optional bytes devaddr = 9;
+        optional bytes nwkskey = 10;
+        optional bytes appskey = 11;
         optional uint32 sub_band = 12;
         optional uint32 link_check_interval = 13;
         optional uint32 link_check_fail_rejoin = 14;
@@ -75,10 +75,10 @@ message AppConfigMessage {
         optional bool cap_pir_detector = 46;
         optional MotionSensitivity accel_motion_sensitivity = 54;
         optional bool cap_accelerometer = 55;
-        optional string sensor1_rom = 56;
-        optional string sensor2_rom = 57;
-        optional string sensor3_rom = 58;
-        optional string sensor4_rom = 59;
+        optional bytes sensor1_rom = 56;
+        optional bytes sensor2_rom = 57;
+        optional bytes sensor3_rom = 58;
+        optional bytes sensor4_rom = 59;
         optional bool cap_w1_sensors = 60;
     }
 

--- a/app/src/app_config_ingest.c
+++ b/app/src/app_config_ingest.c
@@ -36,37 +36,6 @@ LOG_MODULE_REGISTER(app_config_ingest, LOG_LEVEL_DBG);
 		ret = -EINVAL;                                                                     \
 	} while (0)
 
-static bool parse_hex_string(const char *hex_str, uint8_t *buf, size_t buf_len)
-{
-	if (!hex_str || !buf) {
-		return false;
-	}
-
-	size_t str_len = strlen(hex_str);
-	if (str_len != 2 * buf_len) {
-		LOG_ERR("Invalid hex string length: expected %zu, got %zu", 2 * buf_len, str_len);
-		return false;
-	}
-
-	/* Decode into a temp buffer first: hex2bin writes byte-by-byte into the
-	 * destination and bails (returning 0) on the first invalid nibble, so
-	 * decoding straight into the config field would leave a half-overwritten
-	 * value that a later save would persist (#91). Commit only on full success. */
-	uint8_t tmp[16];
-	if (buf_len > sizeof(tmp)) {
-		LOG_ERR("hex buffer too large: %zu", buf_len);
-		return false;
-	}
-
-	if (hex2bin(hex_str, str_len, tmp, buf_len) != buf_len) {
-		LOG_ERR_CALL_FAILED("hex2bin");
-		return false;
-	}
-
-	memcpy(buf, tmp, buf_len);
-	return true;
-}
-
 static bool requested(const uint32_t *ids, size_t n, uint32_t tag)
 {
 	for (size_t i = 0; i < n; i++) {
@@ -110,33 +79,33 @@ int app_config_apply_lorawan(const AppConfigMessage_Lorawan *src, uint32_t *faul
 			FAULT(4);
 		}
 	}
-	if (src->has_deveui &&
-	    !parse_hex_string(src->deveui, config->lrw_deveui, sizeof(config->lrw_deveui))) {
-		FAULT(5);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_deveui) {
+		memcpy(config->lrw_deveui, src->deveui, sizeof(config->lrw_deveui));
 	}
-	if (src->has_joineui &&
-	    !parse_hex_string(src->joineui, config->lrw_joineui, sizeof(config->lrw_joineui))) {
-		FAULT(6);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_joineui) {
+		memcpy(config->lrw_joineui, src->joineui, sizeof(config->lrw_joineui));
 	}
-	if (src->has_nwkkey &&
-	    !parse_hex_string(src->nwkkey, config->lrw_nwkkey, sizeof(config->lrw_nwkkey))) {
-		FAULT(7);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_nwkkey) {
+		memcpy(config->lrw_nwkkey, src->nwkkey, sizeof(config->lrw_nwkkey));
 	}
-	if (src->has_appkey &&
-	    !parse_hex_string(src->appkey, config->lrw_appkey, sizeof(config->lrw_appkey))) {
-		FAULT(8);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_appkey) {
+		memcpy(config->lrw_appkey, src->appkey, sizeof(config->lrw_appkey));
 	}
-	if (src->has_devaddr &&
-	    !parse_hex_string(src->devaddr, config->lrw_devaddr, sizeof(config->lrw_devaddr))) {
-		FAULT(9);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_devaddr) {
+		memcpy(config->lrw_devaddr, src->devaddr, sizeof(config->lrw_devaddr));
 	}
-	if (src->has_nwkskey &&
-	    !parse_hex_string(src->nwkskey, config->lrw_nwkskey, sizeof(config->lrw_nwkskey))) {
-		FAULT(10);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_nwkskey) {
+		memcpy(config->lrw_nwkskey, src->nwkskey, sizeof(config->lrw_nwkskey));
 	}
-	if (src->has_appskey &&
-	    !parse_hex_string(src->appskey, config->lrw_appskey, sizeof(config->lrw_appskey))) {
-		FAULT(11);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_appskey) {
+		memcpy(config->lrw_appskey, src->appskey, sizeof(config->lrw_appskey));
 	}
 	if (src->has_sub_band) {
 		int val = src->sub_band;
@@ -190,15 +159,15 @@ void app_config_fill_lorawan(AppConfigMessage_Lorawan *dst, const uint32_t *ids,
 	}
 	if (requested(ids, n, 5)) {
 		dst->has_deveui = true;
-		bin2hex(c->lrw_deveui, sizeof(c->lrw_deveui), dst->deveui, sizeof(dst->deveui));
+		memcpy(dst->deveui, c->lrw_deveui, sizeof(c->lrw_deveui));
 	}
 	if (requested(ids, n, 6)) {
 		dst->has_joineui = true;
-		bin2hex(c->lrw_joineui, sizeof(c->lrw_joineui), dst->joineui, sizeof(dst->joineui));
+		memcpy(dst->joineui, c->lrw_joineui, sizeof(c->lrw_joineui));
 	}
 	if (requested(ids, n, 9)) {
 		dst->has_devaddr = true;
-		bin2hex(c->lrw_devaddr, sizeof(c->lrw_devaddr), dst->devaddr, sizeof(dst->devaddr));
+		memcpy(dst->devaddr, c->lrw_devaddr, sizeof(c->lrw_devaddr));
 	}
 	if (requested(ids, n, 12)) {
 		dst->has_sub_band = true;
@@ -321,21 +290,21 @@ int app_config_apply_sensors(const AppConfigMessage_Sensors *src, uint32_t *faul
 	if (src->has_cap_accelerometer) {
 		config->cap_accelerometer = src->cap_accelerometer;
 	}
-	if (src->has_sensor1_rom &&
-	    !parse_hex_string(src->sensor1_rom, config->sensor1_rom, sizeof(config->sensor1_rom))) {
-		FAULT(56);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_sensor1_rom) {
+		memcpy(config->sensor1_rom, src->sensor1_rom, sizeof(config->sensor1_rom));
 	}
-	if (src->has_sensor2_rom &&
-	    !parse_hex_string(src->sensor2_rom, config->sensor2_rom, sizeof(config->sensor2_rom))) {
-		FAULT(57);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_sensor2_rom) {
+		memcpy(config->sensor2_rom, src->sensor2_rom, sizeof(config->sensor2_rom));
 	}
-	if (src->has_sensor3_rom &&
-	    !parse_hex_string(src->sensor3_rom, config->sensor3_rom, sizeof(config->sensor3_rom))) {
-		FAULT(58);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_sensor3_rom) {
+		memcpy(config->sensor3_rom, src->sensor3_rom, sizeof(config->sensor3_rom));
 	}
-	if (src->has_sensor4_rom &&
-	    !parse_hex_string(src->sensor4_rom, config->sensor4_rom, sizeof(config->sensor4_rom))) {
-		FAULT(59);
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_sensor4_rom) {
+		memcpy(config->sensor4_rom, src->sensor4_rom, sizeof(config->sensor4_rom));
 	}
 	if (src->has_cap_w1_sensors) {
 		config->cap_w1_sensors = src->cap_w1_sensors;
@@ -386,23 +355,19 @@ void app_config_fill_sensors(AppConfigMessage_Sensors *dst, const uint32_t *ids,
 	}
 	if (requested(ids, n, 56)) {
 		dst->has_sensor1_rom = true;
-		bin2hex(c->sensor1_rom, sizeof(c->sensor1_rom), dst->sensor1_rom,
-			sizeof(dst->sensor1_rom));
+		memcpy(dst->sensor1_rom, c->sensor1_rom, sizeof(c->sensor1_rom));
 	}
 	if (requested(ids, n, 57)) {
 		dst->has_sensor2_rom = true;
-		bin2hex(c->sensor2_rom, sizeof(c->sensor2_rom), dst->sensor2_rom,
-			sizeof(dst->sensor2_rom));
+		memcpy(dst->sensor2_rom, c->sensor2_rom, sizeof(c->sensor2_rom));
 	}
 	if (requested(ids, n, 58)) {
 		dst->has_sensor3_rom = true;
-		bin2hex(c->sensor3_rom, sizeof(c->sensor3_rom), dst->sensor3_rom,
-			sizeof(dst->sensor3_rom));
+		memcpy(dst->sensor3_rom, c->sensor3_rom, sizeof(c->sensor3_rom));
 	}
 	if (requested(ids, n, 59)) {
 		dst->has_sensor4_rom = true;
-		bin2hex(c->sensor4_rom, sizeof(c->sensor4_rom), dst->sensor4_rom,
-			sizeof(dst->sensor4_rom));
+		memcpy(dst->sensor4_rom, c->sensor4_rom, sizeof(c->sensor4_rom));
 	}
 	if (requested(ids, n, 60)) {
 		dst->has_cap_w1_sensors = true;

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -337,6 +337,8 @@ The TTN/ChirpStack payload formatter (`app/decoder/ttn.js`) was extended for v1.
 
 `encodeDownlink` returns `{ bytes, fPort: 85, warnings, errors }`.
 
+**Binary config fields are native `bytes` (v1.4.0).** DevEUI, the LoRaWAN keys, DevAddr and the 1-Wire ROMs travel as native protobuf `bytes` on the wire — raw bytes, half the size of the previous hex-string encoding — which trims fPort-85 config payloads and NFC-tag usage. No change for formatter users: `encodeDownlink` still accepts these as hex strings and `decodeUplink`/`decodeDownlink` still present them as hex. Only clients that build the protobuf directly (e.g. the NFC manager app) must send and read raw bytes.
+
 ---
 
 ## 9. Shell command summary (v1.4.0 changes)

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -364,6 +364,12 @@ def _proto_type(param, enum_proto_name):
     ptype = param.get("type")
     if ptype == "enum":
         return enum_proto_name[param["enum"]]
+    # Non-callback bytes use native protobuf `bytes` (nanopb fixed_length, see
+    # build_options_lines) to avoid the 2x hex-string overhead on the wire.
+    # Callback bytes (e.g. secret_key) stay `string` — their hand-written
+    # callback handles the raw stream and they are off the SetParam/dump paths.
+    if ptype == "bytes" and not param.get("proto_callback"):
+        return "bytes"
     return PROTO_SCALAR.get(ptype, "uint32")
 
 
@@ -598,8 +604,10 @@ def build_ingest_model(config):
 
 
 def build_options_lines(config):
-    """nanopb max_length options for hex-key (bytes) fields. Fields flagged
-    `proto_callback: true` are left as nanopb callbacks (no option emitted)."""
+    """nanopb options for bytes fields: native `bytes` with fixed_length (a plain
+    `pb_byte_t[size]`, no length word) — half the wire size of the old hex string
+    and the C struct stays `uint8_t[size]`. Fields flagged `proto_callback: true`
+    are left as nanopb callbacks (no option emitted)."""
     proto, gmap = _proto_groups(config)
     msg = proto["message"]
     lines = []
@@ -610,7 +618,7 @@ def build_options_lines(config):
         fname = _proto_field_name(p, g)
         path = (f"{msg}.{fname}" if g["key"] == "root"
                 else f"{msg}.{g['message']}.{fname}")
-        lines.append(f"{path} max_length:{p['size'] * 2}")
+        lines.append(f"{path} max_size:{p['size']} fixed_length:true")
     return lines
 
 

--- a/scripts/west_commands/templates/config_ingest.c.j2
+++ b/scripts/west_commands/templates/config_ingest.c.j2
@@ -36,37 +36,6 @@ LOG_MODULE_REGISTER({{ module.name }}_ingest, LOG_LEVEL_DBG);
 		ret = -EINVAL;                                                                     \
 	} while (0)
 
-static bool parse_hex_string(const char *hex_str, uint8_t *buf, size_t buf_len)
-{
-	if (!hex_str || !buf) {
-		return false;
-	}
-
-	size_t str_len = strlen(hex_str);
-	if (str_len != 2 * buf_len) {
-		LOG_ERR("Invalid hex string length: expected %zu, got %zu", 2 * buf_len, str_len);
-		return false;
-	}
-
-	/* Decode into a temp buffer first: hex2bin writes byte-by-byte into the
-	 * destination and bails (returning 0) on the first invalid nibble, so
-	 * decoding straight into the config field would leave a half-overwritten
-	 * value that a later save would persist (#91). Commit only on full success. */
-	uint8_t tmp[16];
-	if (buf_len > sizeof(tmp)) {
-		LOG_ERR("hex buffer too large: %zu", buf_len);
-		return false;
-	}
-
-	if (hex2bin(hex_str, str_len, tmp, buf_len) != buf_len) {
-		LOG_ERR_CALL_FAILED("hex2bin");
-		return false;
-	}
-
-	memcpy(buf, tmp, buf_len);
-	return true;
-}
-
 static bool requested(const uint32_t *ids, size_t n, uint32_t tag)
 {
 	for (size_t i = 0; i < n; i++) {
@@ -101,9 +70,9 @@ int {{ g.apply_fn }}(const {{ g.c_message }} *src, uint32_t *fault_field)
 		}
 	}
 {% elif p.kind == 'bytes' %}
-	if (src->has_{{ p.proto_name }} &&
-	    !parse_hex_string(src->{{ p.proto_name }}, config->{{ p.c_name }}, sizeof(config->{{ p.c_name }}))) {
-		FAULT({{ p.tag }});
+	/* Native fixed_length bytes: nanopb decodes exactly sizeof(field) bytes. */
+	if (src->has_{{ p.proto_name }}) {
+		memcpy(config->{{ p.c_name }}, src->{{ p.proto_name }}, sizeof(config->{{ p.c_name }}));
 	}
 {% elif p.kind == 'float' %}
 	if (src->has_{{ p.proto_name }}) {
@@ -140,8 +109,7 @@ void {{ g.fill_fn }}({{ g.c_message }} *dst, const uint32_t *ids, size_t n)
 {% if p.kind == 'bytes' %}
 	if (requested(ids, n, {{ p.tag }})) {
 		dst->has_{{ p.proto_name }} = true;
-		bin2hex(c->{{ p.c_name }}, sizeof(c->{{ p.c_name }}), dst->{{ p.proto_name }},
-			sizeof(dst->{{ p.proto_name }}));
+		memcpy(dst->{{ p.proto_name }}, c->{{ p.c_name }}, sizeof(c->{{ p.c_name }}));
 	}
 {% elif p.kind == 'enum' %}
 	if (requested(ids, n, {{ p.tag }})) {

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -69,20 +69,21 @@ def workdir(tmp_path):
 def test_build_options_lines_matches_committed():
     cfg = _load_config()
     lines = configen.build_options_lines(cfg)
-    # The 7 hex Lorawan keys + the 4 per-slot 1-Wire ROM keys get max_length;
+    # The 7 LoRaWAN keys + the 4 per-slot 1-Wire ROM keys are native bytes with
+    # nanopb fixed_length (plain pb_byte_t[size], half the old hex wire size);
     # secret_key is a callback. Order-independent (config declaration order).
     assert sorted(lines) == sorted([
-        "AppConfigMessage.Lorawan.deveui max_length:16",
-        "AppConfigMessage.Lorawan.joineui max_length:16",
-        "AppConfigMessage.Lorawan.nwkkey max_length:32",
-        "AppConfigMessage.Lorawan.appkey max_length:32",
-        "AppConfigMessage.Lorawan.devaddr max_length:8",
-        "AppConfigMessage.Lorawan.nwkskey max_length:32",
-        "AppConfigMessage.Lorawan.appskey max_length:32",
-        "AppConfigMessage.Sensors.sensor1_rom max_length:16",
-        "AppConfigMessage.Sensors.sensor2_rom max_length:16",
-        "AppConfigMessage.Sensors.sensor3_rom max_length:16",
-        "AppConfigMessage.Sensors.sensor4_rom max_length:16",
+        "AppConfigMessage.Lorawan.deveui max_size:8 fixed_length:true",
+        "AppConfigMessage.Lorawan.joineui max_size:8 fixed_length:true",
+        "AppConfigMessage.Lorawan.nwkkey max_size:16 fixed_length:true",
+        "AppConfigMessage.Lorawan.appkey max_size:16 fixed_length:true",
+        "AppConfigMessage.Lorawan.devaddr max_size:4 fixed_length:true",
+        "AppConfigMessage.Lorawan.nwkskey max_size:16 fixed_length:true",
+        "AppConfigMessage.Lorawan.appskey max_size:16 fixed_length:true",
+        "AppConfigMessage.Sensors.sensor1_rom max_size:8 fixed_length:true",
+        "AppConfigMessage.Sensors.sensor2_rom max_size:8 fixed_length:true",
+        "AppConfigMessage.Sensors.sensor3_rom max_size:8 fixed_length:true",
+        "AppConfigMessage.Sensors.sensor4_rom max_size:8 fixed_length:true",
     ])
     assert not any("secret_key" in ln for ln in lines)
 
@@ -280,6 +281,48 @@ def _decode_with_node(hex_str):
     out = subprocess.check_output(["node", "-e", js], text=True)
     import json
     return json.loads(out)
+
+
+def _encode_with_node(data):
+    import json
+    js = (
+        "const fs=require('fs'),vm=require('vm');"
+        "const ctx={Buffer,console};vm.createContext(ctx);"
+        f"vm.runInContext(fs.readFileSync({str(DECODER)!r},'utf8'),ctx);"
+        f"const r=ctx.encodeDownlink({{data:{json.dumps(data)}}});"
+        "if(r.errors&&r.errors.length)throw new Error(r.errors.join(','));"
+        "process.stdout.write(Buffer.from(r.bytes).toString('hex'));"
+    )
+    return subprocess.check_output(["node", "-e", js], text=True)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_bytes_fields_native_roundtrip(tmp_path):
+    """Config `bytes` params go on the wire as native protobuf bytes (not a hex
+    string), so the payload is half the size. The ttn.js decoder keeps its hex
+    contract (hexes the raw bytes for output; accepts hex on encode). Verify both
+    directions agree between python-protobuf and ttn.js."""
+    pb = _compile_proto(tmp_path)
+
+    # python encodes raw bytes -> ttn.js decode must present them as hex
+    cmd = pb.Command()
+    cmd.seq = 9
+    cmd.set_param.lorawan.deveui = bytes.fromhex("70b3d5470a0b0c0d")
+    cmd.set_param.sensors.sensor1_rom = bytes.fromhex("28000011223344a5")
+    wire = cmd.SerializeToString()
+    # native bytes: deveui occupies 8 payload bytes, not 16 hex chars
+    assert b"70b3d5470a0b0c0d" not in wire  # not ASCII hex on the wire
+    js = _decode_with_node(wire.hex())
+    assert js["set_param"]["lorawan"]["deveui"] == "70b3d5470a0b0c0d"
+    assert js["set_param"]["sensors"]["sensor1_rom"] == "28000011223344a5"
+
+    # ttn.js encodes hex -> python protobuf must read the raw bytes
+    enc = _encode_with_node({
+        "command": "set_param",
+        "set_param": {"lorawan": {"deveui": "70b3d5470a0b0c0d"}},
+    })
+    msg = pb.Command.FromString(bytes.fromhex(enc))
+    assert msg.set_param.lorawan.deveui == bytes.fromhex("70b3d5470a0b0c0d")
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not available")


### PR DESCRIPTION
> Draft for #154. Design decided (see below); ready to implement on approval.

## Goal
Encode config `bytes` parameters as **native protobuf `bytes`** instead of `string`-carrying-hex,
halving their on-wire size. Saves airtime on **fPort 85** (config SetParam/GetParam/ConfigDump)
and space on the **NFC tag**. Does **not** touch fPort 2/3 (no bytes fields there). Analysis in #154.

## Feasibility (verified)
nanopb `fixed_length` is supported in this version (`nanopb.proto`), so `bytes` +
`max_size:N fixed_length:true` generates a plain `pb_byte_t[N]` → the C struct stays
`uint8_t field[N]` and the ~133 access sites are unchanged. NVS unchanged (already raw).

## Decisions
- **Scope: ALL bytes fields at once** — `deveui, joineui, devaddr, nwkkey, appkey, nwkskey,
  appskey, secret_key, sensor1..4_rom, alarm_0..15`. No mixed encoding.
- **Decoder (ttn.js): keep hex in/out** — decode reads raw bytes → `_pbBytesToHex` for output;
  encode takes hex → `_hexToBytes` → packs native bytes. TTN/ChirpStack integrations unaffected.
- **manager-app: tracked separately** — breaking contract change filed as
  manager-app#22 (gitlab tester/manager-app), to land with NFC-encryption #135.
- **Shell stays hex**; **no migration** (v1.4.0 unreleased); base **v1.4.0**.

## Implementation touch points
1. `configen.py`: `PROTO_SCALAR` bytes→`"bytes"`; `_proto_type`; `build_options_lines` →
   `max_size:N fixed_length:true` (instead of `max_length:N*2`).
2. `templates/config.proto.j2`: `optional bytes` instead of `optional string`.
3. `templates/config_ingest.c.j2`: apply → `memcpy` instead of `parse_hex_string`; fill →
   `memcpy` instead of `bin2hex`.
4. `templates/config.c.j2`: keep shell `bin2hex`/`hex2bin` against the C array.
5. `ttn.js`: decode `_pbBytesToHex(slice)` (already), encode `_hexToBytes` (already) — verify
   wire reads/writes raw bytes; keep external hex contract.
6. Regenerate (local python driver), update pytest options/roundtrip expectations.

## Verification
- pytest (options + roundtrip), node decoder tests, clang-format.
- release + debug build size (should shrink slightly).
- HW: SetParam/GetParam round-trip of a hex field (deveui) over ChirpStack + NFC.