### PR TITLE
Add immutable claim_token device-identity field (NFC + LoRaWAN) (#170)

### DIFF
--- a/app/decoder/ttn.js
+++ b/app/decoder/ttn.js
@@ -230,8 +230,11 @@ function _decodeInfo(bytes, start, end) {
       else if (field === 7) info.unix_time = v.value;
       else if (field === 8) info.debug = v.value !== 0;
     } else if (wire === 2) {
-      // Skip unknown length-delimited fields (forward compatibility).
       var len = _pbReadVarint(bytes, pos); pos = len.next;
+      // field 9 = claim_token (#170): 128-bit device claim token, presented as
+      // hex. Omitted by the device until commissioned.
+      if (field === 9) info.claim_token = _pbBytesToHex(bytes.slice(pos, pos + len.value));
+      // else: skip unknown length-delimited fields (forward compatibility).
       pos += len.value;
     } else {
       break;

--- a/app/decoder/ttn.test.js
+++ b/app/decoder/ttn.test.js
@@ -145,6 +145,29 @@ test("decodeUplink decodes a W1Scan response (fPort 85)", () => {
   assert.deepEqual(got.w1_scan.rom, ["28000011223344a5", "28abcdef010203b7"]);
 });
 
+// Info response carrying the claim_token (#170): Info.claim_token = field 9
+// (bytes), presented as hex. Readable over both NFC and LoRaWAN.
+test("decodeUplink decodes get_info with claim_token (fPort 85)", () => {
+  const got = codec.decodeUplink({
+    bytes: hex("0108031a24080110041802200228d285d8cc04302a40014a10158a6a5d5b54c5118e62a8f4af0de8d2"),
+    fPort: 85,
+  }).data;
+  assert.equal(got.seq, 3);
+  assert.equal(got.info.fw_version, "1.4.2");
+  assert.equal(got.info.serial_number, 1234567890);
+  assert.equal(got.info.claim_token, "158a6a5d5b54c5118e62a8f4af0de8d2");
+});
+
+// An uncommissioned device omits claim_token (the all-zero sentinel) → absent.
+test("decodeUplink get_info omits claim_token when uncommissioned (fPort 85)", () => {
+  const got = codec.decodeUplink({
+    bytes: hex("0108031a0c08011004180228d285d8cc04"),
+    fPort: 85,
+  }).data;
+  assert.equal(got.seq, 3);
+  assert.equal(got.info.claim_token, undefined);
+});
+
 // --- Uplink: protobuf telemetry (fPort 2) ---------------------------------
 // Real HW capture (#78/#80 verification, device sticker-2162165131, 2026-06-09):
 // a non-boot report with hall-left + hall-right capabilities enabled but no

--- a/app/src/app_ats.c
+++ b/app/src/app_ats.c
@@ -806,6 +806,28 @@ static int cmd_device_info(const struct shell *sh, size_t argc, char **argv)
 		shell_print(sh, "Wall clock:    RTC not synced");
 	}
 
+	/* Device identity keys (local shell only). secret-key is confidential; the
+	 * claim-token (#170) is shown as "(unset)" until commissioned. */
+	char hexbuf[2 * 16 + 1];
+
+	bin2hex(g_app_config.secret_key, sizeof(g_app_config.secret_key), hexbuf, sizeof(hexbuf));
+	shell_print(sh, "Secret key:    %s", hexbuf);
+
+	bool claim_set = false;
+	for (size_t i = 0; i < sizeof(g_app_config.claim_token); i++) {
+		if (g_app_config.claim_token[i] != 0) {
+			claim_set = true;
+			break;
+		}
+	}
+	if (claim_set) {
+		bin2hex(g_app_config.claim_token, sizeof(g_app_config.claim_token), hexbuf,
+			sizeof(hexbuf));
+		shell_print(sh, "Claim token:   %s", hexbuf);
+	} else {
+		shell_print(sh, "Claim token:   (unset)");
+	}
+
 	return 0;
 }
 

--- a/app/src/app_cmd.c
+++ b/app/src/app_cmd.c
@@ -81,6 +81,10 @@ void app_cmd_get_info(struct app_cmd_info *info)
 		.uptime_s = (uint32_t)(k_uptime_get() / 1000),
 	};
 
