### PR TITLE
configen: unify per-parameter access into readable/writable transport lists

### DIFF
--- a/app/src/app_config.yml
+++ b/app/src/app_config.yml
@@ -112,8 +112,8 @@ parameters:
   - name: secret_key
     proto_group: root
     proto_id: 2
-    dump: false
-    proto_callback: true
+    readable: [shell]
+    writable: [shell]
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -137,16 +137,16 @@ parameters:
     help: "Get/Set nonce counter (unsigned integer)."
 
   # Device claim token (#170): 128-bit identity, on the same level as
-  # serial_number. Written ONCE during commissioning via `config claim-token`
-  # and then immutable (write_once latch in the shell setter — the only write
-  # path; root fields are not in SetParam). Read back over NFC + LoRaWAN via the
-  # get_info Info message. Off the wire in AppConfigMessage (proto_callback, like
-  # secret_key); preserved across reset, cleared only by a full NVS erase.
+  # serial_number. writable:[shell] = written ONCE during commissioning via
+  # `config claim-token` (write_once latch), then immutable. readable everywhere
+  # — its air read goes via the hand-written get_info Info message (root bytes
+  # are kept off the generated config wire automatically). Preserved across
+  # reset, cleared only by a full NVS erase.
   - name: claim_token
     proto_group: root
     proto_id: 9
-    dump: false
-    proto_callback: true
+    readable: [shell, nfc, lrw]
+    writable: [shell]
     type: bytes
     size: 16
     write_once: true
@@ -270,8 +270,7 @@ parameters:
   - name: lrw_nwkkey
     proto_group: lorawan
     proto_id: 8
-    dump: false
-    dump_nfc_only: true
+    readable: [shell, nfc]
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -280,8 +279,7 @@ parameters:
   - name: lrw_appkey
     proto_group: lorawan
     proto_id: 9
-    dump: false
-    dump_nfc_only: true
+    readable: [shell, nfc]
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -298,8 +296,7 @@ parameters:
   - name: lrw_nwkskey
     proto_group: lorawan
     proto_id: 11
-    dump: false
-    dump_nfc_only: true
+    readable: [shell, nfc]
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -308,8 +305,7 @@ parameters:
   - name: lrw_appskey
     proto_group: lorawan
     proto_id: 12
-    dump: false
-    dump_nfc_only: true
+    readable: [shell, nfc]
     type: bytes
     size: 16
     preserve_on_reset: true
@@ -425,7 +421,8 @@ parameters:
     proto_id: 7
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 0 (packed hex, see app_config.yml)."
 
   - name: alarm_1
@@ -433,7 +430,8 @@ parameters:
     proto_id: 8
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 1 (packed hex, see app_config.yml)."
 
   - name: alarm_2
@@ -441,7 +439,8 @@ parameters:
     proto_id: 9
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 2 (packed hex, see app_config.yml)."
 
   - name: alarm_3
@@ -449,7 +448,8 @@ parameters:
     proto_id: 10
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 3 (packed hex, see app_config.yml)."
 
   - name: alarm_4
@@ -457,7 +457,8 @@ parameters:
     proto_id: 11
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 4 (packed hex, see app_config.yml)."
 
   - name: alarm_5
@@ -465,7 +466,8 @@ parameters:
     proto_id: 12
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 5 (packed hex, see app_config.yml)."
 
   - name: alarm_6
@@ -473,7 +475,8 @@ parameters:
     proto_id: 13
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 6 (packed hex, see app_config.yml)."
 
   - name: alarm_7
@@ -481,7 +484,8 @@ parameters:
     proto_id: 14
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 7 (packed hex, see app_config.yml)."
 
   - name: alarm_8
@@ -489,7 +493,8 @@ parameters:
     proto_id: 15
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 8 (packed hex, see app_config.yml)."
 
   - name: alarm_9
@@ -497,7 +502,8 @@ parameters:
     proto_id: 16
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 9 (packed hex, see app_config.yml)."
 
   - name: alarm_10
@@ -505,7 +511,8 @@ parameters:
     proto_id: 17
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 10 (packed hex, see app_config.yml)."
 
   - name: alarm_11
@@ -513,7 +520,8 @@ parameters:
     proto_id: 18
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 11 (packed hex, see app_config.yml)."
 
   - name: alarm_12
@@ -521,7 +529,8 @@ parameters:
     proto_id: 19
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 12 (packed hex, see app_config.yml)."
 
   - name: alarm_13
@@ -529,7 +538,8 @@ parameters:
     proto_id: 20
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 13 (packed hex, see app_config.yml)."
 
   - name: alarm_14
