### PR TITLE
Uniform APP_PROTO_VERSION byte on fPort-3 AlarmReport (#165)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -909,12 +909,14 @@ function decodeAlarmBatch(bytes) {
 }
 
 // 1-byte format version prefixed to application protobuf payloads (fPort 2
-// telemetry, fPort 85 response). Mirrors APP_PROTO_VERSION in app_cmd.h.
+// telemetry, fPort 3 alarm report, fPort 85 response). Mirrors APP_PROTO_VERSION
+// in app_cmd.h.
 var _PROTO_VERSION = 0x01;
 
 // Strip + validate the version prefix at byte[0]. Returns the protobuf bytes
 // (byte 1..end) and pushes a warning on an unexpected version (the remainder is
-// still decoded best-effort). fPort 1 (legacy bitmap) and fPort 3 are unversioned.
+// still decoded best-effort). fPort 1 (legacy bitmap) and fPort 10 (calibration)
+// are unversioned.
 function _stripProtoVersion(bytes, warnings) {
   if (!bytes || bytes.length < 1) return bytes;
   if (bytes[0] !== _PROTO_VERSION) {
@@ -936,9 +938,11 @@ function decodeUplink(input) {
     };
   }
 
-  // fPort 3: alarm-detail batch (#27).
+  // fPort 3: alarm-detail batch (#27), version-prefixed like fPort 2/85 (#165).
   if (input.fPort === 3) {
-    return { data: decodeAlarmBatch(input.bytes), warnings: [], errors: [] };
+    var w3 = [];
+    var b3 = _stripProtoVersion(input.bytes, w3);
+    return { data: decodeAlarmBatch(b3), warnings: w3, errors: [] };
   }
 
   // fPort 2: protobuf Telemetry (new format). fPort 1 stays the legacy bitmap.

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -351,7 +351,8 @@ function alarmEvent(source, quantity, edge, side, rel, value, slot) {
   return e;
 }
 function buildAlarmReport(base, total, events) {
-  let b = pbTV(1, base).concat(pbTV(2, total));
+  // 0x01 = APP_PROTO_VERSION prefix (#165), then the AlarmReport protobuf.
+  let b = [0x01].concat(pbTV(1, base)).concat(pbTV(2, total));
   for (const e of events) b = b.concat(pbLD(3, e));
   return b;
 }
@@ -428,6 +429,26 @@ test("fPort-3 batch: accel motion state activate", () => {
   assert.equal(d.alarms[0].side, "none");
   assert.equal(d.alarms[0].value, 1);
   assert.equal(d.alarms[0].time, base);
+});
+
+test("fPort-3 batch: version prefix is stripped, body decodes after byte 0", () => {
+  const base = 1780000000;
+  const f = buildAlarmReport(base, 1, [alarmEvent(0, 0, 0, 2, 10, 2660, 7)]);
+  assert.equal(f[0], 0x01); // APP_PROTO_VERSION prefix present (#165)
+  const r = codec.decodeUplink({ bytes: f, fPort: 3 });
+  assert.equal(r.warnings.length, 0);
+  assert.equal(r.data.base_time, base);
+  assert.equal(r.data.alarms[0].value, 26.6);
+});
+
+test("fPort-3 batch: unknown version byte warns but still decodes", () => {
+  const base = 1780000000;
+  const f = buildAlarmReport(base, 1, [alarmEvent(0, 0, 0, 2, 10, 2660, 7)]);
+  f[0] = 0x02; // bump the version prefix to an unexpected value
+  const r = codec.decodeUplink({ bytes: f, fPort: 3 });
+  assert.equal(r.warnings.length, 1);
+  assert.match(r.warnings[0], /unknown payload version 0x2/);
+  assert.equal(r.data.base_time, base); // remainder still decoded best-effort
 });
 
 // --- Negative: a corrupted frame must change the result (tests are sensitive) ---

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -835,12 +835,20 @@ int app_cmd_build_alarm_report(uint32_t base_time, uint32_t total,
 	}
 	report.events_count = (pb_size_t)n;
 
-	pb_ostream_t ostream = pb_ostream_from_buffer(out, out_cap);
+	/* fPort 3 carries the same 1-byte APP_PROTO_VERSION prefix as fPort 2
+	 * (telemetry) and fPort 85 (responses) so every protobuf uplink frame is
+	 * uniformly versioned (#165). */
+	if (out_cap < 1) {
+		return -EMSGSIZE;
+	}
+	out[0] = APP_PROTO_VERSION;
+
+	pb_ostream_t ostream = pb_ostream_from_buffer(out + 1, out_cap - 1);
 	if (!pb_encode(&ostream, AlarmReport_fields, &report)) {
 		LOG_ERR_CALL_FAILED_STR("pb_encode", PB_GET_ERROR(&ostream));
 		return -EMSGSIZE;
 	}
 
-	*out_len = ostream.bytes_written;
+	*out_len = ostream.bytes_written + 1;
 	return 0;
 }

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -121,6 +121,8 @@ A runtime `w1_scan` / enroll re-binds the slots and re-arms machine-probe tilt d
 
 When alarms occur, the device sends a batch of alarm events on **fPort 3** as a **protobuf `AlarmReport`** (same wire family as the fPort-2 telemetry and the fPort-85 responses), so it decodes with the generated codec rather than a packed byte layout.
 
