### PR TITLE
feat(nfc): enter_standby — NFC standby, wake on NFC tap (#156)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -140,6 +140,7 @@ var _CMD_NAMES = {
   18: "enter_calibration",
   19: "enter_mailbox",
   20: "exit_mailbox",
+  21: "enter_standby",
 };
 // END GENERATED COMMANDS
 var _CMD_TAGS = _invert(_CMD_NAMES);

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -5,6 +5,10 @@ CONFIG_MAIN_STACK_SIZE=4096
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 
 CONFIG_REBOOT=y
+# Builds app_power.c, which provides the NFC standby (Stop2) path (#156). Also
+# enables sys_poweroff(); coexists with PM (PM = idle Stop modes, POWEROFF =
+# explicit shutdown). Standby itself uses Stop2 + reboot, not poweroff.
+CONFIG_POWEROFF=y
 CONFIG_I2C=y
 CONFIG_SENSOR=y
 CONFIG_PM=y

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -632,6 +632,10 @@ static void app_cmd_dispatch(enum app_cmd_transport tp, const Command *cmd, Resp
 		*action = APP_CMD_ACTION_LEAVE_MAILBOX;
 		resp->which_body = Response_ack_tag;
 		break;
+	case Command_enter_standby_tag:
+		*action = APP_CMD_ACTION_ENTER_STANDBY;
+		resp->which_body = Response_ack_tag;
+		break;
 	default:
 		LOG_WRN("Command tag %u not implemented", cmd->which_body);
 		make_error(resp, Response_Error_Code_UNKNOWN, "not implemented");

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -41,6 +41,7 @@ enum app_cmd_action {
 	APP_CMD_ACTION_COUNTERS_SAVE, /* persist pulse totalizers (no reboot) */
 	APP_CMD_ACTION_ENTER_MAILBOX, /* switch to mailbox (FTM) serving mode */
 	APP_CMD_ACTION_LEAVE_MAILBOX, /* end mailbox serving (phone done streaming) */
+	APP_CMD_ACTION_ENTER_STANDBY, /* NFC-triggered standby (Stop2), wake on NFC tap (#156) */
 };
 
 /* Plain-C device info snapshot (no protobuf dependency), filled by

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -160,6 +160,7 @@ message Command {
         EnterCalibration enter_calibration = 18;
         EnterMailbox     enter_mailbox     = 19;
         ExitMailbox      exit_mailbox      = 20;
+        EnterStandby     enter_standby     = 21;
     }
 // END GENERATED COMMANDS
 
@@ -233,6 +234,14 @@ message Command {
     // when the phone has finished streaming, so the device drops straight back to
     // the low-power NDEF poll instead of waiting out the idle timeout.
     message ExitMailbox { }
+
+    // Enter a user-initiated standby (off-like) state: the device tears down the
+    // radio/sensors/LEDs and enters STM32WL Stop2 (lowest practical power that an
+    // NFC tap can still wake — the ST25DV GPO is on an EXTI pin, not a WKUP pin,
+    // so true Shutdown can't be woken by NFC). A subsequent NFC field (phone tap)
+    // wakes the MCU via the GPO EXTI and the device reboots into normal operation.
+    // RAM-only: a power-cycle / NRST also exits standby. NFC-only command (#156).
+    message EnterStandby { }
 }
 
 message Response {

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -146,6 +146,7 @@ commands:
     - {name: enter_calibration, proto_id: 18, body: EnterCalibration, kind: action, action: ENTER_CALIBRATION, response: ack, transports: [lrw, nfc]}
     - {name: enter_mailbox,  proto_id: 19, body: EnterMailbox,  kind: action,  action: ENTER_MAILBOX, response: ack, transports: [nfc]}
     - {name: exit_mailbox,   proto_id: 20, body: ExitMailbox,   kind: action,  action: LEAVE_MAILBOX, response: ack, transports: [nfc]}
+    - {name: enter_standby,  proto_id: 21, body: EnterStandby,  kind: action,  action: ENTER_STANDBY, response: ack, transports: [nfc]}
 parameters:
   - name: secret_key
     proto_group: root

--- a/app/src/app_nfc.c
+++ b/app/src/app_nfc.c
@@ -109,9 +109,14 @@ static const char *cmd_action_str(enum app_cmd_action a)
 /* Static system config (device E1 0x57). Writing it needs an open I2C security
  * session (present password). GPO bit6 RF_WRITE_EN makes RF EEPROM writes show
  * up in IT_STS_Dyn, letting the poll gate on writes specifically. */
-#define ST25DV_GPO_REG         0x0000
-#define ST25DV_GPO_RF_WRITE_EN 0x40
-#define ST25DV_I2C_PWD_REG     0x0900
+#define ST25DV_GPO_REG             0x0000
+#define ST25DV_GPO_RF_WRITE_EN     0x40
+/* GPO bit3 FIELD_CHANGE_EN: pulse the GPO pin whenever the RF field appears or
+ * disappears (i.e. a phone tap), independent of any EEPROM access. bit7 GPO_EN
+ * gates the GPO output entirely. Used to wake the MCU from Stop2 on a tap (#156). */
+#define ST25DV_GPO_FIELD_CHANGE_EN 0x08
+#define ST25DV_GPO_EN              0x80
+#define ST25DV_I2C_PWD_REG         0x0900
 
 /* Mailbox / Fast Transfer Mode (FTM). A 256 B dual-port RAM that the RF and I2C
  * sides exchange messages through *while the RF field is present* (unlike user
@@ -466,6 +471,65 @@ static void nfc_access_end(void)
 	}
 
 	k_mutex_unlock(&m_lock);
+}
+
+/* Arm the ST25DV GPO to pulse on any RF field change (a phone tap), so the GPO
+ * EXTI line can wake the MCU from Stop2 — the NFC-standby wake source (#156).
+ * Sets GPO_EN | FIELD_CHANGE_EN (read-modify-write, preserving RF_WRITE_EN).
+ *
+ * On success the ST25DV is left POWERED (LPD low) so it keeps detecting the RF
+ * field while the MCU sleeps, and the access mutex is released (the caller is
+ * about to enter Stop2 and reboot on wake, so nothing else touches the tag). On
+ * failure LPD is raised and the mutex released as usual. */
+int app_nfc_arm_field_wake(void)
+{
+	static const uint8_t default_pwd[8] = {0};
+
+	int ret = nfc_access_begin();
+	if (ret) {
+		return ret;
+	}
+
+	ret = nfc_present_password(default_pwd);
+	if (ret) {
+		goto fail;
+	}
+	k_msleep(15);
+
+	uint8_t gpo;
+	ret = read_reg(ST25DV_GPO_REG, &gpo, 1);
+	if (ret) {
+		goto fail;
+	}
+
+	uint8_t want = gpo | ST25DV_GPO_EN | ST25DV_GPO_FIELD_CHANGE_EN;
+	if (want != gpo) {
+		ret = write_reg(ST25DV_GPO_REG, &want, 1);
+		if (ret) {
+			goto fail;
+		}
+		k_msleep(ST25DV_TW_MS_PER_PAGE + 5);
+
+		uint8_t check = 0;
+		ret = read_reg(ST25DV_GPO_REG, &check, 1);
+		if (ret) {
+			goto fail;
+		}
+		if ((check & (ST25DV_GPO_EN | ST25DV_GPO_FIELD_CHANGE_EN)) !=
+		    (ST25DV_GPO_EN | ST25DV_GPO_FIELD_CHANGE_EN)) {
+			ret = -EIO;
+			goto fail;
+		}
+	}
+
+	/* Keep the tag powered (LPD low) so it detects the field while we sleep.
+	 * Release the mutex without raising LPD (unlike nfc_access_end). */
+	k_mutex_unlock(&m_lock);
+	return 0;
+
+fail:
+	nfc_access_end();
+	return ret;
 }
 
 /* Build CC + NDEF Message TLV + a single short NFC-Forum-external-type record +

--- a/app/src/app_nfc.h
+++ b/app/src/app_nfc.h
@@ -54,6 +54,12 @@ bool app_nfc_periodic_enabled(void);
  * EnterMailbox command is taken via app_nfc_take_cmd_action(). */
 int app_nfc_serve_mailbox(uint32_t idle_timeout_ms);
 
+/* Arm the ST25DV GPO to pulse on RF field changes (a phone tap) so the GPO EXTI
+ * line can wake the MCU from Stop2. On success the tag is left powered (LPD low)
+ * to keep detecting the field while the MCU sleeps. Used by app_power_standby()
+ * (#156). Returns 0 or a negative errno. */
+int app_nfc_arm_field_wake(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/app_power.c
+++ b/app/src/app_power.c
@@ -7,6 +7,7 @@
 #include "app_power.h"
 #include "app_led.h"
 #include "app_log.h"
+#include "app_nfc.h"
 #include "app_sensor.h"
 #if defined(CONFIG_LORAWAN)
 #include "app_lrw.h"
@@ -16,12 +17,15 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/poweroff.h>
+#include <zephyr/sys/reboot.h>
 #if defined(CONFIG_SHELL)
 #include <zephyr/shell/shell.h>
 #endif
 
 #if defined(CONFIG_SOC_FAMILY_STM32)
 #include <stm32_ll_system.h> /* LL_DBGMCU_Disable* */
+#include <stm32_ll_pwr.h>    /* LL_PWR_SetPowerMode, LL_PWR_MODE_STOP2 */
+#include <stm32_ll_cortex.h> /* LL_LPM_Enable{DeepSleep,Sleep} */
 #endif
 
 #if defined(CONFIG_FW_DEBUG) && (CONFIG_APP_DEBUG_AUTOSUSPEND_S > 0)
@@ -63,6 +67,61 @@ void app_power_suspend(void)
 	 * LoRaWAN keys live in NVS (flash) and survive; RAM and the RTC wall-clock
 	 * are lost, so wake is a clean boot that re-syncs time from the network. */
 	sys_poweroff();
+}
+
+void app_power_standby(void)
+{
+	/* User-initiated, NFC-triggered standby (#156): behaves "off" but is woken
+	 * by an NFC tap. The ST25DV GPO is on PB12/EXTI (not a WKUP pin), which can
+	 * wake STM32WL Stop2 but NOT Shutdown — so standby uses Stop2 (RAM retained,
+	 * low µA) rather than the deeper Shutdown used by app_power_suspend(). On
+	 * wake we cold-reboot into normal operation (RAM-only: a power-cycle / NRST
+	 * also exits standby). */
+	LOG_WRN("Entering NFC standby (Stop2) — tap a phone (NFC) to wake");
+
+#if defined(CONFIG_LORAWAN)
+	app_report_suspend();
+	app_lrw_suspend();
+#endif
+	app_sensor_suspend();
+
+	app_led_set(APP_LED_CHANNEL_R, APP_LED_OFF);
+	app_led_set(APP_LED_CHANNEL_G, APP_LED_OFF);
+	app_led_set(APP_LED_CHANNEL_Y, APP_LED_OFF);
+
+	/* Arm the ST25DV GPO to pulse PB12/EXTI on an RF field change (tap). Leaves
+	 * the tag powered (LPD low) so it keeps sensing the field while we sleep. */
+	int ret = app_nfc_arm_field_wake();
+	if (ret) {
+		/* Could not arm the wake source — entering Stop2 now would be a one-way
+		 * trip (only NRST/power-cycle could recover). Abort to normal operation. */
+		LOG_ERR_CALL_FAILED_INT("app_nfc_arm_field_wake", ret);
+		LOG_ERR("NFC standby aborted — wake source not armed");
+		return;
+	}
+
+	/* Let the RTT log line flush before the core sleeps. */
+	k_sleep(K_MSEC(100));
+
+#if defined(CONFIG_SOC_FAMILY_STM32)
+	/* Without this the debug domain keeps the core out of Stop2 (and would wake
+	 * it immediately), same as the Shutdown path. */
+	LL_DBGMCU_DisableDBGStopMode();
+
+	/* Enter Stop2 via a direct WFI rather than the PM idle path, so the dwell is
+	 * deterministic (it does not depend on quiescing every kernel timeout): mask
+	 * interrupts (the pending GPO EXTI still wakes WFI, its handler just does not
+	 * run), select Stop2, set SLEEPDEEP, and sleep. A phone tap (or NRST) wakes
+	 * us; we then cold-reboot into a clean normal boot. */
+	(void)irq_lock();
+	LL_PWR_SetPowerMode(LL_PWR_MODE_STOP2);
+	LL_LPM_EnableDeepSleep();
+	__WFI();
+	/* Woken by the GPO EXTI (NFC tap). Clear deep-sleep and restart clean. */
+	LL_LPM_EnableSleep();
+#endif
+
+	sys_reboot(SYS_REBOOT_COLD);
 }
 
 #if defined(CONFIG_FW_DEBUG) && (CONFIG_APP_DEBUG_AUTOSUSPEND_S > 0)

--- a/app/src/app_power.h
+++ b/app/src/app_power.h
@@ -17,6 +17,15 @@ extern "C" {
  * survive in flash). Requires CONFIG_POWEROFF. */
 void app_power_suspend(void);
 
+/* Enter user-initiated NFC standby (#156): stop LoRaWAN + sensor activity, turn
+ * the LEDs off, arm the ST25DV GPO to wake on an RF field change, then enter
+ * STM32WL Stop2 (Shutdown can't be woken by the GPO — it is on an EXTI pin, not
+ * a WKUP pin). A phone tap (or NRST / power-cycle) wakes the MCU and the device
+ * cold-reboots into normal operation. RAM-only: standby does not persist across
+ * a reset. Returns only if the wake source could not be armed (aborts to normal
+ * operation rather than entering an unwakeable sleep). */
+void app_power_standby(void);
+
 /* Debug idle watchdog. Call periodically from the main loop. After
  * CONFIG_APP_DEBUG_AUTOSUSPEND_S with no RTT/shell interaction it calls
  * app_power_suspend(). Compiled to a no-op unless CONFIG_FW_DEBUG and the

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -190,6 +190,12 @@ static void nfc_poll_thread_fn(void *p1, void *p2, void *p3)
 				 * picked up by the next loop iteration below. */
 				app_nfc_serve_mailbox(0);
 				break;
+			case APP_CMD_ACTION_ENTER_STANDBY:
+				/* The phone has read the Ack off the tag; go dark. Enters
+				 * Stop2 and does not return (cold-reboots on the next NFC tap
+				 * or NRST). #156. */
+				app_power_standby();
+				break;
 			default:
 				break;
 			}

