### PR TITLE
doc(nfc): document power-off provisioning (boot-staged config) (#147)

### DIFF
--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -1251,6 +1251,26 @@ wakes the poll thread on a tap and the device idles (low power) otherwise.
 
 - [ ] Pass
 
+### N7 — Provisioning while powered off (boot-staged config, #147)
+
+**Goal:** A STICKER written over NFC while **unpowered** self-configures on the next boot, before
+the LoRaWAN stack starts, with nonce anti-replay.
+**Observable:** A config/command record written to the tag with the MCU off is applied on the next
+boot (yellow NFC carousel), persisted, and cleared from the tag (info record restored); a stale/replay
+record is rejected and the device still boots normally.
+
+**Prompt for Claude (needs the Manager-App phone + a way to remove device power — not bench/J-Link testable):**
+> With the device **fully powered off** (battery out, J-Link disconnected so SWD can't back-power it),
+> use the Manager-App to write an (encrypted) `set_param` (e.g. `lorawan.adr` toggled, `save=true`) to
+> the tag and confirm the bytes read back. Power the device on with **no further phone interaction**
+> and confirm: the yellow NFC carousel blinks, the new value is persisted (read it back over shell/NFC),
+> the tag no longer holds the staged record (info record restored), and — because the early boot check
+> runs before LoRaWAN — staged LoRaWAN keys take effect on the first join. Then power-cycle again and
+> confirm the config is **not** re-applied (nonce anti-replay) and the device boots normally. Report
+> results, including that the **encrypted** path (decrypt + nonce at boot) works end-to-end.
+
+- [ ] Pass
+
 ---
 
 ## Payload formatter (`ttn.js`)

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -454,6 +454,15 @@ A phone's Web NFC reader sees each as `record.recordType === "hio.stck:…"`.
 - The keys are flagged `dump_nfc_only`: the dump path emits them only when the transport is NFC. A `get_config`/`get_param` arriving as a **LoRaWAN downlink never selects the key tags**, so they can never leave in an uplink — important because the fPort-85 payload is plain protobuf (the LoRaWAN MAC layer would expose the keys to the network server). The DevEUI/JoinEUI/DevAddr identifiers remain readable over both transports as before.
 - **`secret_key` itself is never readable** on any transport (it is the master key for the whole NFC channel).
 
+**Provisioning while powered off (boot-staged config).** Because the ST25DV is powered by the phone's RF field, a STICKER can be configured **while it is unpowered** — on the shelf, before first power-on, or with the battery removed. A phone (Manager-App) writes a config record (`hio.stck:cfg`) or a command record (`hio.stck:cmd`, e.g. `set_param … save=true`) into the tag's user EEPROM over RF; the write lands and persists with no MCU power. On the **next boot** the firmware applies it:
+
+- The boot sequence runs a synchronous NFC check (`app_nfc_check()` in `main.c`) **early — before the LED boot carousel and before the LoRaWAN stack starts** — so a staged config (including LoRaWAN keys) takes effect *before the first join attempt*, not one poll cycle later.
+- A staged config is decrypted and **nonce-checked** (same anti-replay as the runtime channel: `nonce_counter` must be strictly greater than the last accepted, then it is persisted), applied through the same config-ingest path, persisted (`settings_save`, which reboots), and the staged record is **cleared** (the plaintext info record is restored) so it is not re-applied on the following boot.
+- A **stale or replayed** record left on the tag is rejected by the nonce check on every boot; the firmware logs it and **continues booting** (it never bricks into a reboot loop).
+- The yellow NFC LED carousel blinks when a staged config is applied, as operator feedback.
+- If the device is already running when the tag is written, the same record is picked up by the normal low-power poll instead (on the GPO interrupt, or within the ~30 s fallback).
+
+Notes: the payload budget is the same ~400–450 B as the runtime config channel; `secret_key` is **not** applied via a config record (the ingest ignores it — key provisioning is handled separately); and the phone must supply the correct `nonce_counter` (it is not exposed in the plaintext info record today). HW feasibility — RF read/write with the MCU fully unpowered, and auto-apply on the next boot — is confirmed on hardware (see #147); an end-to-end pass of the **encrypted** boot-staging path is still pending.
 ---
 
 ## Debug auto-suspend / deep sleep (NEW)


### PR DESCRIPTION
## Summary

Documents the **power-off provisioning** capability requested in #147 — configuring a STICKER while it is unpowered, applied on the next boot.

### Discussion finding: the mechanism is already implemented on v1.4.0

Analysing the current code (not the `sticker-v140real` branch the issue was filed against), the proposed behaviour is **already in place**:

| #147 proposed behaviour | v1.4.0 state |
|--|--|
| Early boot config check (before the poll thread) | `main.c` runs `app_nfc_check()` synchronously **before the LED boot carousel and before the LoRaWAN stack starts** |
| Apply + persist + clear staged record | `nfc_check_locked()` ingests the record, `app_settings_save()` persists (reboots), and the staged record is cleared (info record restored) |
| Anti-replay | `decrypt()` requires a strictly-greater `nonce_counter`; a stale/replay record is rejected on every boot and the device **still boots** (no reboot loop) |
| Staged config before the first join | the boot check runs before app_lrw init → provisioned LoRaWAN keys apply before the first join attempt |
| Partial-write robustness | unrecognized-data debounce (`m_unknown_count`) |
| Operator indication | yellow NFC LED carousel on apply |
| HW feasibility (RF write with MCU off) | confirmed on hardware (#147 comment) |

So per the discussion, this PR is **documentation only** — no code change.

## Changes

- `doc/version 1.4.md` §10: new subsection *"Provisioning while powered off (boot-staged config)"*.
- `doc/manual-test-plan.md`: **N7** — power-off provisioning test (needs the Manager-App phone).

## Follow-up (deferred)

End-to-end HW verification of the **encrypted** boot-staging path (the existing HW proof in #147 used the plaintext validation build). #147 stays open until that pass is done.