+The frame is prefixed with the same **1-byte format version** (`APP_PROTO_VERSION = 0x01`) as fPort 2 and fPort 85, so every protobuf uplink shares the rule *"byte 0 = version, protobuf starts at byte 1"* (#165). `decodeUplink` strips and validates it. *(fPort 1 legacy bitmap and fPort 10 calibration remain unversioned.)*
+
 ### Message
 
 ```proto


### PR DESCRIPTION
Closes #165 (Option A, scoped: fPort 10 calibration kept unversioned per request).

## What

Make the 1-byte format-version prefix (`APP_PROTO_VERSION = 0x01`) uniform across **all protobuf uplinks**. fPort 2 (telemetry) and fPort 85 (responses) already carried it; fPort 3 (`AlarmReport`) did not. After this change every protobuf uplink follows the same rule:

> **byte 0 = version, protobuf starts at byte 1**

fPort 1 (legacy bitmap) and **fPort 10 (calibration) stay unversioned by design** — calibration framing left exactly as-is as requested.

## Changes

- **`app/src/app_cmd.c`** — `app_cmd_build_alarm_report()` writes `out[0] = APP_PROTO_VERSION` and encodes the protobuf into `out + 1`; `out_len` includes the prefix. Buffer budget (`ALARM_FRAME_MAX` / DR cap) accounted for via `out_cap - 1`; the existing per-event retry loop in `app_alarm.c` still trims to fit.
- **`app/decoder/ttn.js`** — fPort 3 now runs `_stripProtoVersion()` (warns on unexpected version, decodes the remainder best-effort), same as fPort 2/85. Comments updated.
- **`app/decoder/ttn.test.js`** — fPort-3 test vectors carry the `0x01` prefix; two new tests cover the prefix-strip and the unknown-version warning path.
- **`doc/version 1.4.md`** — §3 documents the uniform version-byte rule and the fPort 1/10 exceptions.

## Breaking change

fPort-3 framing changed: the first byte is now `0x01`, not the protobuf. Any consumer decoding `AlarmReport` directly (manager-app / external decoders) must strip byte 0. Coordinated with the manager-app side.

## Testing

- `node --test` (decoder): **25 passed**
- `pytest scripts/west_commands/tests`: **22 passed**
- `clang-format` (22.1.5, CI-pinned): clean
- Pristine builds: release **FLASH 98.14% / RAM 68.91%**, debug **FLASH 93.67% / RAM 81.15%**
- HW test on bench STICKER (J-Link EDU Mini only) — see follow-up comment.