--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -1234,6 +1234,26 @@ wakes the poll thread on a tap and the device idles (low power) otherwise.
 
 - [ ] Pass
 
+### N7 — NFC standby, wake on tap (`enter_standby`, #156)
+
+**Goal:** An NFC `enter_standby` command puts the device into an off-like Stop2 state, and a later
+phone tap wakes it back into normal operation.
+**Observable:** After `enter_standby` the device goes dark (no LEDs, no uplinks); current drops to
+the Stop2 range. A phone tap wakes it and it cold-reboots (boot banner, normal operation). A
+power-cycle / NRST also exits standby.
+
+**Prompt for Claude (needs the Manager-App phone + a current meter for the power check — not fully bench/J-Link testable):**
+> Send an (encrypted) `enter_standby` over NFC and confirm the `ack` is read back, then the device
+> goes dark (LEDs off, no further uplinks/log). Confirm the supply current falls to the Stop2 range
+> (µA, with a meter). Tap the phone again and confirm the device wakes and cold-reboots into normal
+> operation (boot banner, telemetry resumes). Repeat the wake with NRST / power-cycle to confirm
+> standby is RAM-only. **Key HW bring-up checks:** (1) the ST25DV GPO actually pulses PB12/EXTI on a
+> field change so Stop2 wakes; (2) the device is not woken immediately by the still-present field
+> right after entering standby; (3) the IWDG (if running) does not reset the device during the Stop2
+> dwell before a tap. Report results.
+
+- [ ] Pass
+
 ---
 
 ## Payload formatter (`ttn.js`)

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -44,6 +44,7 @@ The device now accepts commands as **LoRaWAN downlinks on fPort 85** and replies
 | `enter_calibration` | Persist `calibration=true` + **reboot** into calibration mode (same end state as `set_param calibration=true` + `settings_save`); the flag is cleared on entry, so the device returns to normal after the calibration window | `ack` |
 | `enter_mailbox` | **NFC only.** Switch into mailbox (ST25DV Fast-Transfer-Mode) serving mode for a bounded window — high-throughput config streaming / firmware update. `ack` is written over NDEF first, then the device serves the mailbox until the phone goes quiet (or `timeout_s` elapses) and returns to the low-power NDEF poll. See §10 | `ack` |
 | `exit_mailbox` | **NFC only.** End mailbox serving immediately (sent as the last mailbox message when the phone is done streaming) so the device drops straight back to the low-power NDEF poll | `ack` |