+	BUILD_ASSERT(sizeof(info->claim_token) == sizeof(g_app_config.claim_token),
+		     "claim_token size mismatch");
+	memcpy(info->claim_token, g_app_config.claim_token, sizeof(info->claim_token));
+
 #ifdef APP_CMD_HAVE_CLOCK
 	uint32_t unix_s;
 	if (app_clock_get_unix(&unix_s) == 0) {
@@ -105,6 +109,17 @@ static void fill_info(Response_Info *info)
 	info->debug = i.debug;
 	if (i.has_unix_time) {
 		info->unix_time = i.unix_time;
+	}
+
+	/* claim_token (#170): emit only once commissioned (any non-zero byte). The
+	 * all-zero "unset" state is omitted so an uncommissioned device's Info stays
+	 * compact. fixed_length bytes -> plain 16-byte array, no .size. */
+	for (size_t j = 0; j < sizeof(i.claim_token); j++) {
+		if (i.claim_token[j] != 0) {
+			info->has_claim_token = true;
+			memcpy(info->claim_token, i.claim_token, sizeof(info->claim_token));
+			break;
+		}
 	}
 }
 

--- a/app/src/app_cmd.h
+++ b/app/src/app_cmd.h
@@ -54,8 +54,9 @@ struct app_cmd_info {
 	bool debug;         /* debug build (CONFIG_FW_DEBUG) */
 	uint32_t serial_number;
 	uint32_t uptime_s;
-	bool has_unix_time; /* unix_time valid (RTC synced) */
-	uint32_t unix_time; /* UTC seconds since epoch */
+	bool has_unix_time;      /* unix_time valid (RTC synced) */
+	uint32_t unix_time;      /* UTC seconds since epoch */
+	uint8_t claim_token[16]; /* 128-bit device claim token (#170); all-zero = uncommissioned */
 };
 
 /* Fill `info` with the current device info: FW version, build type, serial,

--- a/app/src/app_config.c
+++ b/app/src/app_config.c
@@ -92,6 +92,7 @@ static int h_set(const char *key, size_t len, settings_read_cb read_cb, void *cb
 		     sizeof(m_app_config.serial_number));
 	SETTINGS_SET("nonce-counter", &m_app_config.nonce_counter,
 		     sizeof(m_app_config.nonce_counter));
+	SETTINGS_SET("claim-token", m_app_config.claim_token, sizeof(m_app_config.claim_token));
 	SETTINGS_SET("calibration", &m_app_config.calibration, sizeof(m_app_config.calibration));
 	SETTINGS_SET("interval-sample", &m_app_config.interval_sample,
 		     sizeof(m_app_config.interval_sample));
@@ -190,6 +191,8 @@ static int h_commit(void)
 		memcpy(m_app_config.secret_key, stored.secret_key, sizeof(m_app_config.secret_key));
 		m_app_config.serial_number = stored.serial_number;
 		m_app_config.nonce_counter = stored.nonce_counter;
+		memcpy(m_app_config.claim_token, stored.claim_token,
+		       sizeof(m_app_config.claim_token));
 		m_app_config.lrw_region = stored.lrw_region;
 		m_app_config.lrw_sub_band = stored.lrw_sub_band;
 		m_app_config.lrw_network = stored.lrw_network;
@@ -285,6 +288,7 @@ static int h_export(int (*export_func)(const char *name, const void *val, size_t
 		    sizeof(m_app_config.serial_number));
 	EXPORT_FUNC("nonce-counter", &m_app_config.nonce_counter,
 		    sizeof(m_app_config.nonce_counter));
+	EXPORT_FUNC("claim-token", m_app_config.claim_token, sizeof(m_app_config.claim_token));
 	EXPORT_FUNC("calibration", &m_app_config.calibration, sizeof(m_app_config.calibration));
 	EXPORT_FUNC("interval-sample", &m_app_config.interval_sample,
 		    sizeof(m_app_config.interval_sample));
@@ -464,6 +468,20 @@ static void print_serial_number(const struct shell *shell)
 static void print_nonce_counter(const struct shell *shell)
 {
 	shell_print(shell, SETTINGS_PFX " nonce-counter %u", m_app_config.nonce_counter);
+}
+
+static void print_claim_token(const struct shell *shell)
+{
+	char buf[2 * sizeof(m_app_config.claim_token) + 1];
+
+	int ret = bin2hex(m_app_config.claim_token, sizeof(m_app_config.claim_token), buf,
+			  sizeof(buf));
+	if (!ret) {
+		LOG_ERR("Call `bin2hex` failed: %d", ret);
+		return;
+	}
+
+	shell_print(shell, SETTINGS_PFX " claim-token %s", buf);
 }
 
 static void print_calibration(const struct shell *shell)
@@ -839,6 +857,7 @@ static int cmd_show(const struct shell *shell, size_t argc, char **argv)
 	print_secret_key(shell);
 	print_serial_number(shell);
 	print_nonce_counter(shell);
+	print_claim_token(shell);
 	print_calibration(shell);
 	print_interval_sample(shell);
 	print_interval_report(shell);
@@ -913,7 +932,6 @@ static int cmd_secret_key(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.secret_key, tmp, sizeof(tmp));
 
 	return 0;
@@ -995,6 +1013,51 @@ static int cmd_nonce_counter(const struct shell *shell, size_t argc, char **argv
 
 	m_app_config.nonce_counter = (uint32_t)value;
 	shell_print(shell, "%s", m_msg_cmd_success);
+	return 0;
+}
+
+static int cmd_claim_token(const struct shell *shell, size_t argc, char **argv)
+{
+	int ret;
+
+	if (argc == 1) {
+		print_claim_token(shell);
+		return 0;
+	}
+
+	if (argc != 2) {
+		shell_error(shell, "%s", m_msg_invalid_args);
+		return -EINVAL;
+	}
+
+	if (strlen(argv[1]) != 2 * sizeof(m_app_config.claim_token)) {
+		shell_error(shell, "%s", m_msg_invalid_value);
+		return -EINVAL;
+	}
+
+	/* Decode into a temp buffer first. hex2bin writes byte-by-byte straight
+	 * into the destination and bails (returning 0) on the first invalid nibble,
+	 * so decoding into the config would leave a half-overwritten key that a
+	 * later `save` would persist. Commit only on a fully valid decode. */
+	uint8_t tmp[sizeof(m_app_config.claim_token)];
+
+	ret = hex2bin(argv[1], strlen(argv[1]), tmp, sizeof(tmp));
+	if (ret != sizeof(tmp)) {
+		LOG_ERR("Call `hex2bin` failed: %d", ret);
+		shell_error(shell, "%s", m_msg_invalid_value);
+		return -EINVAL;
+	}
+	/* write-once (#170): refuse to overwrite a value that is already set. The
+	 * all-zero state is the "unset" sentinel; once any byte is non-zero the
+	 * field is locked (commission once, then immutable). */
+	for (size_t i = 0; i < sizeof(m_app_config.claim_token); i++) {
+		if (m_app_config.claim_token[i] != 0) {
+			shell_error(shell, "claim-token already set (immutable)");
+			return -EACCES;
+		}
+	}
+	memcpy(m_app_config.claim_token, tmp, sizeof(tmp));
+
 	return 0;
 }
 
