### PR TITLE
power: suspend accelerometer when motion detection is off (#90)

### DIFF
--- a/app/src/app_accel.c
+++ b/app/src/app_accel.c
@@ -15,6 +15,8 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 /* Standard includes */
 #include <errno.h>
@@ -90,6 +92,15 @@ int app_accel_read(float *accel_x, float *accel_y, float *accel_z, int *orientat
 		return -ENODEV;
 	}
 
+	/* Power the LIS2DH up for the read and back down afterwards (runtime PM).
+	 * When motion/free-fall detection is armed the device is already held
+	 * resumed (refcounted get in app_accel_set_motion_sensitivity), so this
+	 * just keeps it on; when detection is OFF the part is in power-down and
+	 * this is the only thing that spins it up — for the duration of the read
+	 * only. RESUME restores the active ODR; the ENODATA retry below absorbs
+	 * the turn-on + first-sample latency. */
+	(void)pm_device_runtime_get(dev);
+
 	/* TODO Check if this is the best aprroach */
 	for (int i = 0; i < 5; i++) {
 		ret = sensor_sample_fetch(dev);
@@ -103,6 +114,7 @@ int app_accel_read(float *accel_x, float *accel_y, float *accel_z, int *orientat
 
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("sensor_sample_fetch", ret);
+		(void)pm_device_runtime_put(dev);
 		k_mutex_unlock(&m_lock);
 		return ret;
 	}
@@ -111,6 +123,7 @@ int app_accel_read(float *accel_x, float *accel_y, float *accel_z, int *orientat
 	ret = sensor_channel_get(dev, SENSOR_CHAN_ACCEL_XYZ, val);
 	if (ret) {
 		LOG_ERR_CALL_FAILED_INT("sensor_channel_get", ret);
+		(void)pm_device_runtime_put(dev);
 		k_mutex_unlock(&m_lock);
 		return ret;
 	}
@@ -145,6 +158,7 @@ int app_accel_read(float *accel_x, float *accel_y, float *accel_z, int *orientat
 		*orientation = orientation_;
 	}
 
+	(void)pm_device_runtime_put(dev);
 	k_mutex_unlock(&m_lock);
 
 	return 0;
@@ -185,6 +199,12 @@ static struct sensor_trigger m_motion_trig = {
 };
 
 static struct k_work_delayable m_motion_arm_work;
+
+/* Tracks whether a runtime-PM "get" is currently held to keep the LIS2DH
+ * resumed for interrupt-driven detection (any-motion + free-fall). Balanced
+ * against the get/put in app_accel_set_motion_sensitivity so the device is
+ * powered down (ODR=0) whenever detection is OFF. */
+static bool m_motion_armed;
 
 static void motion_arm_work_handler(struct k_work *work)
 {
@@ -285,8 +305,29 @@ int app_accel_set_motion_sensitivity(enum app_config_motion_sensitivity level)
 			LOG_ERR_CALL_FAILED_INT("sensor_trigger_set(disable)", ret);
 			return ret;
 		}
+		/* Release the runtime-PM hold so the part can power down (ODR=0).
+		 * With the device suspended it no longer samples, so neither the
+		 * any-motion nor the free-fall comparator can fire — detection is
+		 * fully off and the ~ continuous accelerometer current is saved. */
+		if (m_motion_armed) {
+			(void)pm_device_runtime_put(dev);
+			m_motion_armed = false;
+		}
 		LOG_INF("Motion detection disabled");
 		return 0;
+	}
+
+	/* Keep the LIS2DH resumed (active ODR) for the whole armed period so its
+	 * interrupt generators run. Taken once; balanced by the put in the OFF
+	 * branch. Must precede the register config below (a suspended part ignores
+	 * the HPF snap / threshold writes at the analog level). */
+	if (!m_motion_armed) {
+		ret = pm_device_runtime_get(dev);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_INT("pm_device_runtime_get", ret);
+			return ret;
+		}
+		m_motion_armed = true;
 	}
 
 	int th_ms2, dur;

--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -220,6 +220,16 @@ int app_sensor_init(void)
 	/* The accelerometer is a runtime capability: only arm motion + free-fall
 	 * (and read orientation, see app_sensor_sample) when cap-accelerometer is on. */
 	if (g_app_config.cap_accelerometer) {
+		const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(lis2dh12));
+
+		/* lis2dh12 is deferred-init: power it up only when the cap is on,
+		 * otherwise it would run ODR_5 low-power sampling permanently. */
+		ret = device_init(dev);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_CTX_INT("device_init", "lis2dh12", ret);
+			res = res ? res : ret;
+		}
+
 		ret = app_accel_init_motion(accel_motion_handler, NULL);
 		if (ret) {
 			LOG_ERR_CALL_FAILED_INT("app_accel_init_motion", ret);

--- a/app/src/app_sensor.c
+++ b/app/src/app_sensor.c
@@ -27,6 +27,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
 
 /* Standard includes */
 #include <errno.h>
@@ -227,6 +228,19 @@ int app_sensor_init(void)
 		ret = device_init(dev);
 		if (ret) {
 			LOG_ERR_CALL_FAILED_CTX_INT("device_init", "lis2dh12", ret);
+			res = res ? res : ret;
+		}
+
+		/* Hand the part to runtime PM so it idles in power-down (ODR=0) and
+		 * is only resumed on demand: for an orientation read (app_accel_read)
+		 * or while interrupt detection is armed (app_accel_set_motion_
+		 * sensitivity holds a get). device_init() above left it running at
+		 * ODR_5 — enabling runtime PM here suspends it immediately (refcount
+		 * 0), removing the ~continuous accelerometer current when detection is
+		 * OFF. */
+		ret = pm_device_runtime_enable(dev);
+		if (ret) {
+			LOG_ERR_CALL_FAILED_CTX_INT("pm_device_runtime_enable", "lis2dh12", ret);
 			res = res ? res : ret;
 		}
 

--- a/boards/sticker/sticker.dts
+++ b/boards/sticker/sticker.dts
@@ -133,6 +133,9 @@ stm32_lp_tick_source: &lptim1 {
 		irq-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>,
 			    <&gpioa 2 GPIO_ACTIVE_HIGH>;
 		disconnect-sdo-sa0-pull-up;
+		/* Deferred so the accel stays powered down (no ODR_5 sampling)
+		 * unless cap-accelerometer is on; device_init() in app_sensor. */
+		zephyr,deferred-init;
 	};
 
 	sht40: sht40@44 {

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -415,6 +415,8 @@ v1.4.0 organizes configuration keys **by sensor/source** rather than under a glo
 
 **Unchanged:** discrete sources (`hall-*`, `input-*`, `pir-notify-act`) and global params (`alarm-limit`, `alarm-notif-time`). `accel-motion-sensitivity` defaults to `off` (no accelerometer detection).
 
+> **Accelerometer power (#90).** The LIS2DH is now power-managed on demand: it idles in power-down (ODR=0) and is only resumed for an orientation read or while motion detection is armed — saving ~30 µA of continuous idle current when the accelerometer would otherwise run free. **Consequence:** free-fall detection is active only when `accel-motion-sensitivity != off` (it shares the single motion-sensitivity knob); with sensitivity `off` the accelerometer is fully powered down.
+
 The protobuf field numbers are **unchanged**, so the over-the-air wire format stays compatible; only the user-facing keys and code identifiers change. Devices must be reprovisioned with the new shell keys (the NVS settings keys moved).
 
 ---


### PR DESCRIPTION
## Accelerometer idle-power fix (#90)

Splits the one confirmed, measured power saving out of the #90 investigation (PR #160) into a clean, mergeable change.

### Problem
With `cap_accelerometer` enabled, the LIS2DH drew **~+30 µA continuously** in idle. Free-fall (INT1) was armed unconditionally, so the part ran at a fixed ODR and never powered down — independent of the configured `accel_motion_sensitivity` (measured: HIGH and OFF identical).

### Fix
Two small commits:

1. **`sensor: defer accelerometer init unless cap-accelerometer is on`** — `zephyr,deferred-init` on the `lis2dh12` DT node + a conditional `device_init()` so the part is only powered up when the cap is enabled (otherwise it would run ODR_5 low-power sampling permanently).

2. **`power: suspend accelerometer when motion/free-fall detection is off`** — hand the device to **runtime PM** (the on-demand / "shutdown + one-shot" pattern, same idea as the TMP112 work in Zephyr PR #110325 and CHESTER `c8f153d`, applied to the LIS2DH):
   - `pm_device_runtime_enable()` after init → idles in power-down (ODR=0).
   - `app_accel_read()` wraps the fetch in `pm_device_runtime_get/put` → resumed only for the on-demand orientation read.
   - `app_accel_set_motion_sensitivity()` holds a refcounted `get` while sensitivity != OFF (kept resumed for the interrupt path), releases it on OFF.

### Behaviour change
Free-fall now requires `accel_motion_sensitivity != OFF` (it shares the single motion-sensitivity knob). This is the only way to recover the +30 µA without re-tuning the sensor ODR. Approved during the #90 investigation.

### Measured
- `cap_accelerometer` on, motion OFF: floor **−20 µA** (mid-band) / **−30 µA** (median) vs before, now matching the caps-off baseline.
- Release builds clean.

### Scope note
This PR is **only** the accelerometer fix. The broader #90 idle-current finding — the residual ~57 µA is an inherent HW-level Stop2 draw (LDO mode, STM32WLE5) + an asynchronous non-kernel wake, not fixable in firmware — is documented in PR #160 and issue #90 and is intentionally **not** part of this PR.

HW validation of the encrypted/on-device path pending (needs a phone to toggle `cap_accelerometer` over NFC); the power delta itself was bench-measured with PPK2.