+| `enter_standby` | **NFC only.** Enter an off-like standby (STM32WL Stop2): no uplinks/join, no sampling, LEDs off, lowest practical power that an NFC tap can still wake. `ack` is written over NDEF first, then the device sleeps; a phone tap (or NRST / power-cycle) wakes it and it cold-reboots into normal operation. RAM-only. See §10 | `ack` |
 
 > After `set_param`, send `settings_save` to persist (it reboots). If a command fails, the device returns an `error` with a code (1 = BAD_REQUEST, 2 = OUT_OF_RANGE, 3 = NOT_READY, 4 = HISTORY_UNAVAILABLE, 5 = UNSUPPORTED_FIELD, 6 = PERSIST_FAILED), an optional `fault_field`, and a `detail` string.
 >
@@ -447,6 +448,13 @@ A phone's Web NFC reader sees each as `record.recordType === "hio.stck:…"`.
 **Power.** The poll thread sleeps on the ST25DV **GPO interrupt** (wired to the STM32, EXTI) and only wakes to read the tag when RF activity occurs — so an untouched tag costs almost nothing and the CPU stays asleep when no phone is present. A periodic fallback timer (30 s) is a safety net in case an edge is missed; each wake still does the cheap gated check (one `IT_STS_Dyn` byte; full read + NDEF parse only on RF activity).
 
 **Robustness.** The command/response round-trip hardens the ST25DV write path (RF_WRITE_EN enable timing after present-password, an "unrecognized data" debounce so a poll that catches a half-written record doesn't clobber it, and an always-read poll). The earlier *auto-restore of the info record over a just-written response* was dropped — it raced with the phone reading the reply (#144).
+
+**Standby, wake on tap (`enter_standby`, #156).** The `enter_standby` command puts the device into a user-initiated, off-like state and arms an NFC tap as the wake source:
+
+- On `enter_standby` (NFC only), the firmware writes the `ack` over NDEF, tears down the radio / sensors / LEDs, and enters **STM32WL Stop2**. A subsequent NFC field (a phone tap) wakes the MCU and it **cold-reboots into normal operation**.
+- **Why Stop2 and not Shutdown:** the ST25DV GPO is wired to an STM32 **EXTI** pin (PB12), not a **WKUP** pin. An EXTI line can wake the MCU from Stop2 but not from the deeper Shutdown used by the debug auto-suspend below — so standby uses Stop2 (RAM retained, low µA), the lowest-power state an NFC tap can still wake on the current board.
+- To make a tap wake the MCU, the GPO is configured to pulse on any **RF field change** (`GPO_EN | FIELD_CHANGE_EN`), and the tag is left powered (LPD low) so it keeps sensing the field while the MCU sleeps.
+- **RAM-only:** standby does not persist across a reset — a power-cycle / NRST also exits it (no NVS flag, so a device can never get "stuck" in standby). If the wake source cannot be armed, the command aborts back to normal operation rather than entering an unwakeable sleep.
 
 ---
 


### PR DESCRIPTION
Closes #156 (pending HW bring-up).

## Summary

A user-initiated **off-like standby** entered over NFC and woken by a phone **tap**.

## Discussion / HW finding

The ST25DV GPO is wired to **PB12 (EXTI12)** — *not* a WKUP pin. An EXTI line can wake STM32WL **Stop2**, but **not** the deeper **Shutdown** (`sys_poweroff`) used by the debug auto-suspend (#132, wakes only via NRST/WKUP/RTC). So an NFC-tap-wakeable standby must use **Stop2** (RAM retained, low µA) — the lowest-power state an NFC tap can wake on the current board. (Per the discussion: Stop2 + GPO RF-detect wake, RAM-only.)

The GPO→PB12→EXTI→ISR path already exists (the low-power NFC poll-wake from #148); this PR adds the *field-change* GPO source and the Stop2 entry.

## Changes

- **`enter_standby`** command — proto_id **21**, `kind: action` (`ENTER_STANDBY`), `transports: [nfc]`, encrypted. `app_config.yml` + hand-written `EnterStandby{}` marker; configen regenerated the oneof / `ttn.js` / dispatch.
- **`app_nfc_arm_field_wake()`** — sets the ST25DV GPO to `GPO_EN | FIELD_CHANGE_EN` so a tap pulses PB12/EXTI; leaves the tag powered (LPD low) so it keeps sensing the field while the MCU sleeps.
- **`app_power_standby()`** — teardown (radio/sensors/LEDs) + arm the field wake + enter **Stop2** via a direct WFI (deterministic dwell, not the PM idle path) + **cold-reboot on wake**. Aborts to normal operation if the wake source can't be armed (never enters an unwakeable sleep).
- **`main.c`** — run `ENTER_STANDBY` from the NFC poll deferred-action path (after the `ack` is written so the phone reads it first).
- **`prj.conf`** — `CONFIG_POWEROFF=y` so `app_power.c` is built in the **release** image too (standby is a production feature); coexists with PM.

**RAM-only:** a power-cycle / NRST also exits standby (no NVS flag → can't get "stuck").

## Build & tests

- release **97.95%** / debug **93.78%** FLASH (debug headroom thanks to #158)
- `node --test` 23/23, `pytest` 22/22, `native_sim` cmd/compose/history all pass, clang-format (22.1.5) clean

## Draft — HW bring-up pending

Stop2 + GPO-EXTI wake needs an on-HW pass (see manual-test-plan **N7**): (1) the GPO actually pulses PB12/EXTI on a field change so Stop2 wakes; (2) no immediate re-wake from the still-present field right after entering standby; (3) IWDG behaviour during the Stop2 dwell; (4) current measurement. Encrypted-channel + Manager-App phone needed.