@@ -1231,7 +1294,6 @@ static int cmd_lrw_deveui(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_deveui, tmp, sizeof(tmp));
 
 	return 0;
@@ -1268,7 +1330,6 @@ static int cmd_lrw_joineui(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_joineui, tmp, sizeof(tmp));
 
 	return 0;
@@ -1305,7 +1366,6 @@ static int cmd_lrw_nwkkey(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_nwkkey, tmp, sizeof(tmp));
 
 	return 0;
@@ -1342,7 +1402,6 @@ static int cmd_lrw_appkey(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_appkey, tmp, sizeof(tmp));
 
 	return 0;
@@ -1379,7 +1438,6 @@ static int cmd_lrw_devaddr(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_devaddr, tmp, sizeof(tmp));
 
 	return 0;
@@ -1416,7 +1474,6 @@ static int cmd_lrw_nwkskey(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_nwkskey, tmp, sizeof(tmp));
 
 	return 0;
@@ -1453,7 +1510,6 @@ static int cmd_lrw_appskey(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.lrw_appskey, tmp, sizeof(tmp));
 
 	return 0;
@@ -1605,7 +1661,6 @@ static int cmd_sensor1_rom(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.sensor1_rom, tmp, sizeof(tmp));
 
 	return 0;
@@ -1642,7 +1697,6 @@ static int cmd_sensor2_rom(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.sensor2_rom, tmp, sizeof(tmp));
 
 	return 0;
@@ -1679,7 +1733,6 @@ static int cmd_sensor3_rom(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.sensor3_rom, tmp, sizeof(tmp));
 
 	return 0;
