### PR TITLE
feat(nfc): read LoRaWAN keys back over NFC only (#162)

### DIFF
--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -207,34 +207,37 @@ static const struct {
 	uint8_t section;
 	uint8_t tag;
 	uint8_t size;
+	bool nfc_only; /* only dumped over NFC (e.g. LoRaWAN keys) — never over LoRaWAN */
 } DUMP_FIELDS[] = {
 	// BEGIN GENERATED DUMP_FIELDS
-	{DUMP_SECTION_LORAWAN, 1, 2},      {DUMP_SECTION_LORAWAN, 12, 2},
-	{DUMP_SECTION_LORAWAN, 2, 2},      {DUMP_SECTION_LORAWAN, 3, 2},
-	{DUMP_SECTION_LORAWAN, 4, 2},      {DUMP_SECTION_LORAWAN, 5, 18},
-	{DUMP_SECTION_LORAWAN, 6, 18},     {DUMP_SECTION_LORAWAN, 9, 10},
-	{DUMP_SECTION_LORAWAN, 13, 3},     {DUMP_SECTION_LORAWAN, 14, 3},
-	{DUMP_SECTION_APPLICATION, 1, 2},  {DUMP_SECTION_APPLICATION, 2, 3},
-	{DUMP_SECTION_APPLICATION, 4, 4},  {DUMP_SECTION_APPLICATION, 49, 3},
-	{DUMP_SECTION_APPLICATION, 50, 7}, {DUMP_SECTION_SENSORS, 40, 3},
-	{DUMP_SECTION_SENSORS, 41, 3},     {DUMP_SECTION_SENSORS, 42, 3},
-	{DUMP_SECTION_SENSORS, 43, 3},     {DUMP_SECTION_SENSORS, 44, 3},
-	{DUMP_SECTION_SENSORS, 45, 3},     {DUMP_SECTION_SENSORS, 46, 3},
-	{DUMP_SECTION_SENSORS, 60, 3},     {DUMP_SECTION_SENSORS, 55, 3},
-	{DUMP_SECTION_SENSORS, 54, 3},     {DUMP_SECTION_SENSORS, 56, 19},
-	{DUMP_SECTION_SENSORS, 57, 19},    {DUMP_SECTION_SENSORS, 58, 19},
-	{DUMP_SECTION_SENSORS, 59, 19},    {DUMP_SECTION_ALARMS, 51, 4},
-	{DUMP_SECTION_ALARMS, 52, 3},      {DUMP_SECTION_ALARMS, 25, 3},
-	{DUMP_SECTION_ALARMS, 28, 3},      {DUMP_SECTION_ALARMS, 31, 3},
-	{DUMP_SECTION_ALARMS, 34, 3},      {DUMP_SECTION_ALARMS, 54, 37},
-	{DUMP_SECTION_ALARMS, 55, 37},     {DUMP_SECTION_ALARMS, 56, 37},
-	{DUMP_SECTION_ALARMS, 57, 37},     {DUMP_SECTION_ALARMS, 58, 37},
-	{DUMP_SECTION_ALARMS, 59, 37},     {DUMP_SECTION_ALARMS, 60, 37},
-	{DUMP_SECTION_ALARMS, 61, 37},     {DUMP_SECTION_ALARMS, 62, 37},
-	{DUMP_SECTION_ALARMS, 63, 37},     {DUMP_SECTION_ALARMS, 64, 37},
-	{DUMP_SECTION_ALARMS, 65, 37},     {DUMP_SECTION_ALARMS, 66, 37},
-	{DUMP_SECTION_ALARMS, 67, 37},     {DUMP_SECTION_ALARMS, 68, 37},
-	{DUMP_SECTION_ALARMS, 69, 37},
+	{DUMP_SECTION_LORAWAN, 1, 2, false},      {DUMP_SECTION_LORAWAN, 12, 2, false},
+	{DUMP_SECTION_LORAWAN, 2, 2, false},      {DUMP_SECTION_LORAWAN, 3, 2, false},
+	{DUMP_SECTION_LORAWAN, 4, 2, false},      {DUMP_SECTION_LORAWAN, 5, 18, false},
+	{DUMP_SECTION_LORAWAN, 6, 18, false},     {DUMP_SECTION_LORAWAN, 7, 34, true},
+	{DUMP_SECTION_LORAWAN, 8, 34, true},      {DUMP_SECTION_LORAWAN, 9, 10, false},
+	{DUMP_SECTION_LORAWAN, 10, 34, true},     {DUMP_SECTION_LORAWAN, 11, 34, true},
+	{DUMP_SECTION_LORAWAN, 13, 3, false},     {DUMP_SECTION_LORAWAN, 14, 3, false},
+	{DUMP_SECTION_APPLICATION, 1, 2, false},  {DUMP_SECTION_APPLICATION, 2, 3, false},
+	{DUMP_SECTION_APPLICATION, 4, 4, false},  {DUMP_SECTION_APPLICATION, 49, 3, false},
+	{DUMP_SECTION_APPLICATION, 50, 7, false}, {DUMP_SECTION_SENSORS, 40, 3, false},
+	{DUMP_SECTION_SENSORS, 41, 3, false},     {DUMP_SECTION_SENSORS, 42, 3, false},
+	{DUMP_SECTION_SENSORS, 43, 3, false},     {DUMP_SECTION_SENSORS, 44, 3, false},
+	{DUMP_SECTION_SENSORS, 45, 3, false},     {DUMP_SECTION_SENSORS, 46, 3, false},
+	{DUMP_SECTION_SENSORS, 60, 3, false},     {DUMP_SECTION_SENSORS, 55, 3, false},
+	{DUMP_SECTION_SENSORS, 54, 3, false},     {DUMP_SECTION_SENSORS, 56, 19, false},
+	{DUMP_SECTION_SENSORS, 57, 19, false},    {DUMP_SECTION_SENSORS, 58, 19, false},
+	{DUMP_SECTION_SENSORS, 59, 19, false},    {DUMP_SECTION_ALARMS, 51, 4, false},
+	{DUMP_SECTION_ALARMS, 52, 3, false},      {DUMP_SECTION_ALARMS, 25, 3, false},
+	{DUMP_SECTION_ALARMS, 28, 3, false},      {DUMP_SECTION_ALARMS, 31, 3, false},
+	{DUMP_SECTION_ALARMS, 34, 3, false},      {DUMP_SECTION_ALARMS, 54, 37, false},
+	{DUMP_SECTION_ALARMS, 55, 37, false},     {DUMP_SECTION_ALARMS, 56, 37, false},
+	{DUMP_SECTION_ALARMS, 57, 37, false},     {DUMP_SECTION_ALARMS, 58, 37, false},
+	{DUMP_SECTION_ALARMS, 59, 37, false},     {DUMP_SECTION_ALARMS, 60, 37, false},
+	{DUMP_SECTION_ALARMS, 61, 37, false},     {DUMP_SECTION_ALARMS, 62, 37, false},
+	{DUMP_SECTION_ALARMS, 63, 37, false},     {DUMP_SECTION_ALARMS, 64, 37, false},
+	{DUMP_SECTION_ALARMS, 65, 37, false},     {DUMP_SECTION_ALARMS, 66, 37, false},
+	{DUMP_SECTION_ALARMS, 67, 37, false},     {DUMP_SECTION_ALARMS, 68, 37, false},
+	{DUMP_SECTION_ALARMS, 69, 37, false},
 	// END GENERATED DUMP_FIELDS
 };
 
@@ -249,10 +252,14 @@ static const struct {
 static void app_cmd_handle_get_config(enum app_cmd_transport tp, const Command *cmd, Response *resp,
 				      enum app_cmd_action *action)
 {
-	ARG_UNUSED(tp);
 	ARG_UNUSED(action);
 	const Command_GetConfig *gc = &cmd->body.get_config;
 	uint32_t page = gc->has_page ? gc->page : 0;
+	/* NFC-only fields (LoRaWAN keys) are read-back exclusively over the encrypted
+	 * NFC channel; never include them in a LoRaWAN response (the fPort-85 payload
+	 * is plain protobuf — the network server would see the keys). They are skipped
+	 * for paging too, so page layout is consistent within a transport. */
+	const bool allow_nfc_only = (tp == APP_CMD_TRANSPORT_NFC);
 
 	/* One tag buffer per section, each sized to the whole table so any single
 	 * section can hold all of a page's tags without overflow. */
@@ -263,6 +270,9 @@ static void app_cmd_handle_get_config(enum app_cmd_transport tp, const Command *
 	 * the requested page's tags per section, and learn the total page count. */
 	uint32_t cur_page = 0, used = 0;
 	for (size_t i = 0; i < ARRAY_SIZE(DUMP_FIELDS); i++) {
+		if (DUMP_FIELDS[i].nfc_only && !allow_nfc_only) {
+			continue;
+		}
 		if (used > 0 && used + DUMP_FIELDS[i].size > DUMP_PAGE_BUDGET) {
 			cur_page++;
 			used = 0;
@@ -312,11 +322,12 @@ static void app_cmd_handle_get_config(enum app_cmd_transport tp, const Command *
 /* Encoded-size bound for a (section, tag) from DUMP_FIELDS. Returns false for a
  * field that isn't dumpable (secret / unknown id): such ids never appear in the
  * response (app_config_fill_<group>() skips them) so they take no page budget. */
-static bool dump_field_size(uint8_t section, uint32_t tag, uint8_t *size)
+static bool dump_field_size(uint8_t section, uint32_t tag, uint8_t *size, bool *nfc_only)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(DUMP_FIELDS); i++) {
 		if (DUMP_FIELDS[i].section == section && DUMP_FIELDS[i].tag == tag) {
 			*size = DUMP_FIELDS[i].size;
+			*nfc_only = DUMP_FIELDS[i].nfc_only;
 			return true;
 		}
 	}
@@ -326,10 +337,12 @@ static bool dump_field_size(uint8_t section, uint32_t tag, uint8_t *size)
 static void app_cmd_handle_get_param(enum app_cmd_transport tp, const Command *cmd, Response *resp,
 				     enum app_cmd_action *action)
 {
-	ARG_UNUSED(tp);
 	ARG_UNUSED(action);
 	const Command_GetParam *gp = &cmd->body.get_param;
 	uint32_t page = gp->has_page ? gp->page : 0;
+	/* NFC-only fields (LoRaWAN keys) are returned over the encrypted NFC channel
+	 * only — never in a LoRaWAN response (see get_config). */
+	const bool allow_nfc_only = (tp == APP_CMD_TRANSPORT_NFC);
 
 	/* Requested ids per section, in ConfigDump section order. DUMP_SECTION_*
 	 * equals the index here (0..3). */
@@ -352,8 +365,12 @@ static void app_cmd_handle_get_param(enum app_cmd_transport tp, const Command *c
 	for (uint8_t s = 0; s < 4; s++) {
 		for (size_t j = 0; j < req_n[s]; j++) {
 			uint8_t sz;
-			if (!dump_field_size(s, req_ids[s][j], &sz)) {
+			bool nfc_only;
+			if (!dump_field_size(s, req_ids[s][j], &sz, &nfc_only)) {
 				continue; /* secret/unknown → not dumpable */
+			}
+			if (nfc_only && !allow_nfc_only) {
+				continue; /* keys: NFC transport only */
 			}
 			if (used > 0 && used + sz > DUMP_PAGE_BUDGET) {
 				cur_page++;

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -292,6 +292,7 @@ parameters:
     proto_group: lorawan
     proto_id: 7
     dump: false
+    dump_nfc_only: true
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -301,6 +302,7 @@ parameters:
     proto_group: lorawan
     proto_id: 8
     dump: false
+    dump_nfc_only: true
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -318,6 +320,7 @@ parameters:
     proto_group: lorawan
     proto_id: 10
     dump: false
+    dump_nfc_only: true
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -327,6 +330,7 @@ parameters:
     proto_group: lorawan
     proto_id: 11
     dump: false
+    dump_nfc_only: true
     type: bytes
     size: 16
     preserve_on_reset: true

--- a/app/src/app_config_ingest.c
+++ b/app/src/app_config_ingest.c
@@ -165,9 +165,25 @@ void app_config_fill_lorawan(AppConfigMessage_Lorawan *dst, const uint32_t *ids,
 		dst->has_joineui = true;
 		memcpy(dst->joineui, c->lrw_joineui, sizeof(c->lrw_joineui));
 	}
+	if (requested(ids, n, 7)) {
+		dst->has_nwkkey = true;
+		memcpy(dst->nwkkey, c->lrw_nwkkey, sizeof(c->lrw_nwkkey));
+	}
+	if (requested(ids, n, 8)) {
+		dst->has_appkey = true;
+		memcpy(dst->appkey, c->lrw_appkey, sizeof(c->lrw_appkey));
+	}
 	if (requested(ids, n, 9)) {
 		dst->has_devaddr = true;
 		memcpy(dst->devaddr, c->lrw_devaddr, sizeof(c->lrw_devaddr));
+	}
+	if (requested(ids, n, 10)) {
+		dst->has_nwkskey = true;
+		memcpy(dst->nwkskey, c->lrw_nwkskey, sizeof(c->lrw_nwkskey));
+	}
+	if (requested(ids, n, 11)) {
+		dst->has_appskey = true;
+		memcpy(dst->appskey, c->lrw_appskey, sizeof(c->lrw_appskey));
 	}
 	if (requested(ids, n, 12)) {
 		dst->has_sub_band = true;

--- a/doc/manual-test-plan.md
+++ b/doc/manual-test-plan.md
@@ -1060,6 +1060,23 @@ periodically-saved value (not zero).
 
 - [ ] Pass
 
+### C10 — Read LoRaWAN keys back over NFC only (#162)
+
+**Goal:** The LoRaWAN crypto keys (`nwkkey`/`appkey`/`nwkskey`/`appskey`) are readable over the
+encrypted NFC channel but never over LoRaWAN.
+**Observable:** A `GetParam`/`GetConfig` selecting a key returns it when sent over NFC; the same
+request over a LoRaWAN downlink comes back with the key **omitted**. `secret_key` is never returned.
+
+**Prompt for Claude:**
+> Provision known LoRaWAN keys. Over a **LoRaWAN downlink**, send a `GetParam` selecting `nwkkey`
+> (and `appkey`) and confirm the `config_dump` response does **not** contain them (and `GetConfig`
+> never includes them on any page). Then over **NFC** (Manager-App, encrypted) send the same
+> `GetParam` and confirm the keys come back with the provisioned values. Confirm `secret_key` is
+> never returned on either transport. (LRW omission is also covered by the native_sim unit test
+> `test_get_param_keys_nfc_only`; this is the on-air / NFC confirmation.)
+
+- [ ] Pass
+
 ---
 
 ## Clock / RTC

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -448,6 +448,12 @@ A phone's Web NFC reader sees each as `record.recordType === "hio.stck:…"`.
 
 **Robustness.** The command/response round-trip hardens the ST25DV write path (RF_WRITE_EN enable timing after present-password, an "unrecognized data" debounce so a poll that catches a half-written record doesn't clobber it, and an always-read poll). The earlier *auto-restore of the info record over a just-written response* was dropped — it raced with the phone reading the reply (#144).
 
+**Reading the LoRaWAN keys back (NFC only, #162).** So an operator can verify which keys a device holds, `get_config` / `get_param` now return the LoRaWAN crypto keys (`nwkkey`, `appkey`, `nwkskey`, `appskey`) — but **only over NFC**, never over LoRaWAN:
+
+- The NFC command/config channel is AES-CCM encrypted with the device `secret_key`, so a key read-back is only decryptable by a phone that already holds `secret_key` (the provisioning operator). A device with no `secret_key` knowledge is unreachable over NFC beyond the plaintext info record.
+- The keys are flagged `dump_nfc_only`: the dump path emits them only when the transport is NFC. A `get_config`/`get_param` arriving as a **LoRaWAN downlink never selects the key tags**, so they can never leave in an uplink — important because the fPort-85 payload is plain protobuf (the LoRaWAN MAC layer would expose the keys to the network server). The DevEUI/JoinEUI/DevAddr identifiers remain readable over both transports as before.
+- **`secret_key` itself is never readable** on any transport (it is the master key for the whole NFC channel).
+
 ---
 
 ## Debug auto-suspend / deep sleep (NEW)

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -569,6 +569,7 @@ def build_ingest_model(config):
                 "proto_name": _proto_field_name(p, g),
                 "tag": p["proto_id"],
                 "dump": p.get("dump", True),
+                "dump_nfc_only": bool(p.get("dump_nfc_only")),
                 "callback": bool(p.get("proto_callback")),
             }
             if t == "bool":
@@ -783,16 +784,23 @@ def _dump_field_size(p):
 def build_dump_fields_model(config):
     """Rows for the get_config DUMP_FIELDS[] table: every dumpable parameter
     (proto_group in a ConfigDump section and not `dump: false`), grouped by
-    section in DUMP_SECTION order, YAML declaration order within a section."""
+    section in DUMP_SECTION order, YAML declaration order within a section.
+
+    A `dump_nfc_only: true` field is included with nfc_only=1; the handler only
+    selects it when the transport is NFC, so it never enters a LoRaWAN response
+    (e.g. the LoRaWAN crypto keys — readable over the encrypted NFC channel only).
+    A plain `dump: false` field stays excluded from every transport."""
     rows = []
     for section in DUMP_SECTIONS:
         macro = "DUMP_SECTION_" + section.upper()
         for p in config["parameters"]:
             if p.get("proto_group") != section or "proto_id" not in p:
                 continue
-            if p.get("dump") is False:
+            nfc_only = bool(p.get("dump_nfc_only"))
+            if p.get("dump") is False and not nfc_only:
                 continue
-            rows.append({"section": macro, "tag": p["proto_id"], "size": _dump_field_size(p)})
+            rows.append({"section": macro, "tag": p["proto_id"],
+                         "size": _dump_field_size(p), "nfc_only": nfc_only})
     return {"dump_fields": rows}
 
 

--- a/scripts/west_commands/templates/config_ingest.c.j2
+++ b/scripts/west_commands/templates/config_ingest.c.j2
@@ -105,7 +105,7 @@ void {{ g.fill_fn }}({{ g.c_message }} *dst, const uint32_t *ids, size_t n)
 {
 	const struct {{ module.name }} *c = {{ module.name }}();
 
-{% for p in g.params if p.dump and not p.callback %}
+{% for p in g.params if (p.dump or p.dump_nfc_only) and not p.callback %}
 {% if p.kind == 'bytes' %}
 	if (requested(ids, n, {{ p.tag }})) {
 		dst->has_{{ p.proto_name }} = true;

--- a/scripts/west_commands/templates/dump_fields.c.j2
+++ b/scripts/west_commands/templates/dump_fields.c.j2
@@ -1,3 +1,3 @@
 {% for f in dump_fields -%}
-	{ {{ f.section }}, {{ f.tag }}, {{ f.size }} },
+	{ {{ f.section }}, {{ f.tag }}, {{ f.size }}, {{ 'true' if f.nfc_only else 'false' }} },
 {% endfor -%}

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -161,6 +161,34 @@ ZTEST(cmd, test_get_param_paging)
 		      r.body.error.code);
 }
 
+/* The LoRaWAN crypto keys are read-back over NFC only — never over LoRaWAN
+ * (the fPort-85 payload is plain protobuf). A get_param requesting nwkkey (tag 7)
+ * must dump it over NFC and omit it over LoRaWAN. (#162) */
+ZTEST(cmd, test_get_param_keys_nfc_only)
+{
+	Response r;
+
+	reset_cfg();
+	g_app_config.lrw_nwkkey[0] = 0xAB;
+	g_app_config.lrw_nwkkey[15] = 0xCD;
+
+	/* seq3 get_param{ lorawan_field=[7 nwkkey] } */
+	const char *cmd = "08031a030a0107";
+
+	/* NFC: key is dumped. */
+	handle_via(APP_CMD_TRANSPORT_NFC, cmd, &r);
+	zassert_equal(r.which_body, Response_config_dump_tag, "NFC which=%d", r.which_body);
+	zassert_true(r.body.config_dump.has_lorawan, "NFC: lorawan section missing");
+	zassert_true(r.body.config_dump.lorawan.has_nwkkey, "NFC: nwkkey not dumped");
+	zassert_equal(r.body.config_dump.lorawan.nwkkey[0], 0xAB, "NFC: nwkkey[0]");
+	zassert_equal(r.body.config_dump.lorawan.nwkkey[15], 0xCD, "NFC: nwkkey[15]");
+
+	/* LoRaWAN: key must NOT be dumped (omitted entirely → empty lorawan section). */
+	handle_via(APP_CMD_TRANSPORT_LRW, cmd, &r);
+	zassert_equal(r.which_body, Response_config_dump_tag, "LRW which=%d", r.which_body);
+	zassert_false(r.body.config_dump.lorawan.has_nwkkey, "LRW: nwkkey leaked over LoRaWAN!");
+}
+
 ZTEST(cmd, test_build_info)
 {
 	uint8_t out[128];


### PR DESCRIPTION
Closes #162.

## Summary

Lets an operator verify which LoRaWAN keys a STICKER holds. The crypto keys (`nwkkey`, `appkey`, `nwkskey`, `appskey`) were write-only (`dump: false`); they are now readable — **over the encrypted NFC channel only, never over LoRaWAN**.

## Security rationale

- The NFC command/config channel is AES-CCM encrypted with the device `secret_key` (#135/#136); a key read-back is only decryptable by a phone that already holds `secret_key` (the provisioning operator). A regular user cannot reach the STICKER over NFC beyond the plaintext info record.
- **The danger is the shared dump path leaking over LoRaWAN:** the app-layer encryption is NFC-only, so over LoRaWAN the fPort-85 response is plain protobuf (MAC-layer only) — the network server would see the keys. So the keys must never enter the LoRaWAN dump path. Verified by a unit test.
- `secret_key` stays unreadable on every transport.
- `CONFIG_APP_NFC_ENCRYPTION=n` / `secret_key=0` are test-only; production always uses the encrypted channel + a real per-device `secret_key`.

(Full analysis kept locally: `sticker-lrw-key-readback-security-analysis.md`.)

## Implementation

- **configen**: new `dump_nfc_only: true` flag (alongside `dump: false`). The field is then included in `app_config_fill_<group>()` *and* emitted into `DUMP_FIELDS[]` with `nfc_only=1`. Templates: fill gate `(dump or dump_nfc_only) and not callback`; `DUMP_FIELDS[]` gains an `nfc_only` column.
- **app_config.yml**: `dump_nfc_only` on the 4 LoRaWAN keys.
- **app_cmd.c**: `DUMP_FIELDS` struct gains `bool nfc_only`; `get_config` + `get_param` skip `nfc_only` fields (incl. for paging) unless `transport == NFC`.
- `secret_key` untouched (callback, off the dump path).

## Build & tests

- release **97.85%** / debug **93.66%** FLASH
- node 23/23, pytest 22/22, **native_sim `cmd` 11/11** incl. new `test_get_param_keys_nfc_only` (nwkkey dumped over NFC, omitted over LoRaWAN), clang-format (22.1.5) clean

Doc: version 1.4 §10 + manual-test-plan **C10**. The LoRaWAN-omission (the security-critical property) is unit-tested; the on-NFC read confirmation (C10) needs the Manager-App phone.