@@ -537,7 +547,8 @@ parameters:
     proto_id: 21
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 14 (packed hex, see app_config.yml)."
 
   - name: alarm_15
@@ -545,7 +556,8 @@ parameters:
     proto_id: 22
     type: bytes
     size: 17
-    no_shell: true
+    readable: [nfc, lrw]
+    writable: [nfc, lrw]
     help: "Get/Set alarm rule slot 15 (packed hex, see app_config.yml)."
 
   - name: accel_motion_sensitivity

--- a/doc/version 1.4.md
+++ b/doc/version 1.4.md
@@ -429,6 +429,8 @@ This key rename kept the protobuf field numbers; the user-facing keys and code i
 
 > **Wire-format note (#166):** the config protobuf field numbers were later **renumbered** to a contiguous `1..N` per submessage (`lorawan`/`application`/`sensors`/`alarms`) — a one-off **breaking** change to the over-the-air `SetParam`/`GetParam`/`ConfigDump` framing for v1.4.0. Any client that builds/parses the config protobuf directly (the NFC manager app, external decoders) must re-sync to the field numbers in `app_config.proto`. The flat NVS settings keys are by name and are unaffected.
 
+> **Access model (dev note):** each parameter in `app_config.yml` declares **who may read and write it** with two transport lists — `readable` and `writable`, each a subset of `{shell, nfc, lrw}` (omitted ⇒ all three). `west configen` derives the internal generator flags from them (shell command vs not, ConfigDump inclusion, NFC-only keys, off-wire identity blobs), so the read/write matrix is the single source of truth and `proto_group` is purely a layout choice (root vs submessage) with no access side-effect. Example: `secret_key` is `readable/writable: [shell]` (local only); `claim_token` is `readable: [shell, nfc, lrw]` + `writable: [shell]` (public, write-once); LoRaWAN keys are `readable: [shell, nfc]` (never dumped over LoRaWAN). This is an authoring-side change only — no wire-format impact.
+
 ---
 
 ## 10. Local NFC access (NEW)

--- a/scripts/west_commands/configen-template.yml
+++ b/scripts/west_commands/configen-template.yml
@@ -113,6 +113,30 @@ parameters:
     readonly: true      # Cannot be modified via shell
 
   # ---------------------------------------------------------------------------
+  # Access control: who may read / write a parameter, over which transport.
+  # Each list is a subset of {shell, nfc, lrw}; omit a list to allow all three
+  # (the common case). configen derives the internal dump / dump_nfc_only /
+  # no_shell / readonly flags from these. proto_group is layout only and does
+  # not affect access.
+  # ---------------------------------------------------------------------------
+  - name: claim_token_example
+    proto_group: root
+    type: bytes
+    size: 16
+    readable: [shell, nfc, lrw]   # readable everywhere
+    writable: [shell]             # set only locally (commissioning)
+    write_once: true              # ...and only once; then immutable
+    help: "Write-once identity token set at commissioning"
+
+  - name: lorawan_key_example
+    proto_group: lorawan
+    type: bytes
+    size: 16
+    readable: [shell, nfc]        # never dumped over LoRaWAN (LNS would see it)
+    # writable omitted -> [shell, nfc, lrw]
+    help: "Secret key: NFC-readable, settable over any transport"
+
+  # ---------------------------------------------------------------------------
   # Floating Point Types: float, double
   # ---------------------------------------------------------------------------
   - name: temperature_hi

--- a/scripts/west_commands/configen.py
+++ b/scripts/west_commands/configen.py
@@ -28,11 +28,27 @@ Parameter options:
 - minlen/maxlen: length constraints for string type
 - array: array size for numeric types
 - hidden: hide from shell 'show' command
-- readonly: prevent shell modification
-- no_shell: skip shell get/set command generation entirely (param still has
-  NVS/proto/ingest; use for bulk/packed params not meant for manual shell use)
 - precision: decimal places for float/double display
 - format: display format (hex/dec for integers, printf format for uint)
+- write_once: once the field holds a non-zero value the shell setter refuses to
+  overwrite it (commission-once identity fields, e.g. claim_token)
+
+Access control (readable / writable):
+  Each parameter declares who may read and who may write it, as a subset of the
+  transports {shell, nfc, lrw}. Both lists default to all three (the common
+  case, so they are usually omitted):
+    readable: [shell, nfc, lrw]   # shell = `config <name>` / `config show`;
+                                  # nfc/lrw = ConfigDump (get_param/get_config)
+    writable: [shell, nfc, lrw]   # shell = `config <name>` set; nfc/lrw = SetParam
+  configen derives the internal generator flags from these (see normalize_access):
+    - no_shell      <- shell in neither list
+    - readonly      <- shell readable but not writable
+    - dump          <- readable over nfc or lrw
+    - dump_nfc_only <- readable over nfc but not lrw (e.g. LoRaWAN keys)
+  Root `bytes` identity blobs (secret_key, claim_token) are emitted as a nanopb
+  callback and kept off the wire automatically (their air read, if any, goes via
+  a hand-written message such as Info). `proto_group` is a layout choice only
+  (root vs submessage); it no longer implies anything about access.
 """
 
 import argparse
@@ -381,6 +397,54 @@ def _proto_groups(config):
     if not proto:
         return None, None
     return proto, {g["key"]: g for g in proto["groups"]}
+
+
+TRANSPORTS = ("shell", "nfc", "lrw")
+
+
+def normalize_access(config):
+    """Derive the internal per-parameter flags from the `readable`/`writable`
+    transport lists (the single source of truth for who may read/write a field).
+
+    Each list is a subset of {shell, nfc, lrw}; an omitted list defaults to all
+    three (the common case). From them we compute the legacy flags the code
+    generators already consume, so the templates stay unchanged:
+
+      - no_shell      = shell in neither readable nor writable (no `config` entry)
+      - readonly      = shell may read but not write
+      - dump          = field is readable over the air (nfc or lrw) -> ConfigDump
+      - dump_nfc_only = readable over nfc but NOT lrw (keys: LNS must not see them)
+      - proto_callback = root `bytes` (identity blobs stay off the wire, as
+                         before) — structural, independent of the access lists
+
+    Idempotent: callable more than once (the model builders and do_run share it).
+    """
+    for p in config.get("parameters", []):
+        readable = p.get("readable", list(TRANSPORTS))
+        writable = p.get("writable", list(TRANSPORTS))
+        for which, lst in (("readable", readable), ("writable", writable)):
+            bad = set(lst) - set(TRANSPORTS)
+            if bad:
+                log.die(f"parameter '{p.get('name')}' has invalid {which} "
+                        f"transport(s) {sorted(bad)}; valid: {list(TRANSPORTS)}")
+        r, w = set(readable), set(writable)
+
+        if "shell" not in r and "shell" not in w:
+            p["no_shell"] = True
+        if "shell" in r and "shell" not in w:
+            p["readonly"] = True
+
+        air_read = ("nfc" in r) or ("lrw" in r)
+        p["dump"] = air_read
+        if ("nfc" in r) and ("lrw" not in r):
+            p["dump_nfc_only"] = True
+
+        # Root byte blobs (secret_key / claim_token) stay off the wire: emitted as
+        # a nanopb callback in the proto, never in SetParam/ConfigDump. The air
+        # read for these identity fields (claim_token) goes via the hand-written
+        # Info message, not the generated config path.
+        if p.get("proto_group") == "root" and p.get("type") == "bytes":
+            p["proto_callback"] = True
 
 
 def allocate_proto_ids(config, rt_doc):
@@ -920,6 +984,10 @@ class Configen(WestCommand):
         # Validate parameters
         for param in parameters:
             self._validate_param(param)
+
+        # Derive the internal access flags (dump / no_shell / ...) from the
+        # readable/writable transport lists before any model is built.
+        normalize_access(config)
 
         # Setup Jinja2 environment
         templates_dir = args.templates_dir or TEMPLATES_DIR

--- a/scripts/west_commands/tests/test_configen.py
+++ b/scripts/west_commands/tests/test_configen.py
@@ -29,7 +29,11 @@ GEN_FILES = ["app_config.c", "app_config.h", "app_config.proto", "app_config.opt
 
 def _load_config():
     with open(YAML) as f:
-        return pyyaml.safe_load(f)
+        cfg = pyyaml.safe_load(f)
+    # Mirror do_run: derive the internal access flags (dump/no_shell/...) from the
+    # readable/writable transport lists before the model builders consume them.
+    configen.normalize_access(cfg)
+    return cfg
 
 
 def _run_configen(out_dir):
@@ -102,6 +106,53 @@ def test_no_shell_omits_shell_command():
     assert "config->alarm_0" in ingest
     # A normal param in the same group keeps its shell command.
     assert "cmd_alarm_limit(" in c
+
+
+def test_normalize_access_derives_internal_flags():
+    """readable/writable transport lists are the source of truth; configen derives
+    the legacy dump/dump_nfc_only/no_shell/readonly/proto_callback flags from them."""
+    cfg = {"parameters": [
+        # secret: shell-only read+write, root bytes -> off-wire callback, no dump
+        {"name": "secret_key", "proto_group": "root", "type": "bytes",
+         "readable": ["shell"], "writable": ["shell"]},
+        # claim: readable everywhere, write-once shell only; root bytes -> callback
+        {"name": "claim_token", "proto_group": "root", "type": "bytes",
+         "readable": ["shell", "nfc", "lrw"], "writable": ["shell"]},
+        # key: NFC-readable only (never over LoRaWAN), writable everywhere
+        {"name": "lrw_nwkkey", "proto_group": "lorawan", "type": "bytes",
+         "readable": ["shell", "nfc"]},
+        # packed slot: no shell entry, air read/write only
+        {"name": "alarm_0", "proto_group": "alarms", "type": "bytes",
+         "readable": ["nfc", "lrw"], "writable": ["nfc", "lrw"]},
+        # plain param: lists omitted -> all transports, normal flags
+        {"name": "interval_report", "proto_group": "application", "type": "int"},
+    ]}
+    configen.normalize_access(cfg)
+    by = {p["name"]: p for p in cfg["parameters"]}
+
+    assert by["secret_key"]["dump"] is False
+    assert by["secret_key"]["proto_callback"] is True
+    assert "no_shell" not in by["secret_key"] and "readonly" not in by["secret_key"]
+
+    assert by["claim_token"]["proto_callback"] is True  # root bytes -> off-wire
+    assert by["claim_token"]["dump"] is True             # readable over the air
+    assert "readonly" not in by["claim_token"]           # shell is writable
+
+    assert by["lrw_nwkkey"]["dump_nfc_only"] is True
+    assert "proto_callback" not in by["lrw_nwkkey"]      # submessage bytes = native
+
+    assert by["alarm_0"]["no_shell"] is True
+    assert "proto_callback" not in by["alarm_0"]
+
+    assert by["interval_report"]["dump"] is True
+    assert "no_shell" not in by["interval_report"]
+
+
+def test_normalize_access_rejects_bad_transport():
+    cfg = {"parameters": [{"name": "x", "proto_group": "root", "type": "bool",
+                           "readable": ["shell", "ble"]}]}
+    with pytest.raises(SystemExit):
+        configen.normalize_access(cfg)
 
 
 def test_build_proto_model_structure():


### PR DESCRIPTION
## What

Replace the scattered per-parameter access flags (`dump`, `dump_nfc_only`, `no_shell`, `readonly`, `proto_callback`) with **two explicit transport lists**:

```yaml
readable: [shell, nfc, lrw]   # who may read it
writable: [shell, nfc, lrw]   # who may write it
```

Each is a subset of `{shell, nfc, lrw}` and **defaults to all three** when omitted (the common case → most params get *shorter*). The read/write matrix is now self-documenting, and **`proto_group` is decoupled from access** — it is layout-only (root vs submessage) and no longer implies "not writable over the air".

- `shell` = the generated `config <name>` get/set + `config show`
- `nfc` / `lrw` = `ConfigDump` (get_param/get_config) for read, `SetParam` for write

## How (pure refactor — generated output is byte-identical)

A new `normalize_access()` in configen derives the legacy generator flags from the lists, so **the templates are untouched**:

| derived flag | rule |
|---|---|
| `no_shell` | `shell` in neither list |
| `readonly` | `shell` readable but not writable |
| `dump` | readable over `nfc` or `lrw` |
| `dump_nfc_only` | readable over `nfc` but not `lrw` (LoRaWAN keys — LNS must not see them) |
| `proto_callback` | root `bytes` (identity blobs stay off the wire) — structural |

`write_once` stays orthogonal. Regenerating every artifact (`app_config.{c,h,proto,options.in}`, `app_config_ingest.c`, `DUMP_FIELDS`, `ttn.js`) yields **zero diff** against the current tree — proof the change is behaviour-neutral.

## YAML now reads

```yaml
secret_key   readable: [shell]            writable: [shell]      # local-only secret
claim_token  readable: [shell, nfc, lrw]  writable: [shell]      # public id, write-once
lrw_nwkkey   readable: [shell, nfc]                              # never over LoRaWAN
alarm_0..15  readable: [nfc, lrw]         writable: [nfc, lrw]   # packed slots, no config tree
interval_*   (omitted -> all three)
```

## Testing

- Regenerate → **byte-identical** generated C/proto/options/decoder (no diff)
- `pytest`: **24 passed** (incl. new `test_normalize_access_derives_internal_flags` + bad-transport rejection)
- `node --test`: **27 passed**
- The build consumes the committed generated files (nanopb on the committed `.proto`); since those are unchanged the firmware is identical to the merged v1.4.0.

No wire-format change (proto field numbers untouched). Docs: configen header + `configen-template.yml` document the new model.