@@ -1716,7 +1769,6 @@ static int cmd_sensor4_rom(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
 	memcpy(m_app_config.sensor4_rom, tmp, sizeof(tmp));
 
 	return 0;
@@ -1755,6 +1807,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(nonce-counter, NULL,
 	              "Get/Set nonce counter (unsigned integer).",
 	              cmd_nonce_counter, 1, 1),
+
+	SHELL_CMD_ARG(claim-token, NULL,
+	              "Get/Set device claim token (32 hexadecimal digits); write-once at commissioning.",
+	              cmd_claim_token, 1, 1),
 
 	SHELL_CMD_ARG(calibration, NULL,
 	              "Get/Set calibration mode (true/false).",
@@ -1941,6 +1997,7 @@ int app_config_factory_reset(void)
 	memcpy(m_app_config.secret_key, preserved.secret_key, sizeof(m_app_config.secret_key));
 	m_app_config.serial_number = preserved.serial_number;
 	m_app_config.nonce_counter = preserved.nonce_counter;
+	memcpy(m_app_config.claim_token, preserved.claim_token, sizeof(m_app_config.claim_token));
 	m_app_config.lrw_region = preserved.lrw_region;
 	m_app_config.lrw_sub_band = preserved.lrw_sub_band;
 	m_app_config.lrw_network = preserved.lrw_network;

--- a/app/src/app_config.h
+++ b/app/src/app_config.h
@@ -47,6 +47,7 @@ struct app_config {
 	uint8_t secret_key[16];
 	uint32_t serial_number;
 	uint32_t nonce_counter;
+	uint8_t claim_token[16];
 	bool calibration;
 	int interval_sample;
 	int interval_report;

--- a/app/src/app_config.options.in
+++ b/app/src/app_config.options.in
@@ -30,6 +30,7 @@ AppConfigMessage.Sensors.sensor4_rom max_size:8 fixed_length:true
 
 Response.Error.detail       max_size:32
 Response.HistoryFrame.samples max_size:48
+Response.Info.claim_token   max_size:16 fixed_length:true
 
 # Alarm-detail batch (fPort 3, #27). 8 events fit the smallest practical DR; the
 # encoder further caps by the live payload budget.

--- a/app/src/app_config.proto
+++ b/app/src/app_config.proto
@@ -10,6 +10,7 @@ message AppConfigMessage {
     optional Application application = 6;
     optional Sensors sensors = 7;
     optional Alarms alarms = 8;
+    optional string claim_token = 9;
 
     message Lorawan {
         enum Region {
@@ -233,6 +234,7 @@ message Response {
         uint32 uptime_s      = 6;   // seconds since boot
         uint32 unix_time     = 7;   // wall-clock (UTC); 0/absent until RTC synced
         bool   debug         = 8;   // true = debug build, false = release
+        optional bytes claim_token = 9;   // 128-bit device claim token (#170); omitted until commissioned
     }
 
     message ConfigDump {

--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -136,6 +136,23 @@ parameters:
     preserve_on_reset: true
     help: "Get/Set nonce counter (unsigned integer)."
 
+  # Device claim token (#170): 128-bit identity, on the same level as
+  # serial_number. Written ONCE during commissioning via `config claim-token`
+  # and then immutable (write_once latch in the shell setter — the only write
+  # path; root fields are not in SetParam). Read back over NFC + LoRaWAN via the
+  # get_info Info message. Off the wire in AppConfigMessage (proto_callback, like
+  # secret_key); preserved across reset, cleared only by a full NVS erase.
+  - name: claim_token
+    proto_group: root
+    proto_id: 9
+    dump: false
+    proto_callback: true
+    type: bytes
+    size: 16
+    write_once: true
+    preserve_on_reset: true
+    help: "Get/Set device claim token (32 hexadecimal digits); write-once at commissioning."
+
   - name: calibration
     proto_group: application
     proto_id: 1

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -204,8 +204,13 @@ After every LoRaWAN join the device automatically sends a device-info message on
 | `serial_number` | Device serial |
 | `uptime_s` | Seconds since boot |
 | `unix_time` | Wall-clock UTC (0 until the clock is synced) |
+| `claim_token` | 128-bit device claim token, hex (#170) — **omitted** until the device is commissioned |
 
-The same message is returned on demand by the `get_info` command.
+The same message is returned on demand by the `get_info` command (over LoRaWAN **and** NFC), so a backend can read the claim token over either channel.
+
+### Claim token (#170)
+
+The **claim token** is a 128-bit device-identity value, on the same footing as the serial number, used by the backend to claim/associate the unit. It is **set once during commissioning** with the shell command **`config claim-token <32-hex>`** (then `settings save`), and is afterwards **immutable** — any further write (shell, `SetParam`, NFC, LoRaWAN) is rejected (`claim-token already set`). It survives `settings reset` and is cleared only by a full NVS erase. Unlike the LoRaWAN/secret keys it is **not** confidential: it is reported in the `Info` message and readable over both NFC and LoRaWAN.
 
 ---
 
@@ -395,6 +400,7 @@ The TTN/ChirpStack payload formatter (`app/decoder/ttn.js`) was extended for v1.
 | `ats cmd lrw \| nfc <hex>` | **New** (debug) — inject a command over the LoRaWAN/NFC transport for bench testing |
 | `nfc dump` / `read` / `write` / `clear` / `check` / `autocheck` / `reg` / `regw` | **New** (debug) — direct ST25DV tag access; `nfc check` prints a readable trace of what it read, decoded and wrote back (see §10) |
 | `config history-enable` / `history-sensors` / `alarm-limit` / `alarm-notif-time` / `pir-notify-act` | **New** parameters (see §6, §7) |
+| `config claim-token <32-hex>` | **New** — set the 128-bit claim token once at commissioning; **write-once** (immutable after first set, see §4) |
 | `settings reset` | **Changed** — now keeps device identity + LoRaWAN credentials (see §13); restores only application config + alarm rules to defaults |
 | `settings erase` | **New** — full NVS wipe incl. identity + LoRaWAN credentials; shell-only, destructive (see §13) |
 

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -210,7 +210,7 @@ The same message is returned on demand by the `get_info` command (over LoRaWAN *
 
 ### Claim token (#170)
 
-The **claim token** is a 128-bit device-identity value, on the same footing as the serial number, used by the backend to claim/associate the unit. It is **set once during commissioning** with the shell command **`config claim-token <32-hex>`** (then `settings save`), and is afterwards **immutable** — any further write (shell, `SetParam`, NFC, LoRaWAN) is rejected (`claim-token already set`). It survives `settings reset` and is cleared only by a full NVS erase. Unlike the LoRaWAN/secret keys it is **not** confidential: it is reported in the `Info` message and readable over both NFC and LoRaWAN.
+The **claim token** is a 128-bit device-identity value, on the same footing as the serial number, used by the backend to claim/associate the unit. It is **set once during commissioning** with the shell command **`config claim-token <32-hex>`** (then `settings save`), and is afterwards **immutable** — any further write (shell, `SetParam`, NFC, LoRaWAN) is rejected (`claim-token already set`). It survives `settings reset` and is cleared only by a full NVS erase. Unlike the LoRaWAN/secret keys it is **not** confidential: it is reported in the `Info` message and readable over both NFC and LoRaWAN. Locally, **`ats device info`** prints it (and the secret key) next to the serial number, firmware and uptime.
 
 ---
 

--- a/scripts/west_commands/templates/config.c.j2
+++ b/scripts/west_commands/templates/config.c.j2
@@ -292,7 +292,17 @@ static int cmd_{{ param.name | c_name }}(const struct shell *shell, size_t argc,
 		shell_error(shell, "%s", m_msg_invalid_value);
 		return -EINVAL;
 	}
-
+{% if param.write_once | default(false) %}
+	/* write-once (#170): refuse to overwrite a value that is already set. The
+	 * all-zero state is the "unset" sentinel; once any byte is non-zero the
+	 * field is locked (commission once, then immutable). */
+	for (size_t i = 0; i < sizeof(m_{{ module.name }}.{{ param.name | c_name }}); i++) {
+		if (m_{{ module.name }}.{{ param.name | c_name }}[i] != 0) {
+			shell_error(shell, "{{ param.name | settings_key }} already set (immutable)");
+			return -EACCES;
+		}
+	}
+{% endif %}
 	memcpy(m_{{ module.name }}.{{ param.name | c_name }}, tmp, sizeof(tmp));
 
 	return 0;

--- a/tests/cmd/src/main.c
+++ b/tests/cmd/src/main.c
@@ -207,6 +207,27 @@ ZTEST(cmd, test_build_info)
 	zassert_true(pb_decode(&is, Response_fields, &r), "decode");
 	zassert_equal(r.which_body, Response_info_tag, "expected Info");
 	zassert_equal(r.body.info.serial_number, 1234567890, "serial");
+	/* #170: uncommissioned device (all-zero claim_token) omits the field. */
+	zassert_false(r.body.info.has_claim_token, "claim_token must be omitted when unset");
+}
+
+/* #170: once commissioned, the Info carries the 16-byte claim_token. */
+ZTEST(cmd, test_build_info_claim_token)
+{
+	uint8_t out[128];
+	size_t out_len = 0;
+	const uint8_t token[16] = {0x15, 0x8a, 0x6a, 0x5d, 0x5b, 0x54, 0xc5, 0x11,
+				   0x8e, 0x62, 0xa8, 0xf4, 0xaf, 0x0d, 0xe8, 0xd2};
+
+	reset_cfg();
+	memcpy(g_app_config.claim_token, token, sizeof(token));
+
+	zassert_equal(app_cmd_build_info(out, sizeof(out), &out_len), 0, "build_info");
+	Response r = Response_init_zero;
+	pb_istream_t is = pb_istream_from_buffer(out + 1, out_len - 1);
+	zassert_true(pb_decode(&is, Response_fields, &r), "decode");
+	zassert_true(r.body.info.has_claim_token, "claim_token must be present once set");
+	zassert_mem_equal(r.body.info.claim_token, token, sizeof(token), "claim_token bytes");
 }
 
 ZTEST(cmd, test_deferred_actions)


### PR DESCRIPTION
Closes #170.

## What

A new **`claim_token`** — a 128-bit device-identity value on the same level as `serial_number` (a root `AppConfigMessage` identity field). It is **set once during commissioning via the shell** and is then **immutable**; it is **readable over both NFC and LoRaWAN**.

## Behaviour

| | `secret_key` | **`claim_token`** |
|---|---|---|
| Shell write | any time, rewritable | **once only** (write-once latch) |
| Readable over the air | never (secret) | **yes** — NFC + LoRaWAN (in `Info`) |
| Purpose | NFC AES-CCM secret (#135) | device claim / ownership identity |
| In `SetParam` | no (root) | no (root) |
| `preserve_on_reset` | yes | yes |

- **Commissioning:** `config claim-token <32-hex>` then `settings save`. Once any byte is non-zero the field is locked — a second write (shell / `SetParam` / NFC / LoRaWAN) is rejected with `claim-token already set` (`-EACCES`). The shell is the only write path: root identity fields are excluded from `SetParam`, so NFC/LoRaWAN cannot set it.
- **Read-back:** exposed in the `get_info` `Info` message (`bytes claim_token = 9`), so a backend reads it over **NFC and LoRaWAN**, and it rides the device-info-on-join uplink. **Omitted** while uncommissioned (all-zero sentinel) so an unprovisioned device's `Info` stays compact.
- Survives `settings reset`; cleared only by a full NVS erase (then it can be commissioned again).

## Changes

- **`app_config.yml`** — new root `claim_token` (bytes[16], `proto_callback` + `dump:false` like `secret_key` → off the over-the-air config path; `preserve_on_reset`). New **`write_once`** configen flag.
- **`config.c.j2`** — write-once latch generated into the bytes shell setter.
- **`Response.Info`** — `optional bytes claim_token = 9` (+ nanopb `fixed_length`); `app_cmd_get_info`/`fill_info` copy from config and emit only once commissioned.
- **`ttn.js`** — decode `Info.claim_token` (field 9) as hex.
- **tests** — node (Info with/without token), `cmd` ztest (`build_info` present/absent).
- **doc** — §4 claim-token behaviour + §9 `config claim-token`.

Additive protobuf change; the manager-app / `ttn.js` should surface the new `Info` field (track with manager-app#22).

## Testing

- `node --test`: **27 passed**
- `pytest` (configen): **22 passed**
- `cmd` ztest (native_sim): **12 passed** (incl. `test_build_info_claim_token`)
- `clang-format` (22.1.5): clean
- Pristine builds: release **FLASH 98.08% / RAM 68.75%**, debug **FLASH 94.02% / RAM 81.25%**
- HW (J-Link EDU Mini only): see follow-up comment.